### PR TITLE
Move warmup plots into table with inline plots

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -117,9 +117,22 @@ table.benchmark-details .btn-sm {
   padding-right: 0.5ex;
 }
 
-.warmup-plot {
-  margin-top: 1ex;
-  margin-bottom: 1ex;
+td.warmup-plot {
+  padding-top: 1em;
+  padding-bottom: 2em;
+  text-align: center;
+  border-top: 0;
+}
+
+.btn-expand {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-left: auto;
+  content: "";
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23212529'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-size: 1.25rem;
 }
 
 .card-columns {

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ router.post(
 );
 
 if (DEV) {
-  router.get(`${siteConfig.staticUrl}/:filename`, async (ctx) => {
+  router.get(`${siteConfig.staticUrl}/:filename*`, async (ctx) => {
     console.log(`serve ${ctx.params.filename}`);
     // TODO: robustPath?
     ctx.body = readFileSync(
@@ -191,6 +191,8 @@ if (DEV) {
       ctx.type = 'css';
     } else if (ctx.params.filename.endsWith('.js')) {
       ctx.type = 'application/javascript';
+    } else if (ctx.params.filename.endsWith('.svg')) {
+      ctx.type = 'image/svg+xml';
     }
   });
 

--- a/src/views/compare.html
+++ b/src/views/compare.html
@@ -46,6 +46,14 @@
                             <path d="M6 9a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3A.5.5 0 0 1 6 9zM3.854 4.146a.5.5 0 1 0-.708.708L4.793 6.5 3.146 8.146a.5.5 0 1 0 .708.708l2-2a.5.5 0 0 0 0-.708l-2-2z"/>
                             <path d="M2 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2H2zm12 1a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1h12z"/>
                             </svg>`);
+
+      const expandButtons = $('.btn-expand');
+      expandButtons.click((e) => {
+        let url = $(e.target).data('img');
+        const insert = `<tr><td class="warmup-plot" colspan="6">
+            <img src="${url}"></td></tr>`;
+        $(e.target).parent().parent().after(insert);
+      });
     });
   </script>
 </head>

--- a/src/views/compare.html
+++ b/src/views/compare.html
@@ -32,6 +32,15 @@
       });
     }
 
+    function insertWarmupPlot(button) {
+      const jqButton = $(button);
+      let url = jqButton.data('img');
+      const insert = `<tr><td class="warmup-plot" colspan="6">
+          <img src="${url}"></td></tr>`;
+      jqButton.parent().parent().after(insert);
+      jqButton.remove();
+    }
+
     $(document).ready(() => {
       $('#significance')
         .on('input', determineAndDisplaySignificance);
@@ -48,12 +57,16 @@
                             </svg>`);
 
       const expandButtons = $('.btn-expand');
-      expandButtons.click((e) => {
-        let url = $(e.target).data('img');
-        const insert = `<tr><td class="warmup-plot" colspan="6">
-            <img src="${url}"></td></tr>`;
-        $(e.target).parent().parent().after(insert);
-      });
+      expandButtons.click((e) => insertWarmupPlot(e.target));
+
+      const headlinesForTablesWithWarmupPlots = $("table:has(button.btn-expand)").prev().prev();
+      headlinesForTablesWithWarmupPlots.append(
+        `<button type="button" class="btn btn-sm btn-light btn-expand"></button>`);
+      const buttons = headlinesForTablesWithWarmupPlots.find('.btn-expand');
+      buttons.click((e) => {
+        const expandButtons = $(e.target).parent().next().next().find('.btn-expand');
+        expandButtons.each((i, elm) => insertWarmupPlot(elm));
+      })
     });
   </script>
 </head>

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -47,7 +47,7 @@ extra_cmd      <- args[[11]]
 
 # Load Libraries
 source(paste0(lib_dir, "/common.R"), chdir=TRUE)
-library(dplyr)
+suppressMessages(library(dplyr))
 library(stringr)
 options(warn=1)
 


### PR DESCRIPTION
This moves the warmup tables where we need them to assess the results of a particular benchmark.
Having them in a separate section at the end of the report was mostly because of KnitR restrictions.
Since we aren't using KnitR any longer, having them inline seems better.

Initially, the warmup plots won't be shown.
Instead, there are buttons to expand the whole section, or the specific plot.