### PR TITLE
Speedup timeline compute

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -4,7 +4,7 @@ import {
   BenchmarkData, Executor, Suite, Benchmark, RunId, Source, Environment,
   Criterion, Run
 } from './api';
-import { Pool, PoolConfig, PoolClient, QueryResult } from 'pg';
+import { Pool, PoolConfig, PoolClient } from 'pg';
 import { SingleRequestOnly } from './single-requester';
 import { startRequest, completeRequest } from './perf-tracker';
 
@@ -102,7 +102,8 @@ export class Database {
       name: 'insertMeasurement',
       text: `INSERT INTO Measurement
           (runId, trialId, invocation, iteration, criterion, value)
-        VALUES ($1, $2, $3, $4, $5, $6)`,
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT DO NOTHING`,
       values: <any[]>[]
     },
 
@@ -120,7 +121,8 @@ export class Database {
           ($37, $38, $39, $40, $41, $42),
           ($43, $44, $45, $46, $47, $48),
           ($49, $50, $51, $52, $53, $54),
-          ($55, $56, $57, $58, $59, $60)`,
+          ($55, $56, $57, $58, $59, $60)
+          ON CONFLICT DO NOTHING`,
       values: <any[]>[]
     },
 
@@ -171,7 +173,8 @@ export class Database {
     this.queries.insertMeasurementBatchedN.text =
       `INSERT INTO Measurement
          (runId, trialId, invocation, iteration, criterion, value)
-       VALUES ` + this.generateBatchInsert(Database.batchN, 6);
+       VALUES ${this.generateBatchInsert(Database.batchN, 6)}
+       ON CONFLICT DO NOTHING`;
 
     this.timelineUpdater = new SingleRequestOnly(
       async () => { return this.performTimelineUpdate(); });
@@ -423,8 +426,8 @@ export class Database {
       // there are 6 parameters, i.e., values
       const rest = batchedValues.splice(6 * 1);
       try {
-        await this.recordMeasurement(batchedValues);
-        recordedMeasurements += 1;
+        const result = await this.recordMeasurement(batchedValues);
+        recordedMeasurements += result;
       } catch (err) {
         // looks like we already have this data
         if (!isUniqueViolationError(err)) {
@@ -457,8 +460,8 @@ export class Database {
         batchedValues = batchedValues.concat(values);
         if (batchedMs === Database.batchN) {
           try {
-            await this.recordMeasurementBatchedN(batchedValues);
-            recordedMeasurements += batchedMs;
+            const result = await this.recordMeasurementBatchedN(batchedValues);
+            recordedMeasurements += result;
           } catch (err) {
             // we may have concurrent inserts, or partially inserted data,
             // where a request aborted
@@ -479,8 +482,8 @@ export class Database {
       // there are 6 parameters, i.e., values
       const rest = batchedValues.splice(6 * 10);
       try {
-        await this.recordMeasurementBatched10(batchedValues);
-        recordedMeasurements += 10;
+        const result = await this.recordMeasurementBatched10(batchedValues);
+        recordedMeasurements += result;
       } catch (err) {
         if (isUniqueViolationError(err)) {
           recordedMeasurements += await this.recordMeasurementsFromBatch(
@@ -536,27 +539,25 @@ export class Database {
     return data.data.length;
   }
 
-  public async recordMeasurementBatched10(values: any[]):
-    Promise<QueryResult<any>> {
+  public async recordMeasurementBatched10(values: any[]): Promise<number> {
     const q = this.queries.insertMeasurementBatched10;
     // [runId, trialId, invocation, iteration, critId, value];
     q.values = values;
-    return await this.client.query(q);
+    return (await this.client.query(q)).rowCount;
   }
 
-  public async recordMeasurementBatchedN(values: any[]):
-    Promise<QueryResult<any>> {
+  public async recordMeasurementBatchedN(values: any[]): Promise<number> {
     const q = this.queries.insertMeasurementBatchedN;
     // [runId, trialId, invocation, iteration, critId, value];
     q.values = values;
-    return await this.client.query(q);
+    return (await this.client.query(q)).rowCount;
   }
 
-  public async recordMeasurement(values: any[]): Promise<QueryResult<any>> {
+  public async recordMeasurement(values: any[]): Promise<number> {
     const q = this.queries.insertMeasurement;
     // [runId, trialId, invocation, iteration, critId, value];
     q.values = values;
-    return await this.client.query(this.queries.insertMeasurement);
+    return (await this.client.query(this.queries.insertMeasurement)).rowCount;
   }
 
   private generateTimeline() {
@@ -603,5 +604,3 @@ export class Database {
     return prom;
   }
 }
-
-

--- a/src/db/db.sql
+++ b/src/db/db.sql
@@ -212,3 +212,15 @@ CREATE TABLE Timeline (
   foreign key (runId) references Run (id),
   foreign key (criterion) references Criterion (id)
 );
+
+-- the specified run needs an update on the timeline
+CREATE SEQUENCE TimelineJobId AS smallint CYCLE;
+
+CREATE TABLE TimelineCalcJob (
+  timelineJobId smallint NOT NULL DEFAULT nextval('TimelineJobId') PRIMARY KEY,
+  trialId   smallint,
+  runId     smallint,
+  criterion smallint
+);
+
+ALTER SEQUENCE TimelineJobId OWNED BY TimelineCalcJob.timelineJobId;

--- a/src/db/migration.002.sql
+++ b/src/db/migration.002.sql
@@ -9,3 +9,15 @@ ALTER TABLE Trial ADD COLUMN denoise jsonb;
 -- set sensible defaults for projects
 ALTER TABLE Project ALTER COLUMN showChanges SET DEFAULT true;
 ALTER TABLE Project ALTER COLUMN allResults SET DEFAULT false;
+
+-- add the TimelineCalcJob table
+CREATE SEQUENCE TimelineJobId AS smallint CYCLE;
+
+CREATE TABLE TimelineCalcJob (
+  timelineJobId smallint NOT NULL DEFAULT nextval('TimelineJobId') PRIMARY KEY,
+  trialId   smallint,
+  runId     smallint,
+  criterion smallint
+);
+
+ALTER SEQUENCE TimelineJobId OWNED BY TimelineCalcJob.timelineJobId;

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -2,7 +2,7 @@
 ## Exposes standardized data sets for access by reports.
 library(RPostgres)
 library(DBI)
-library(qs)
+suppressMessages(library(qs))
 
 load_data_file <- function(filename) {
   qread(filename)  


### PR DESCRIPTION
Updating the time line has been a very expensive operation, because we queried the measurement table with HAVING COUNT(..), GROUP BY, etc.

This PR replaces this by using a separate table, where we keep track of the experiments that have need data, and thus, communicate directly, with the R script, what needs calculation.
Then, requesting the data becomes significantly cheaper.
However, there's probably room for further improvements, since currently, the query takes still 10seconds on rebench.stefan-marr.de.

This PR also uses the `ON CONFLICT` versions of queries to avoid previously problematic things, and either ignore existing entries in the database, or update them.
For measurements, the DB is supposed to be append only.
So, we ignore them.
For the timeline, we simply update them with the most recent calculated stats.