### PR TITLE
Added database support for denoise information

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,12 @@ module.exports = {
   },
   rules: {
     '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
-    '@typescript-eslint/no-explicit-any': 'off'
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': [
+      'error',
+      { allowArgumentsExplicitlyTypedAsAny: true }
+    ],
+    // TODO: make all tests work and avoid skipping them
+    'jest/no-disabled-tests': 'off'
   }
 };

--- a/src/api.ts
+++ b/src/api.ts
@@ -86,6 +86,11 @@ export interface Environment {
    * possibly on a developer machine, instead of the usual benchmark server.
    */
   manualRun: boolean;
+
+  /**
+   * Settings reported by `rebench-denoise`.
+   */
+  denoise?: Record<string, string | boolean | number>;
 }
 
 export interface BenchmarkData {

--- a/src/db.ts
+++ b/src/db.ts
@@ -75,8 +75,8 @@ export class Database {
     insertEnv: `INSERT INTO Environment (hostname, osType, memory, cpu, clockSpeed) VALUES ($1, $2, $3, $4, $5) RETURNING *`,
 
     fetchTrialByUserEnvStart: 'SELECT * from Trial WHERE username = $1 AND envId = $2 AND startTime = $3',
-    insertTrial: `INSERT INTO Trial (manualRun, startTime, expId, username, envId, sourceId)
-      VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+    insertTrial: `INSERT INTO Trial (manualRun, startTime, expId, username, envId, sourceId, denoise)
+      VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
 
     fetchProjectByName: 'SELECT * from Project WHERE name = $1',
     fetchProjectById: 'SELECT * from Project WHERE id = $1',
@@ -285,7 +285,7 @@ export class Database {
       this.queries.fetchTrialByUserEnvStart,
       [e.userName, env.id, data.startTime],
       this.queries.insertTrial,
-      [e.manualRun, data.startTime, exp.id, e.userName, env.id, source.id]);
+      [e.manualRun, data.startTime, exp.id, e.userName, env.id, source.id, e.denoise]);
   }
 
   public async recordProject(projectName: string): Promise<any> {

--- a/src/db/db.sql
+++ b/src/db/db.sql
@@ -119,6 +119,9 @@ CREATE TABLE Trial (
   envId smallint,
   sourceId smallint,
 
+  -- details on system settings that influence noise level for measurements
+  denoise jsonb,
+
   -- can only be supplied when everything is done
   -- but we may want to start storing data before
   endTime timestamp with time zone NULL,

--- a/src/db/migration.002.sql
+++ b/src/db/migration.002.sql
@@ -2,3 +2,10 @@ ALTER TABLE Run ALTER COLUMN warmup TYPE int;
 ALTER TABLE Run ALTER COLUMN maxInvocationTime TYPE int;
 ALTER TABLE Run ALTER COLUMN minIterationTime TYPE int;
 ALTER TABLE Timeline ALTER COLUMN numSamples TYPE int;
+
+-- details on system settings that influence noise level for measurements
+ALTER TABLE Trial ADD COLUMN denoise jsonb;
+
+-- set sensible defaults for projects
+ALTER TABLE Project ALTER COLUMN showChanges SET DEFAULT true;
+ALTER TABLE Project ALTER COLUMN allResults SET DEFAULT false;

--- a/src/perf-tracker.ts
+++ b/src/perf-tracker.ts
@@ -64,7 +64,8 @@ function constructData(time: number, it: number, benchmark: string) {
     env: {
       hostName: 'self',
       cpu: '', memory: 0, clockSpeed: 0, osType: '', userName: '', software: [],
-      manualRun: false
+      manualRun: false,
+      denoise: {}
     },
     source: {
       repoURL: 'https://github.com/smarr/ReBenchDB',

--- a/tests/db-setup.test.ts
+++ b/tests/db-setup.test.ts
@@ -148,6 +148,32 @@ describe('Recording a ReBench execution data fragments', () => {
     expect(env.id).toEqual(result.envid);
   });
 
+  it('should accept trial denoise info', async () => {
+    const testData: BenchmarkData = JSON.parse(
+      readFileSync(`${__dirname}/small-payload.json`).toString());
+
+    const e = testData.env;
+
+    // add denoise details to test data
+    e.denoise = {
+      "scaling_governor": "performance",
+      "no_turbo": true,
+      "perf_event_max_sample_rate": 1,
+      "can_set_nice": true,
+      "shielding": true
+    };
+
+    const env = await db.recordEnvironment(e);
+    const exp = await db.recordExperiment(testData);
+
+    const result = await db.recordTrial(testData, env, exp);
+    expect(e.userName).toEqual(result.username);
+    expect(e.manualRun).toEqual(result.manualrun);
+    expect(env.id).toEqual(result.envid);
+    expect(e.denoise.scaling_governor).toEqual("performance");
+    expect(e.denoise).toEqual(result.denoise);
+  });
+
   it('should accept experiment information', async () => {
     const e = basicTestData.env;
     await db.recordEnvironment(e);


### PR DESCRIPTION
The denoise information contains details on system settings that influence noise level for measurements.

This change does not yet use or display this information yet.

This PR also disables lint rules for explicit any types and skipped tests.