### PR TITLE
Show benchmarks separately on main page and only last 100 results

### DIFF
--- a/resources/plots.js
+++ b/resources/plots.js
@@ -3,7 +3,28 @@
 /* eslint-disable no-undef */
 'use strict';
 
-function renderResultsPlot(timeSeries, projectId, $) {
+function simpleSlug(str) {
+  return str.replace(/[\W_]+/g,"");
+}
+
+function renderResultsPlots(timeSeries, projectId, $) {
+  let plotDivs = '';
+  for (const series in timeSeries) {
+    const slug = simpleSlug(series);
+    plotDivs += `<h6>${series}</h6><div id="p${projectId}-results-${slug}"></div>`
+  }
+
+  $(`#p${projectId}-results`).append(plotDivs);
+
+  for (const series in timeSeries) {
+    const slug = simpleSlug(series);
+    const id = `p${projectId}-results-${slug}`;
+    renderResultsPlot(timeSeries[series], id, $);
+  }
+}
+
+
+function renderResultsPlot(timeSeries, divId, $) {
   const index = [];
 
   const trace1 = {
@@ -36,7 +57,7 @@ function renderResultsPlot(timeSeries, projectId, $) {
   }
   trace1.x = index;
 
-  Plotly.newPlot(`p${projectId}-results`, data, layout);
+  Plotly.newPlot(divId, data, layout);
 }
 
 function renderTimelinePlot(key, results) {

--- a/resources/render.js
+++ b/resources/render.js
@@ -133,7 +133,7 @@ function renderAllResults(project, $) {
   resultsP.then(
     async (resultsResponse) => {
       const results = await resultsResponse.json();
-      renderResultsPlot(results.timeSeries, project.id, $);
+      renderResultsPlots(results.timeSeries, project.id, $);
     });
 
   return `<div id="p${project.id}-results"></div>`;

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -25,7 +25,7 @@ describe('Test Dashboard on empty DB', () => {
 
   it('Should get empty results request', async () => {
     const result = await dashResults(0, db);
-    expect(result.timeSeries).toHaveLength(0);
+    expect(result.timeSeries).toEqual({});
   });
 
   it('Should get empty statistics', async () => {
@@ -69,8 +69,8 @@ describe('Test Dashboard with basic test data loaded', () => {
 
   it('Should get results, but does not have any values', async () => {
     const results = (await dashResults(1, db)).timeSeries;
-    expect(results).toHaveLength(3);
-    expect(results[0]).toBeCloseTo(383.82, 2);
+    expect(results['NBody']).toHaveLength(3);
+    expect(results['NBody'][0]).toBeCloseTo(383.82, 2);
   });
 
   it('Should get statistics', async () => {


### PR DESCRIPTION
Until now, we did show everything on a single plot, which is worse than useless.

Now the plots are split out, and the results are limited to the last 100 data points.