### PR TITLE
Type DB results and reject data without startTime

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,13 @@ router.put('/rebenchdb/results', koaBody({ jsonLimit: '500mb' }), async ctx => {
     validateSchema(data, ctx);
   }
 
+  if (!data.startTime) {
+    ctx.body = `Request misses a startTime setting,
+                which is needed to store results correctly.`;
+    ctx.status = 400;
+    return;
+  }
+
   try {
     const recordedRuns = await db.recordMetaDataAndRuns(data);
     db.recordAllData(data)

--- a/src/perf-tracker.ts
+++ b/src/perf-tracker.ts
@@ -66,7 +66,8 @@ function constructData(time: number, it: number, benchmark: string) {
     ],
     env: {
       hostName: 'self',
-      cpu: '', memory: 0, clockSpeed: 0, osType: '', userName: '', software: [],
+      cpu: '', memory: 0, clockSpeed: 0, osType: 'nodejs',
+      userName: 'rebench-perf-tracking', software: [],
       manualRun: false,
       denoise: {}
     },


### PR DESCRIPTION
This change may slightly increase the robustness of the system.

It also uses slightly more telling data for the performance recording of ReBenchDB operations.
The non-telling data confused me into a ghost chase.