### PR TITLE
Post Summary on GitHub

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,8 @@ module.exports = {
     node: true
   },
   rules: {
-    'max-len': ["error", { "code": 80 }],
+    'max-len': ['error', { 'code': 80 }],
+    'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
     '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-module-boundary-types': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,6 +1156,156 @@
         "chalk": "^3.0.0"
       }
     },
+    "@octokit/auth-app": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-2.4.14.tgz",
+      "integrity": "sha512-1D1+8VFZpgbQdaePVWll3qb7mpKazu15xtZ17xzLjbfGFUcB4ddp/nHvDtfIWTMWrx92Iaz+5FGLCLVi8p4WOg==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0",
+        "universal-github-app-jwt": "^1.0.1",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "@octokit/auth-token": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
+      "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^5.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
+      "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^4.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+          "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA=="
+        }
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.3.tgz",
+      "integrity": "sha512-JyYvi3j2tOb5ofASEpcg1Advs07H+Ag+I+ez7buuZfNVAmh1IYcDTuxd4gnYH8S2PSGu+f5IdDGxMmkK+5zsdA==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz",
+      "integrity": "sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==",
+      "requires": {
+        "@octokit/types": "^5.2.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.1.2.tgz",
+      "integrity": "sha512-PTI7wpbGEZ2IR87TVh+TNWaLcgX/RsZQalFbQCq8XxYUrQ36RHyERrHSNXFy5gkWpspUAOYRSV707JJv6BhqJA==",
+      "requires": {
+        "@octokit/types": "^5.1.1",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
+      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^4.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+          "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA=="
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "requires": {
+        "@octokit/types": "^5.0.1",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.3.tgz",
+      "integrity": "sha512-GubgemnLvUJlkhouTM2BtX+g/voYT/Mqh0SASGwTnLvSkW1irjt14N911/ABb6m1Hru0TwScOgFgMFggp3igfQ==",
+      "requires": {
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.0",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "4.1.2"
+      }
+    },
+    "@octokit/types": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.0.tgz",
+      "integrity": "sha512-D/uotqF69M50OIlwMqgyIg9PuLT2daOiBAYF0P40I2ekFA2ESwwBY5dxZe/UhXdPvIbNKDzuZmQrO7rMpuFbcg==",
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1380,6 +1530,14 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/jsonwebtoken": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
+      "integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
@@ -1418,6 +1576,11 @@
       "requires": {
         "@types/koa": "*"
       }
+    },
+    "@types/lru-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -2042,6 +2205,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -2106,6 +2274,11 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -2666,6 +2839,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -2732,6 +2910,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "editorconfig": {
@@ -5928,6 +6114,23 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5938,6 +6141,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "keygrip": {
@@ -6108,11 +6330,46 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -6322,6 +6579,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6517,7 +6779,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6864,6 +7125,11 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promisify-child-process": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/promisify-child-process/-/promisify-child-process-4.1.1.tgz",
+      "integrity": "sha512-/sRjHZwoXf1rJ+8s4oWjYjGRVKNK1DUnqfRC1Zek18pl0cN6k3yJ1cCbqd0tWNe4h0Gr+SY4vR42N33+T82WkA=="
     },
     "prompts": {
       "version": "2.3.2",
@@ -7378,8 +7644,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -8329,6 +8594,20 @@
         "crypto-random-string": "^2.0.0"
       }
     },
+    "universal-github-app-jwt": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.0.2.tgz",
+      "integrity": "sha512-bJ3hVBdPREry3vob+JBOjXkO76QAQkYTIJvQ62Ja7XBSrKv6v6gHaRBWADddvS0HiLF0Q6lCK1kg4ZJrj/Kl9g==",
+      "requires": {
+        "@types/jsonwebtoken": "^8.3.3",
+        "jsonwebtoken": "^8.5.1"
+      }
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -8632,8 +8911,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "koa-body": "4.1.1",
     "koa-router": "8.0.8",
     "mustache": "4.0.1",
-    "pg": "8.0.3"
+    "@octokit/rest": "18.0.3",
+    "@octokit/auth-app": "2.4.14",
+    "pg": "8.0.3",
+    "promisify-child-process": "4.1.1"
   },
   "devDependencies": {
     "@types/jest": "26.0.4",
@@ -23,6 +26,7 @@
     "@types/pg": "7.14.3",
     "@typescript-eslint/eslint-plugin": "3.6.0",
     "@typescript-eslint/parser": "3.6.0",
+    "@octokit/types": "5.4.0",
     "ajv": "6.12.3",
     "eslint": "7.4.0",
     "eslint-plugin-jest": "23.18.0",

--- a/resources/plots.js
+++ b/resources/plots.js
@@ -4,7 +4,7 @@
 'use strict';
 
 function simpleSlug(str) {
-  return str.replace(/[\W_]+/g,"");
+  return str.replace(/[\W_]+/g, '');
 }
 
 function renderResultsPlots(timeSeries, projectId, $) {

--- a/resources/render.js
+++ b/resources/render.js
@@ -39,7 +39,7 @@ function formatCommitMessages(messages) {
   if (newLineIdx > -1) {
     const firstLine = messages.substr(0, newLineIdx);
     return `${firstLine} <a href="#" onclick="expandMessage(event)"` +
-        ` data-fulltext="${messages.replace('"', "\x22")}">&hellip;</a>`;
+        ` data-fulltext="${messages.replace('"', '\x22')}">&hellip;</a>`;
   } else {
     return messages;
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -107,6 +107,12 @@ export interface BenchmarkData {
   projectName: string;
 }
 
+export interface BenchmarkCompletion {
+  projectName: string;
+  experimentName: string;
+  endTime?: string | null;
+}
+
 export interface Criterion {
   /** Id used to identify a criterion tuple. */
   i: number;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -450,7 +450,7 @@ export async function reportCompletion(dbConfig: DatabaseConfig, db: Database,
     .then(() => {
       const plotFile = getSummaryPlotFileName(reportId + '.html');
       const summaryPlot = `${siteConfig.staticUrl}/reports/${plotFile}`;
-      const msg = `#### Performance changes from ${baselineSha} to ${changeSha}
+      const msg = `#### Performance changes for ${baselineSha}...${changeSha}
 
 ![Summary Over All Benchmarks](${siteConfig.publicUrl}/${
         summaryPlot})

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -151,7 +151,7 @@ export function startReportGeneration(base: string, change: string,
   ];
 
   const cmd = robustPath(`views/knitr.R`);
-  console.log(`Generate Report: ${cmd} '${args.join("' '")}'`);
+  console.log(`Generate Report: ${cmd} '${args.join(`' '`)}'`);
 
   return execFile(
     cmd, args, { cwd: robustPath(`../resources/reports/`) }, callback);

--- a/src/db.ts
+++ b/src/db.ts
@@ -482,7 +482,7 @@ export class Database {
     return result.rowCount === 1;
   }
 
-  public async getBaselineCommit(projectName: string):
+  public async getBaselineCommit(projectName: string, currentCommitId: string):
     Promise<Baseline | undefined> {
     const result = await this.client.query(`
       SELECT DISTINCT s.*, min(t.startTime) as firstStart
@@ -492,10 +492,11 @@ export class Database {
           JOIN Project p ON p.id = e.projectId
         WHERE p.name = $1 AND
           s.branchOrTag = p.baseBranch AND
+          s.commitId <> $2 AND
           p.baseBranch IS NOT NULL
         GROUP BY e.id, s.id
         ORDER BY firstStart DESC
-        LIMIT 1`, [projectName]);
+        LIMIT 1`, [projectName, currentCommitId]);
 
     if (result.rowCount < 1) {
       return undefined

--- a/src/db.ts
+++ b/src/db.ts
@@ -3,7 +3,8 @@ import { readFileSync, existsSync } from 'fs';
 import {
   BenchmarkData, Executor as ApiExecutor, Suite as ApiSuite,
   Benchmark as ApiBenchmark, RunId as ApiRunId, Source as ApiSource,
-  Environment as ApiEnvironment, Criterion as ApiCriterion, Run as ApiRun
+  Environment as ApiEnvironment, Criterion as ApiCriterion, Run as ApiRun,
+  BenchmarkCompletion
 } from './api';
 import { Pool, PoolConfig, PoolClient } from 'pg';
 import { SingleRequestOnly } from './single-requester';
@@ -83,6 +84,7 @@ export interface Project {
   logo: string;
   showchanges: boolean;
   allresults: boolean;
+  basebranch: string;
 }
 
 export interface Source {
@@ -152,6 +154,10 @@ export interface Measurement {
   value: number;
 }
 
+export interface Baseline extends Source {
+  firststart: string;
+}
+
 export class Database {
   public client: Pool | PoolClient;
   protected readonly dbConfig: PoolConfig;
@@ -211,11 +217,17 @@ export class Database {
     insertTrial: `INSERT INTO Trial (manualRun, startTime, expId, username,
                                      envId, sourceId, denoise)
                   VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
+    updateTrialEndTime: `UPDATE Trial t
+                         SET endTime = $2
+                         WHERE expId = $1 AND endTime IS NULL`,
 
     fetchProjectByName: 'SELECT * from Project WHERE name = $1',
     fetchProjectById: 'SELECT * from Project WHERE id = $1',
     insertProject: 'INSERT INTO Project (name) VALUES ($1) RETURNING *',
 
+    fetchExpByNames: `SELECT e.* FROM Experiment e
+                        JOIN Project p ON p.id = e.projectId
+                        WHERE p.name = $1 AND e.name = $2`,
     fetchExpByProjectIdName: `SELECT * FROM Experiment
                               WHERE projectId = $1 AND name = $2`,
     insertExp: `INSERT INTO Experiment (name, projectId, description)
@@ -461,6 +473,54 @@ export class Database {
     }
   }
 
+  public async setProjectBaseBranch(projectName: string, baseBranch: string):
+    Promise<boolean> {
+    const result = await this.client.query(`
+      UPDATE Project
+        SET baseBranch = $2
+        WHERE name = $1`, [projectName, baseBranch]);
+    return result.rowCount === 1;
+  }
+
+  public async getBaselineCommit(projectName: string):
+    Promise<Baseline | undefined> {
+    const result = await this.client.query(`
+      SELECT DISTINCT s.*, min(t.startTime) as firstStart
+        FROM Source s
+          JOIN Trial t ON s.id = t.sourceId
+          JOIN Experiment e ON e.id = t.expId
+          JOIN Project p ON p.id = e.projectId
+        WHERE p.name = $1 AND
+          s.branchOrTag = p.baseBranch AND
+          p.baseBranch IS NOT NULL
+        GROUP BY e.id, s.id
+        ORDER BY firstStart DESC
+        LIMIT 1`, [projectName]);
+
+    if (result.rowCount < 1) {
+      return undefined
+    } else {
+      return result.rows[0];
+    }
+  }
+
+  public async getSourceByNames(projectName: string, experimentName: string):
+    Promise<Source | undefined> {
+    const result = await this.client.query(`
+      SELECT DISTINCT s.*
+        FROM Source s
+          JOIN Trial t ON s.id = t.sourceId
+          JOIN Experiment e ON e.id = t.expId
+          JOIN Project p ON p.id = e.projectId
+        WHERE p.name = $1 AND e.name = $2`, [projectName, experimentName]);
+
+    if (result.rowCount < 1) {
+      return undefined;
+    } else {
+      return result.rows[0];
+    }
+  }
+
   public async recordExperiment(data: BenchmarkData): Promise<Experiment> {
     const cacheKey = `${data.projectName}::${data.experimentName}`;
 
@@ -474,6 +534,46 @@ export class Database {
       this.queries.fetchExpByProjectIdName, [project.id, data.experimentName],
       this.queries.insertExp,
       [data.experimentName, project.id, data.experimentDesc]);
+  }
+
+  public async getExperimentByNames(
+    projectName: string, experimentName: string):
+    Promise<Experiment | undefined> {
+    const cacheKey = `${projectName}::${experimentName}`;
+    if (this.exps.has(cacheKey)) {
+      return this.exps.get(cacheKey);
+    }
+
+    const result = await this.client.query(
+      this.queries.fetchExpByNames, [projectName, experimentName]);
+    if (result.rowCount < 1) {
+      return undefined;
+    }
+    return result.rows[0];
+  }
+
+  public async recordExperimentCompletion(expId: number, endTime: string):
+    Promise<void> {
+    await this.client.query(
+      this.queries.updateTrialEndTime, [expId, endTime]);
+  }
+
+  public async reportCompletion(data: BenchmarkCompletion):
+    Promise<Experiment> {
+    const exp = await this.getExperimentByNames(
+      data.projectName, data.experimentName);
+    if (exp === undefined) {
+      throw new Error(
+        `Could not record completion, no experiment found for ${
+        data.projectName} ${data.experimentName}`);
+    }
+
+    if (!data.endTime) {
+      throw new Error(`Could not record completion without endTime`);
+    }
+
+    await this.recordExperimentCompletion(exp.id, data.endTime);
+    return exp;
   }
 
   private async recordUnit(unitName: string) {

--- a/src/db/db.sql
+++ b/src/db/db.sql
@@ -70,7 +70,10 @@ CREATE TABLE Project (
   description text,
   logo varchar,
   showChanges bool DEFAULT true,
-  allResults bool DEFAULT false
+  allResults bool DEFAULT false,
+
+  -- the bases for comparisons that we generate when a experiment is completed
+  baseBranch varchar
 );
 
 -- Identifies the specific state of the source, the code, on which

--- a/src/db/migration.002.sql
+++ b/src/db/migration.002.sql
@@ -21,3 +21,6 @@ CREATE TABLE TimelineCalcJob (
 );
 
 ALTER SEQUENCE TimelineJobId OWNED BY TimelineCalcJob.timelineJobId;
+
+-- add the things needed for experiment comparisons
+ALTER TABLE Project ADD COLUMN baseBranch varchar;

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,77 @@
+import { Octokit } from '@octokit/rest';
+import { createAppAuth } from '@octokit/auth-app';
+
+export interface Repo {
+  owner: string;
+  repo: string;
+}
+
+export class GitHub {
+  private readonly globalApp: Octokit;
+  private readonly privateKey: string;
+  private readonly appId: number;
+
+  constructor(appId: number, privateKey: string) {
+    this.privateKey = privateKey;
+    this.appId = appId;
+
+    this.globalApp = new Octokit({
+      authStrategy: createAppAuth,
+      auth: {
+        type: 'app',
+        id: appId,
+        privateKey: privateKey
+      }
+    });
+  }
+
+  private async getRepoAuthorization(owner: string, repo: string):
+    Promise<Octokit> {
+    const install = await this.globalApp.apps.getRepoInstallation(
+      { owner, repo });
+
+    const repoAppInstall = new Octokit({
+      authStrategy: createAppAuth,
+      auth: {
+        type: 'install',
+        id: this.appId,
+        privateKey: this.privateKey,
+        installationId: install.data.id
+      }
+    });
+
+    return repoAppInstall;
+  }
+
+  public async postCommitComment(
+    owner: string, repo: string, commitSha: string, message: string):
+    Promise<boolean> {
+    const repoAppInstall = await this.getRepoAuthorization(owner, repo);
+
+    const result = await repoAppInstall.repos.createCommitComment({
+      owner: owner,
+      repo: repo,
+      commit_sha: commitSha,
+      body: message
+    });
+    return result.status === 201; // HTTP 201 Created
+  }
+
+  public getOwnerRepoFromUrl(url: string | undefined): Repo | null {
+    if (url === undefined) {
+      return null;
+    }
+
+    const githubRepoDetails =
+      /github\.com[:/]([A-Za-z0-9_.-]+)[/]([A-Za-z0-9_.-]+)/;
+    const match = url.match(githubRepoDetails);
+    if (!match) {
+      return null;
+    } else {
+      return {
+        owner: match[1],
+        repo: match[2]
+      }
+    }
+  }
+}

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,12 +1,13 @@
 import { readFileSync } from 'fs';
 import { render } from 'mustache';
+import { robustPath } from './util';
 
 const headerHtml = readFileSync(
-  `${__dirname}/../../src/views/header.html`).toString();
+  robustPath('views/header.html')).toString();
 
 export function processTemplate(filename: string, variables: any = {}): string {
   const fileContent = readFileSync(
-    `${__dirname}/../../src/views/${filename}`).toString();
+    robustPath(`views/${filename}`)).toString();
 
   variables.headerHtml = headerHtml;
   return render(fileContent, variables);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,20 @@
+export const robustPath = __dirname.includes('dist/')
+  ? function(path) { return `${__dirname}/../../src/${path}`; }
+  : function(path) { return `${__dirname}/${path}`; };
+
+export const dbConfig = {
+  user: process.env.RDB_USER || '',
+  password: process.env.RDB_PASS || '',
+  host: process.env.RDB_HOST || 'localhost',
+  database: process.env.RDB_DB || 'test_rdb4',
+  port: 5432
+};
+
+export const siteConfig = {
+  reportsUrl: process.env.REPORTS_URL || '/static/reports',
+  staticUrl: process.env.STATIC_URL || '/static',
+  publicUrl: process.env.PUBLIC_URL || 'https://rebench.stefan-marr.de',
+  appId: parseInt(process.env.GITHUB_APP_ID || '') || 76497,
+  githubPrivateKey:
+    process.env.GITHUB_PK || 'rebenchdb.2020-08-11.private-key.pem',
+}

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -94,7 +94,7 @@ describe('Test Dashboard with basic test data loaded', () => {
     expect(data[0].commitids).toEqual(
       '58666d1c84c652306f930daa72e7a47c58478e86');
     expect(data[0].expid).toEqual(1);
-    expect(data[0].name).toEqual("Small Test Case");
+    expect(data[0].name).toEqual('Small Test Case');
   });
 
   it('Should get benchmarks for project', async () => {
@@ -102,7 +102,7 @@ describe('Test Dashboard with basic test data loaded', () => {
     const data = (await dashBenchmarksForProject(db, 1)).benchmarks;
     expect(data).toHaveLength(1);
     expect(data[0].benchid).toEqual(1);
-    expect(data[0].benchmark).toEqual("NBody");
+    expect(data[0].benchmark).toEqual('NBody');
   });
 
   it('Should get stats for the timeline', async () => {
@@ -121,8 +121,8 @@ describe('Test Dashboard with basic test data loaded', () => {
 
     expect(details[0].trialid).toEqual(1);
     expect(details[0].id).toEqual(1);
-    expect(details[0].username).toEqual("smarr");
-    expect(details[0].expname).toEqual("Small Test Case");
+    expect(details[0].username).toEqual('smarr');
+    expect(details[0].expname).toEqual('Small Test Case');
   });
 
   // dashCompare

--- a/tests/db-setup.test.ts
+++ b/tests/db-setup.test.ts
@@ -162,11 +162,11 @@ describe('Recording a ReBench execution data fragments', () => {
 
     // add denoise details to test data
     e.denoise = {
-      "scaling_governor": "performance",
-      "no_turbo": true,
-      "perf_event_max_sample_rate": 1,
-      "can_set_nice": true,
-      "shielding": true
+      'scaling_governor': 'performance',
+      'no_turbo': true,
+      'perf_event_max_sample_rate': 1,
+      'can_set_nice': true,
+      'shielding': true
     };
 
     const env = await db.recordEnvironment(e);
@@ -176,7 +176,7 @@ describe('Recording a ReBench execution data fragments', () => {
     expect(e.userName).toEqual(result.username);
     expect(e.manualRun).toEqual(result.manualrun);
     expect(env.id).toEqual(result.envid);
-    expect(e.denoise.scaling_governor).toEqual("performance");
+    expect(e.denoise.scaling_governor).toEqual('performance');
     expect(e.denoise).toEqual(result.denoise);
   });
 
@@ -198,7 +198,6 @@ describe('Recording a ReBench execution data fragments', () => {
     expect(criterion.id).toBeGreaterThanOrEqual(0);
   });
 });
-
 
 describe('Recording a ReBench execution from payload files', () => {
   let db: TestDatabase;

--- a/tests/db-testing.ts
+++ b/tests/db-testing.ts
@@ -13,7 +13,7 @@ export class TestDatabase extends Database {
 
   public async prepareForTesting(): Promise<void> {
     if (this.preparedForTesting) {
-      throw new Error("This is only to be executed once");
+      throw new Error('This is only to be executed once');
     }
 
     if (this.usesTransactions) {
@@ -59,8 +59,6 @@ export class TestDatabase extends Database {
     }
   }
 }
-
-
 
 export async function createAndInitializeDB(testSuite: string,
   numReplicates = 1000, timelineEnabled = false,


### PR DESCRIPTION
Add support for projects to configure a baseBranch, which can be used to automatically determine comparisons.
Detailed discussion and design reasons are documented in #30.

Summary creation is triggered explicitly when an experiment is marked as completed.

The GitHub interaction relies on GitHub's rest.js.

Cleanups:
- make quote use more consistent
- extract robustPath helper
- add siteConfig and dbConfig in util.ts
- use a promise version of execFile
- for dashboard.test add second experiment be reusing adapted test data

Closing #30.