### PR TITLE
Fix GitHub authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -982,12 +982,22 @@
       "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
-      "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz",
+      "integrity": "sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==",
       "requires": {
-        "@octokit/types": "^6.13.0",
+        "@octokit/types": "^6.13.1",
         "deprecation": "^2.3.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.13.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.1.tgz",
+          "integrity": "sha512-UF/PL0y4SKGx/p1azFf7e6j9lB78tVwAFvnHtslzOJ6VipshYks74qm9jjTEDlCyaTmbhbk2h3Run5l0CtCF6A==",
+          "requires": {
+            "@octokit/openapi-types": "^6.0.0"
+          }
+        }
       }
     },
     "@octokit/request": {
@@ -1021,20 +1031,20 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.5.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz",
-      "integrity": "sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==",
+      "version": "18.5.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.3.tgz",
+      "integrity": "sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==",
       "requires": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "5.0.1"
       }
     },
     "@octokit/types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
-      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.1.tgz",
+      "integrity": "sha512-UF/PL0y4SKGx/p1azFf7e6j9lB78tVwAFvnHtslzOJ6VipshYks74qm9jjTEDlCyaTmbhbk2h3Run5l0CtCF6A==",
       "requires": {
         "@octokit/openapi-types": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "koa-body": "4.2.0",
     "koa-router": "10.0.0",
     "mustache": "4.2.0",
-    "@octokit/rest": "18.5.2",
+    "@octokit/rest": "18.5.3",
     "@octokit/auth-app": "3.3.0",
     "pg": "8.6.0",
     "promisify-child-process": "4.1.1"
   },
   "devDependencies": {
-    "@octokit/types": "6.13.0",
+    "@octokit/types": "6.13.1",
     "@types/jest": "26.0.22",
     "@types/koa": "2.13.1",
     "@types/koa-router": "7.4.2",

--- a/src/github.ts
+++ b/src/github.ts
@@ -19,7 +19,7 @@ export class GitHub {
       authStrategy: createAppAuth,
       auth: {
         type: 'app',
-        id: appId,
+        appId: appId,
         privateKey: privateKey
       }
     });
@@ -38,7 +38,7 @@ export class GitHub {
       authStrategy: createAppAuth,
       auth: {
         type: 'install',
-        id: this.appId,
+        appId: this.appId,
         privateKey: this.privateKey,
         installationId: install.data.id
       }


### PR DESCRIPTION
When updating the `@octokit/auth-app` package beyond v3.0.0, the `id` field in the auth details is not longer supported, but must be `appId`.