### PR TITLE
Use separate databases for testing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,8 +20,6 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': [
       'error',
       { allowArgumentsExplicitlyTypedAsAny: true }
-    ],
-    // TODO: make all tests work and avoid skipping them
-    'jest/no-disabled-tests': 'off'
+    ]
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     node: true
   },
   rules: {
+    'max-len': ["error", { "code": 80 }],
     '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-module-boundary-types': [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,10 @@ jobs:
           cache-name: r-libs
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/stats/install.R') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/stats/install.R') }}-2
+          # restore-keys: |
+          #   ${{ runner.os }}-${{ env.cache-name }}-
+          #   ${{ runner.os }}-
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/resources/plots.js
+++ b/resources/plots.js
@@ -11,7 +11,8 @@ function renderResultsPlots(timeSeries, projectId, $) {
   let plotDivs = '';
   for (const series in timeSeries) {
     const slug = simpleSlug(series);
-    plotDivs += `<h6>${series}</h6><div id="p${projectId}-results-${slug}"></div>`
+    plotDivs +=
+      `<h6>${series}</h6><div id="p${projectId}-results-${slug}"></div>`;
   }
 
   $(`#p${projectId}-results`).append(plotDivs);

--- a/resources/render.js
+++ b/resources/render.js
@@ -38,7 +38,8 @@ function formatCommitMessages(messages) {
   const newLineIdx = messages.indexOf('\n');
   if (newLineIdx > -1) {
     const firstLine = messages.substr(0, newLineIdx);
-    return `${firstLine} <a href="#" onclick="expandMessage(event)" data-fulltext="${messages.replace('"', "\x22")}">&hellip;</a>`;
+    return `${firstLine} <a href="#" onclick="expandMessage(event)"` +
+        ` data-fulltext="${messages.replace('"', "\x22")}">&hellip;</a>`;
   } else {
     return messages;
   }
@@ -58,12 +59,18 @@ function renderProjectDataOverview(data, $) {
       <tr>
         <td>${row.name}</td>
         <td class="desc">${row.description == null ? '' : row.description}</td>
-        <td>${row.minstarttime == null ? '' : formatDateWithTime(row.minstarttime)} ${row.maxendtime == null ? '' : formatDateWithTime(row.maxendtime)}</td>
+        <td>${
+          row.minstarttime == null ? '' : formatDateWithTime(row.minstarttime)
+        } ${
+          row.maxendtime == null ? '' : formatDateWithTime(row.maxendtime)}</td>
         <td>${row.users}</td>
-        <td>${shortenCommitIds(row.commitids)} <p>${formatCommitMessages(row.commitmsgs)}</p></td>
+        <td>${
+          shortenCommitIds(row.commitids)
+        } <p>${formatCommitMessages(row.commitmsgs)}</p></td>
         <td>${row.hostnames}</td>
         <td class="num-col">${row.runs}</td>
-        <td class="num-col"><a href="/rebenchdb/get-exp-data/${row.expid}">${row.measurements}</a></td>
+        <td class="num-col"><a href="/rebenchdb/get-exp-data/${
+          row.expid}">${row.measurements}</a></td>
       </tr>`);
   }
 
@@ -93,7 +100,8 @@ function renderChanges(project, $) {
       </div>
     </div></div>
 
-    <button type="button" class="btn btn-primary" id="p${project.id}-compare">Compare</button>`;
+    <button type="button" class="btn btn-primary" id="p${
+      project.id}-compare">Compare</button>`;
   return changes;
 }
 
@@ -106,7 +114,8 @@ async function renderChangeDetails(changesDetailsResponse, projectId, $) {
     // strip out some metadata to be nicer to view.
     const msg = filterCommitMessage(change.commitmessage);
 
-    const option = `<a class="list-group-item list-group-item-action list-min-padding"
+    const option =
+    `<a class="list-group-item list-group-item-action list-min-padding"
       data-toggle="list" data-hash="${change.commitid}" href="">
         ${change.commitid.substr(0,  6)} ${change.branchortag}<br>
         <div style="font-size: 80%; line-height: 1">${msg}</div>
@@ -144,7 +153,8 @@ function renderProject(project, $) {
   const allResults = renderAllResults(project, $);
 
   const result = `<div class="card">
-    <h5 class="card-header"><a href="/project/${project.id}">${project.name}</a></h5>
+    <h5 class="card-header"><a href="/project/${
+      project.id}">${project.name}</a></h5>
     <div class="card-body">
       ${changes}
       ${allResults}
@@ -161,7 +171,8 @@ async function populateStatistics(statsP, $) {
   for (const t of stats.stats) {
     table.append(`<tr><td>${t.table}</td><td>${t.cnt}</td></tr>`);
   }
-  table.append(`<tr class="table-info"><td>Version</td><td>${stats.version}</td></tr>`);
+  table.append(
+    `<tr class="table-info"><td>Version</td><td>${stats.version}</td></tr>`);
 }
 
 function renderBenchmarks(benchmarks, $) {
@@ -202,7 +213,10 @@ function renderBenchmark(benchmark) {
         <p class="card-text"><small class="text-muted">
         ${benchmark.execname}, ${benchmark.hostname}<br/>
         <code>${cmdline}</code></small></p>
-        <div class="timeline-plot" id="plot-${benchmark.benchid}-${benchmark.suiteid}-${benchmark.execid}-${benchmark.hostname}" class="card-img-top"></div>
+        <div class="timeline-plot" id="plot-${
+          benchmark.benchid}-${benchmark.suiteid}-${
+            benchmark.execid}-${
+              benchmark.hostname}" class="card-img-top"></div>
       </div>
     </div>`;
 
@@ -220,7 +234,8 @@ function renderTimelinePlots(data, $) {
   }
 
   for (const result of data.timeline) {
-    const key = `plot-${result.benchmarkid}-${result.suiteid}-${result.execid}-${result.hostname}`;
+    const key = `plot-${result.benchmarkid}-${
+      result.suiteid}-${result.execid}-${result.hostname}`;
     if (!benchmarks.has(key)) {
       benchmarks.set(key, []);
     }

--- a/src/api-validator.ts
+++ b/src/api-validator.ts
@@ -1,6 +1,8 @@
 import Ajv from 'ajv';
 import { existsSync } from 'fs';
-import { getProgramFromFiles, generateSchema, CompilerOptions, PartialArgs } from 'typescript-json-schema';
+import {
+  getProgramFromFiles, generateSchema, CompilerOptions, PartialArgs
+} from 'typescript-json-schema';
 
 export function createValidator(): Ajv.ValidateFunction {
   const compilerOptions: CompilerOptions = {

--- a/src/db.ts
+++ b/src/db.ts
@@ -28,7 +28,7 @@ export function loadScheme(): string {
 
 export class Database {
   public client: Pool | PoolClient;
-  private readonly dbConfig: PoolConfig;
+  protected readonly dbConfig: PoolConfig;
   private readonly timelineEnabled: boolean;
 
   /** Number of bootstrap samples to take for timeline. */
@@ -136,7 +136,7 @@ export class Database {
 
   private static readonly batchN = 50;
 
-  constructor(config: PoolConfig, numReplicates = 1000, timelineEnabled = false) {
+  constructor(config: PoolConfig, numReplicates: number = 1000, timelineEnabled: boolean = false) {
     console.assert(config !== undefined);
     this.dbConfig = config;
     this.numReplicates = numReplicates;
@@ -202,6 +202,7 @@ export class Database {
 
   public async close(): Promise<void> {
     await (<any> this.client).end();
+    (<any> this).client = null;
   }
 
   public async activateTransactionSupport(): Promise<void> {

--- a/src/db.ts
+++ b/src/db.ts
@@ -200,6 +200,10 @@ export class Database {
     }
   }
 
+  public async close(): Promise<void> {
+    await (<any> this.client).end();
+  }
+
   public async activateTransactionSupport(): Promise<void> {
     this.client = <PoolClient> await this.client.connect();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,12 @@ router.get('/rebenchdb/dash/:projectId/results', async ctx => {
 });
 
 router.get('/rebenchdb/dash/:projectId/benchmarks', async ctx => {
+  const start = startRequest();
+
   ctx.body = await dashBenchmarksForProject(db, ctx.params.projectId);
   ctx.type = 'application/json';
+
+  await completeRequest(start, db, 'project-benchmarks');
 });
 
 router.get('/rebenchdb/dash/:projectId/timeline', async ctx => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,11 @@ import ajv from 'ajv';
 
 import { version } from '../package.json';
 import { initPerfTracker, startRequest, completeRequest } from './perf-tracker';
-import { dashResults, dashStatistics, dashChanges, dashCompare, dashProjects, dashBenchmarksForProject, dashTimelineForProject, dashDataOverview, dashGetExpData } from './dashboard';
+import {
+  dashResults, dashStatistics, dashChanges, dashCompare, dashProjects,
+  dashBenchmarksForProject, dashTimelineForProject, dashDataOverview,
+  dashGetExpData
+} from './dashboard';
 import { processTemplate } from './templates';
 
 console.log('Starting ReBenchDB Version ' + version);
@@ -140,7 +144,9 @@ router.get('/admin/perform-timeline-update', async ctx => {
 if (DEV) {
   router.get('/static/:filename', async ctx => {
     console.log(`serve ${ctx.params.filename}`);
-    ctx.body = readFileSync(`${__dirname}/../../resources/${ctx.params.filename}`);
+    // TODO: robustPath?
+    ctx.body = readFileSync(
+      `${__dirname}/../../resources/${ctx.params.filename}`);
     if (ctx.params.filename.endsWith('.css')) {
       ctx.type = 'css';
     } else if (ctx.params.filename.endsWith('.js')) {
@@ -150,7 +156,8 @@ if (DEV) {
 
   router.get('/static/exp-data/:filename', async ctx => {
     console.log(`serve ${ctx.params.filename}`);
-    ctx.body = readFileSync(`${__dirname}/../../resources/exp-data/${ctx.params.filename}`);
+    ctx.body = readFileSync(
+      `${__dirname}/../../resources/exp-data/${ctx.params.filename}`);
     if (ctx.params.filename.endsWith('.qs')) {
       ctx.type = 'application/octet-stream';
     }
@@ -158,7 +165,9 @@ if (DEV) {
 
   router.get('/static/reports/:change/figure-html/:filename', async ctx => {
     console.log(`serve ${ctx.params.filename}`);
-    ctx.body = readFileSync(`${__dirname}/../../resources/reports/${ctx.params.change}/figure-html/${ctx.params.filename}`);
+    ctx.body = readFileSync(
+      `${__dirname}/../../resources/reports/${ctx.params.change
+      }/figure-html/${ctx.params.filename}`);
     if (ctx.params.filename.endsWith('.svg')) {
       ctx.type = 'svg';
     } else if (ctx.params.filename.endsWith('.css')) {
@@ -176,7 +185,9 @@ router.get('/status', async ctx => {
   ctx.type = 'text';
 });
 
-const validateFn: ajv.ValidateFunction = DEBUG ? createValidator() : <any> undefined;
+const validateFn: ajv.ValidateFunction =
+  DEBUG ? createValidator()
+    : <any> undefined;
 
 function validateSchema(data: BenchmarkData, ctx: Router.IRouterContext) {
   const result = validateFn(data);
@@ -191,7 +202,8 @@ ${validateFn.errors}`;
   }
 }
 
-// curl -X PUT -H "Content-Type: application/json" -d '{"foo":"bar","baz":3}' http://localhost:33333/rebenchdb/results
+// curl -X PUT -H "Content-Type: application/json" -d '{"foo":"bar","baz":3}'
+//  http://localhost:33333/rebenchdb/results
 // DEBUG: koaBody({includeUnparsed: true})
 router.put('/rebenchdb/results', koaBody({ jsonLimit: '500mb' }), async ctx => {
   const start = startRequest();
@@ -206,13 +218,15 @@ router.put('/rebenchdb/results', koaBody({ jsonLimit: '500mb' }), async ctx => {
   try {
     const recordedRuns = await db.recordMetaDataAndRuns(data);
     db.recordAllData(data)
-      .then(recordedMeasurements => console.log(`/rebenchdb/results: stored ${recordedMeasurements} measurements`))
+      .then(recordedMeasurements => console.log(
+        `/rebenchdb/results: stored ${recordedMeasurements} measurements`))
       .catch(e => {
         console.error(`/rebenchdb/results failed to store measurements: ${e}`);
         console.error(e.stack);
       });
 
-    ctx.body = `Meta data for ${recordedRuns} stored. Storing of measurements is ongoing`;
+    ctx.body = `Meta data for ${recordedRuns
+      } stored. Storing of measurements is ongoing`;
     ctx.status = 200;
   } catch (e) {
     ctx.status = 500;

--- a/src/perf-tracker.ts
+++ b/src/perf-tracker.ts
@@ -57,7 +57,8 @@ function constructData(time: number, it: number, benchmark: string) {
           },
           desc: descriptions[benchmark]
         },
-        cmdline: benchmark, location: '', varValue: null, cores: null, inputSize: null, extraArgs: null
+        cmdline: benchmark, location: '', varValue: null, cores: null,
+        inputSize: null, extraArgs: null
       }
     }],
     criteria: [
@@ -91,8 +92,10 @@ export function startRequest(): number {
   return performance.now();
 }
 
-export async function completeRequest(reqStart: number, db: Database, request: string): Promise<void> {
+export async function completeRequest(reqStart: number, db: Database,
+  request: string): Promise<void> {
   const time = performance.now() - reqStart;
   iterations[request] += 1;
-  await db.recordAllData(constructData(time, iterations[request], request), true);
+  await db.recordAllData(
+    constructData(time, iterations[request], request), true);
 }

--- a/src/perf-tracker.ts
+++ b/src/perf-tracker.ts
@@ -10,7 +10,8 @@ const iterations = {
   'generate-report': 0,
   'generate-timeline': 0,
   'prep-exp-data': 0,
-  'get-exp-data': 0
+  'get-exp-data': 0,
+  'project-benchmarks': 0
 };
 
 const descriptions = {
@@ -20,7 +21,8 @@ const descriptions = {
   'generate-report': 'Time of Running R Reporting for /compare/*',
   'generate-timeline': 'Time of Running R stats to generate timeline data',
   'prep-exp-data': 'Prepare experiment data for download',
-  'get-exp-data': 'Starting to prepare experiment data'
+  'get-exp-data': 'Starting to prepare experiment data',
+  'project-benchmarks': 'Time of GET /rebenchdb/dash/:projectId/benchmarks'
 };
 
 export function initPerfTracker(): void {

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,10 +1,12 @@
 import { readFileSync } from 'fs';
 import { render } from 'mustache';
 
-const headerHtml = readFileSync(`${__dirname}/../../src/views/header.html`).toString();
+const headerHtml = readFileSync(
+  `${__dirname}/../../src/views/header.html`).toString();
 
 export function processTemplate(filename: string, variables: any = {}): string {
-  const fileContent = readFileSync(`${__dirname}/../../src/views/${filename}`).toString();
+  const fileContent = readFileSync(
+    `${__dirname}/../../src/views/${filename}`).toString();
 
   variables.headerHtml = headerHtml;
   return render(fileContent, variables);

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -16,7 +16,7 @@ describe('Test Dashboard on empty DB', () => {
 
   afterAll(async () => {
     await db.client.query('ROLLBACK');
-    await (<any> db.client).end();
+    await db.close();
   });
 
   afterEach(async () => {
@@ -57,7 +57,7 @@ describe('Test Dashboard with basic test data loaded', () => {
 
   afterAll(async () => {
     await db.client.query('ROLLBACK');
-    await (<any> db.client).end();
+    await db.close();
   });
 
   it('Should get a project', async () => {

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,26 +1,21 @@
-import { Database } from '../src/db';
-import { getConfig, prepareDbForTesting, rollback } from './db-testing';
+import { TestDatabase, createAndInitializeDB } from './db-testing';
 import { dashStatistics, dashResults, dashChanges, dashProjects, dashDataOverview, dashBenchmarksForProject } from '../src/dashboard';
 import { BenchmarkData } from '../src/api';
 import { readFileSync } from 'fs';
 
-const testDbConfig = getConfig();
-
 describe('Test Dashboard on empty DB', () => {
-  let db: Database;
+  let db: TestDatabase;
 
   beforeAll(async () => {
-    db = new Database(testDbConfig);
-    await prepareDbForTesting(db);
+    db = await createAndInitializeDB('dash_empty');
   });
 
   afterAll(async () => {
-    await db.client.query('ROLLBACK');
     await db.close();
   });
 
   afterEach(async () => {
-    await rollback(db);
+    await db.rollback();
   });
 
   it('Should get empty results request', async () => {
@@ -43,11 +38,12 @@ describe('Test Dashboard on empty DB', () => {
 });
 
 describe('Test Dashboard with basic test data loaded', () => {
-  let db: Database;
+  let db: TestDatabase;
+
+  // switch suites to use a template database
 
   beforeAll(async () => {
-    db = new Database(testDbConfig);
-    await prepareDbForTesting(db);
+    db = await createAndInitializeDB('dash_basic', 25, true, false);
 
     const basicTestData: BenchmarkData = JSON.parse(
       readFileSync(`${__dirname}/small-payload.json`).toString());
@@ -56,7 +52,6 @@ describe('Test Dashboard with basic test data loaded', () => {
   });
 
   afterAll(async () => {
-    await db.client.query('ROLLBACK');
     await db.close();
   });
 
@@ -92,16 +87,21 @@ describe('Test Dashboard with basic test data loaded', () => {
     expect(result[0].commitid).toEqual('58666d1c84c652306f930daa72e7a47c58478e86');
   });
 
-  // TODO: need to await timeline initialization
-  it.skip('Should get available data for DataOverview', async () => {
+  it('Should get available data for DataOverview', async () => {
+    await db.awaitQuiescentTimelineUpdater();
     const data = (await dashDataOverview(1, db)).data;
-    expect(data).toEqual([]);
+    expect(data).toHaveLength(1);
+    expect(data[0].commitids).toEqual("58666d1c84c652306f930daa72e7a47c58478e86");
+    expect(data[0].expid).toEqual(1);
+    expect(data[0].name).toEqual("Small Test Case");
   });
 
-  // TODO: need to await timeline initialization
-  it.skip('Should get benchmarks for project', async () => {
+  it('Should get benchmarks for project', async () => {
+    await db.awaitQuiescentTimelineUpdater();
     const data = (await dashBenchmarksForProject(db, 1)).benchmarks;
-    expect(data).toEqual([]);
+    expect(data).toHaveLength(1);
+    expect(data[0].benchid).toEqual(1);
+    expect(data[0].benchmark).toEqual("NBody");
   });
 
   // dashTimelineForProject

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,5 +1,8 @@
 import { TestDatabase, createAndInitializeDB } from './db-testing';
-import { dashStatistics, dashResults, dashChanges, dashProjects, dashDataOverview, dashBenchmarksForProject } from '../src/dashboard';
+import {
+  dashStatistics, dashResults, dashChanges, dashProjects, dashDataOverview,
+  dashBenchmarksForProject
+} from '../src/dashboard';
 import { BenchmarkData } from '../src/api';
 import { readFileSync } from 'fs';
 
@@ -84,14 +87,16 @@ describe('Test Dashboard with basic test data loaded', () => {
   it('Should get change', async () => {
     const result = (await dashChanges(1, db)).changes;
     expect(result).toHaveLength(1);
-    expect(result[0].commitid).toEqual('58666d1c84c652306f930daa72e7a47c58478e86');
+    expect(result[0].commitid).toEqual(
+      '58666d1c84c652306f930daa72e7a47c58478e86');
   });
 
   it('Should get available data for DataOverview', async () => {
     await db.awaitQuiescentTimelineUpdater();
     const data = (await dashDataOverview(1, db)).data;
     expect(data).toHaveLength(1);
-    expect(data[0].commitids).toEqual("58666d1c84c652306f930daa72e7a47c58478e86");
+    expect(data[0].commitids).toEqual(
+      '58666d1c84c652306f930daa72e7a47c58478e86');
     expect(data[0].expid).toEqual(1);
     expect(data[0].name).toEqual("Small Test Case");
   });

--- a/tests/db-setup.test.ts
+++ b/tests/db-setup.test.ts
@@ -270,7 +270,7 @@ describe('Recording a ReBench execution from payload files', () => {
     expect(parseInt(measurements.rows[0].cnt)).toEqual(459928 + 4);
     const timeline = await db.client.query('SELECT * from Timeline');
     expect(timeline.rowCount).toEqual(462);
-  });
+  }, 200 * 1000);
 
   it('should not fail if some data was already recorded in database', async () => {
     // make sure everything is in the database

--- a/tests/db-setup.test.ts
+++ b/tests/db-setup.test.ts
@@ -36,7 +36,7 @@ describe('Setup of PostgreSQL DB', () => {
     expect(selectCommand.command).toEqual('SELECT');
     expect(selectCommand.rowCount).toEqual(0);
 
-    await (<any> db.client).end();
+    await db.close();
   });
 });
 
@@ -194,7 +194,7 @@ describe('Recording a ReBench execution data fragments', () => {
 
   afterAll(async () => {
     await db.client.query('ROLLBACK');
-    await (<any> db.client).end();
+    await db.close();
   });
 });
 
@@ -225,9 +225,9 @@ describe('Recording a ReBench execution from payload files', () => {
   });
 
   afterAll(async () => {
-    await (<any> db.client).end();
+    await db.close();
     await dbMain.client.query(`DROP DATABASE ${tmpCfg.database}`);
-    await (<any> dbMain.client).end();
+    await dbMain.close();
   });
 
   it('should accept all data (small-payload), and have the measurements persisted', async () => {

--- a/tests/db-setup.test.ts
+++ b/tests/db-setup.test.ts
@@ -221,7 +221,8 @@ describe('Recording a ReBench execution from payload files', () => {
     await db.close();
   });
 
-  it('should accept all data (small-payload), and have the measurements persisted', async () => {
+  it(`should accept all data (small-payload),
+      and have the measurements persisted`, async () => {
     await db.recordMetaDataAndRuns(smallTestData);
     const recMs = await db.recordAllData(smallTestData);
 
@@ -237,9 +238,13 @@ describe('Recording a ReBench execution from payload files', () => {
   it('data recording should be idempotent (small-payload)', async () => {
     // check that the data from the previous test is there
     let trials = await db.client.query('SELECT * from Trial');
-    expect(trials.rowCount).toEqual(2); // performance tracking and the actual trial
+
+    // performance tracking and the actual trial
+    expect(trials.rowCount).toEqual(2);
     let exps = await db.client.query('SELECT * from Experiment');
-    expect(exps.rowCount).toEqual(2); // performance tracking and the actual experiment
+
+    // performance tracking and the actual experiment
+    expect(exps.rowCount).toEqual(2);
 
     // Do recordData a second time
     await db.recordMetaDataAndRuns(smallTestData);
@@ -253,16 +258,22 @@ describe('Recording a ReBench execution from payload files', () => {
     expect(measurements.rowCount).toEqual(4);
 
     trials = await db.client.query('SELECT * from Trial');
-    expect(trials.rowCount).toEqual(2);  // performance tracking and the actual trial
+
+    // performance tracking and the actual trial
+    expect(trials.rowCount).toEqual(2);
     exps = await db.client.query('SELECT * from Experiment');
-    expect(exps.rowCount).toEqual(2);  // performance tracking and the actual experiment
+
+    // performance tracking and the actual experiment
+    expect(exps.rowCount).toEqual(2);
   });
 
-  it('should accept all data (large-payload), and have the measurements persisted', async () => {
+  it(`should accept all data (large-payload),
+      and have the measurements persisted`, async () => {
     await db.recordMetaDataAndRuns(largeTestData);
     const recMs = await db.recordAllData(largeTestData);
 
-    const measurements = await db.client.query('SELECT count(*) as cnt from Measurement');
+    const measurements = await db.client.query(
+      'SELECT count(*) as cnt from Measurement');
 
     await db.awaitQuiescentTimelineUpdater();
 
@@ -272,23 +283,25 @@ describe('Recording a ReBench execution from payload files', () => {
     expect(timeline.rowCount).toEqual(462);
   }, 200 * 1000);
 
-  it('should not fail if some data was already recorded in database', async () => {
-    // make sure everything is in the database
-    await db.recordMetaDataAndRuns(smallTestData);
-    await db.recordAllData(smallTestData);
+  it('should not fail if some data was already recorded in database',
+    async () => {
+      // make sure everything is in the database
+      await db.recordMetaDataAndRuns(smallTestData);
+      await db.recordAllData(smallTestData);
 
-    // obtain the bits, this should match what `recordData` does above
-    const { trial, criteria } = await db.recordMetaData(smallTestData);
+      // obtain the bits, this should match what `recordData` does above
+      const { trial, criteria } = await db.recordMetaData(smallTestData);
 
-    // now, manually do the recording
-    const r = smallTestData.data[0];
+      // now, manually do the recording
+      const r = smallTestData.data[0];
 
-    // and pretend there's no data yet
-    const availableMs = {};
+      // and pretend there's no data yet
+      const availableMs = {};
 
-    const run = await db.recordRun(r.runId);
+      const run = await db.recordRun(r.runId);
 
-    const recordedMeasurements = await db.recordMeasurements(r, run, trial, criteria, availableMs);
-    expect(recordedMeasurements).toEqual(0);
-  });
+      const recordedMeasurements = await db.recordMeasurements(
+        r, run, trial, criteria, availableMs);
+      expect(recordedMeasurements).toEqual(0);
+    });
 });

--- a/tests/db-testing.ts
+++ b/tests/db-testing.ts
@@ -1,6 +1,96 @@
-import { Database } from '../src/db';
+import { Database, DatabaseConfig } from '../src/db';
+import { PoolConfig } from 'pg';
 
-export function getConfig(): { user, password, host, database, port } {
+export class TestDatabase extends Database {
+  private readonly usesTransactions: boolean;
+  private preparedForTesting: boolean = false;
+
+  constructor(config: PoolConfig, numReplicates: number, timelineEnabled: boolean, useTransactions: boolean) {
+    super(config, numReplicates, timelineEnabled);
+    this.usesTransactions = useTransactions;
+  }
+
+  public async prepareForTesting(): Promise<void> {
+    if (this.preparedForTesting) {
+      throw new Error("This is only to be executed once");
+    }
+
+    if (this.usesTransactions) {
+      await this.activateTransactionSupport();
+      await this.client.query('BEGIN');
+    }
+
+    await this.initializeDatabase();
+
+    if (this.usesTransactions) {
+      await this.client.query('SAVEPOINT freshDB');
+    }
+  }
+
+  public async rollback(): Promise<void> {
+    this.clearCache();
+
+    if (this.usesTransactions) {
+      await this.client.query('ROLLBACK TO SAVEPOINT freshDB');
+    }
+  }
+
+  private async release(): Promise<void> {
+    const mainDB = getMainDB();
+    let query = `DROP DATABASE IF EXISTS ${this.dbConfig.database};`;
+    if (this.usesTransactions) {
+      query += 'COMMIT;'
+    }
+
+    await mainDB.client.query(query);
+  }
+
+  public async close(): Promise<void> {
+    this.rollback();
+
+    await super.close();
+    await this.release();
+  }
+}
+
+
+
+export async function createAndInitializeDB(testSuite: string,
+    numReplicates: number = 1000, timelineEnabled: boolean = false,
+    useTransactions: boolean = true): Promise<TestDatabase> {
+  const testDb = await createDB(testSuite, numReplicates, timelineEnabled, useTransactions);
+  await testDb.prepareForTesting();
+  return testDb;
+}
+
+export async function createDB(testSuite: string,
+  numReplicates: number = 1000, timelineEnabled: boolean = false,
+  useTransactions: boolean = true): Promise<TestDatabase> {
+  // TODO: consider using a template database, which may speed up things slightly
+  // https://walrus.ai/blog/2020/04/testing-database-interactions-with-jest/
+  // https://www.postgresql.org/docs/current/manage-ag-templatedbs.html
+  const cfg = getConfig();
+  const db = getMainDB();
+  const dbNameForSuite = `${cfg.database}_${testSuite}`;
+  await db.client.query(`DROP DATABASE IF EXISTS ${dbNameForSuite};`);
+  await db.client.query(`CREATE DATABASE ${dbNameForSuite};`);
+
+  cfg.database = dbNameForSuite;
+
+  return new TestDatabase(cfg, numReplicates, timelineEnabled, useTransactions);
+}
+
+let mainDB: Database | null = null;
+
+function getMainDB(): Database {
+  if (mainDB === null) {
+    const cfg = getConfig();
+    mainDB = new Database(cfg);
+  }
+  return mainDB;
+}
+
+function getConfig(): DatabaseConfig {
   return {
     user: process.env.RDB_USER || '',
     password: process.env.RDB_PASS || '',
@@ -8,32 +98,4 @@ export function getConfig(): { user, password, host, database, port } {
     database: process.env.RDB_DB || 'test_rdb4',
     port: 5432
   };
-}
-
-export function getTempDatabaseName(): string {
-  return 'test_rdb_tmp';
-}
-
-export function wrapInTransaction(sql: string): string {
-  return `
-  begin;
-  ${sql};
-
-  SELECT * FROM Measurement;
-  rollback;
-  `;
-}
-
-export async function prepareDbForTesting(db: Database): Promise<void> {
-  await db.activateTransactionSupport();
-
-  await db.client.query('BEGIN');
-
-  await db.initializeDatabase();
-  await db.client.query('SAVEPOINT freshDB');
-}
-
-export async function rollback(db: Database): Promise<void> {
-  db.clearCache();
-  await db.client.query('ROLLBACK TO SAVEPOINT freshDB');
 }

--- a/tests/db-testing.ts
+++ b/tests/db-testing.ts
@@ -3,9 +3,10 @@ import { PoolConfig } from 'pg';
 
 export class TestDatabase extends Database {
   private readonly usesTransactions: boolean;
-  private preparedForTesting: boolean = false;
+  private preparedForTesting = false;
 
-  constructor(config: PoolConfig, numReplicates: number, timelineEnabled: boolean, useTransactions: boolean) {
+  constructor(config: PoolConfig, numReplicates: number,
+    timelineEnabled: boolean, useTransactions: boolean) {
     super(config, numReplicates, timelineEnabled);
     this.usesTransactions = useTransactions;
   }
@@ -56,17 +57,18 @@ export class TestDatabase extends Database {
 
 
 export async function createAndInitializeDB(testSuite: string,
-    numReplicates: number = 1000, timelineEnabled: boolean = false,
-    useTransactions: boolean = true): Promise<TestDatabase> {
-  const testDb = await createDB(testSuite, numReplicates, timelineEnabled, useTransactions);
+  numReplicates = 1000, timelineEnabled = false,
+  useTransactions = true): Promise<TestDatabase> {
+  const testDb = await createDB(
+    testSuite, numReplicates, timelineEnabled, useTransactions);
   await testDb.prepareForTesting();
   return testDb;
 }
 
 export async function createDB(testSuite: string,
-  numReplicates: number = 1000, timelineEnabled: boolean = false,
-  useTransactions: boolean = true): Promise<TestDatabase> {
-  // TODO: consider using a template database, which may speed up things slightly
+  numReplicates = 1000, timelineEnabled = false,
+  useTransactions = true): Promise<TestDatabase> {
+  // TODO: use a template database, which may speed up things slightly?
   // https://walrus.ai/blog/2020/04/testing-database-interactions-with-jest/
   // https://www.postgresql.org/docs/current/manage-ag-templatedbs.html
   const cfg = getConfig();

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -15,7 +15,8 @@ describe('Knitr Report Generation', () => {
       const extraCmd = `from-file;${baseFile};${changeFile}`;
 
       const reportP = new Promise((resolve, reject) => {
-        startReportGeneration(baseHash, changeHash, outputFile, {} as DatabaseConfig,
+        startReportGeneration(baseHash, changeHash, outputFile,
+          {} as DatabaseConfig,
           async (error, _stdout, _stderr) => {
             if (error) { reject(error); return; }
             resolve(true);
@@ -27,12 +28,15 @@ describe('Knitr Report Generation', () => {
     }, 60000);
 
     it('Should indicate differences in the benchmark sets', () => {
-      const content: string = readFileSync(`${__dirname}/../resources/reports/${outputFile}`, 'utf8');
-      expect(content).toEqual(expect.stringContaining('Changes in Benchmark Set'));
+      const content: string = readFileSync(
+        `${__dirname}/../resources/reports/${outputFile}`, 'utf8');
+      expect(content).toEqual(
+        expect.stringContaining('Changes in Benchmark Set'));
     });
 
     it('Should not have any output that indicates warnings', () => {
-      const content: string = readFileSync(`${__dirname}/../resources/reports/${outputFile}`, 'utf8');
+      const content: string = readFileSync(
+        `${__dirname}/../resources/reports/${outputFile}`, 'utf8');
       // warning output is inside <code> blocks
       expect(content).toEqual(expect.not.stringContaining('<code>'));
     })

--- a/tests/single-requester.test.ts
+++ b/tests/single-requester.test.ts
@@ -16,21 +16,23 @@ describe('Basic functionality of SingleRequestOnly', () => {
     expect(sro.getQuiescencePromise()).toBeUndefined();
   });
 
-  it('should execute the request once only even if triggered twice in a row', async () => {
-    let executed = 0;
-    const sro = new SingleRequestOnly(async () => { executed += 1; });
+  it('should execute the request once only even if triggered twice in a row',
+    async () => {
+      let executed = 0;
+      const sro = new SingleRequestOnly(async () => { executed += 1; });
 
-    // Since the request is executed asynchronously, we do execute it only once
-    sro.trigger();
-    sro.trigger();
+      // Since the request is executed asynchronously,
+      // we do execute it only once
+      sro.trigger();
+      sro.trigger();
 
-    const promise = sro.getQuiescencePromise();
-    expect(promise).not.toBeUndefined();
+      const promise = sro.getQuiescencePromise();
+      expect(promise).not.toBeUndefined();
 
-    await promise;
+      await promise;
 
-    expect(executed).toEqual(1);
-    expect(sro.getQuiescencePromise()).toBeUndefined();
-  });
+      expect(executed).toEqual(1);
+      expect(sro.getQuiescencePromise()).toBeUndefined();
+    });
 
 });


### PR DESCRIPTION
This will allow us to more easily test interaction with R scripts.
Before, the tests used a separate DB just for a single test.
Now, things are more uniform, and DB initialization and release is done more consistently.

- implement incomplete and previously skipped tests
- remove eslint setting to ignore skipped tests
- adds a new eslint setting to limit line length to 80 chars.