### PR TITLE
Fix the color in summary plots

### DIFF
--- a/src/views/plots.R
+++ b/src/views/plots.R
@@ -53,7 +53,7 @@ compare_runtime_ratio_of_suites_plot <- function (
     theme_simple(8) +
     scale_color_manual(values = scale_color) +
     scale_fill_manual(breaks=c("slower", "faster", "indeterminate"),
-                      values=c(fast_color, slow_color, NA)) +
+                      values=c(slow_color, fast_color, NA)) +
     theme(legend.position = "none")
 }
 


### PR DESCRIPTION
The fast/slower colors were switched on the summary plots, which is confusing.
Everything over 1 should be indicated with the slower color, and everything under one with the faster color.
1 refers here to the run-time ratio, where lower is better.