### PR TITLE
Don’t go to compare view when no revision was selected

### DIFF
--- a/resources/render.js
+++ b/resources/render.js
@@ -138,6 +138,10 @@ function openCompare(projectId, $) {
   const projectName = baseJQ.data('project');
   const baseline = baseJQ.find('.active').data('hash');
   const change = $(`#p${projectId}-change`).find('.active').data('hash');
+
+  if (baseline === undefined || change === undefined) {
+    return;
+  }
   window.location.href = `/compare/${projectName}/${baseline}/${change}`;
 }
 


### PR DESCRIPTION
A tiny change, just to not get into the situation mentioned in #10, i.e., looking at a compare view with `undefined` and `undefined` as revision.
