### PR TITLE
Fix the link pointing to full report that is posted to GitHub

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -546,7 +546,7 @@ export async function reportCompletion(
   );
 
   const reportUrl =
-    siteConfig.staticUrl +
+    siteConfig.publicUrl +
     `/compare/${data.projectName}/${baselineSha}/${changeSha}`;
 
   completionPromise


### PR DESCRIPTION
The link didn't contain the full URL.

This was broken when trying to fix linter issues. sigh