### PR TITLE
Use timeline to get benchmarks, instead of checking all measurements

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -280,8 +280,8 @@ export async function dashBenchmarksForProject(db: Database, projectId: number) 
       JOIN Trial t           ON t.expId = exp.id
       JOIN Source src        ON t.sourceId = src.id
       JOIN Environment env   ON t.envId = env.id
-      JOIN Measurement m     ON m.trialId = t.id
-      JOIN Run r             ON m.runId = r.id
+      JOIN Timeline tl       ON tl.trialId = t.id
+      JOIN Run r             ON tl.runId = r.id
       JOIN Benchmark b       ON r.benchmarkId = b.id
       JOIN Suite s           ON r.suiteId = s.id
       JOIN Executor exe      ON r.execId = exe.id


### PR DESCRIPTION
Fix the SQL query to use the timeline table to determine the list if benchmarks.

This should work for "a while".

Not sure what to do when the timeline hast too much data.
But, we can look into that once it comes to it.