### PR TITLE
Add Comparisons between Executors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tmp/interm
 /resources/exp-data
 /src/views/somns.html
 /src/views/test.html
+test.figures
+test.html

--- a/resources/style.css
+++ b/resources/style.css
@@ -2,8 +2,42 @@ body {
   max-width: 800px;
   margin: 0 auto;
 }
+
 body.compare {
+  max-width: initial;
+  padding-left: 10%;
+}
+
+.compare {
   max-width: 900px;
+}
+
+.compare nav a {
+  display: block;
+}
+
+.compare nav span {
+  margin-left: -10px;
+}
+
+nav.compare {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 4rem;
+  height: calc(100vh - 4rem);
+  overflow-y: auto;
+  border-left: 1px solid #eee;
+  font-size: .875rem;
+  order: 2;
+}
+
+.compare main {
+  order: 1;
+}
+
+.compare nav {
+  padding-left: 20px;
+  padding-bottom: 10px;
 }
 
 .card {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -152,6 +152,7 @@ export function startReportGeneration(
     getOutputImageFolder(outputFile),
     // R ReBenchDB library directory
     robustPath(`views/`),
+    siteConfig.reportsUrl,
     base,
     change,
     dbConfig.database,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -154,8 +154,6 @@ export function startReportGeneration(
     robustPath(`views/`),
     base,
     change,
-    '#729fcf',
-    '#e9b96e',
     dbConfig.database,
     dbConfig.user,
     dbConfig.password,

--- a/src/views/common.R
+++ b/src/views/common.R
@@ -22,6 +22,33 @@ timing.stop <- function() {
   res
 }
 
+## Utility Functions
+
+common_string_start <- function(x) {
+  x <- sort(x)
+  n <- min(nchar(x))
+  x <- sapply(x, function(s) {
+    substr(s, 1, n)
+  })
+  x <- unique(x)
+  
+  # split the first and last element by character
+  d_x <- strsplit(x[c(1, length(x))], "")
+  # search for the first not common element and so, get the last matching one
+  der_com <- match(FALSE, do.call("==", d_x)) - 1
+  # if there is no matching element, return an empty vector, else return the common part
+  # if (der_com == 0) {
+  #   character(0)
+  # } else {
+  #   substr(x[1], 1, der_com)
+  # }
+  if (is.na(der_com)) {
+    n + 1
+  } else {
+    der_com  
+  }
+}
+
 
 ## Output Formatting
 

--- a/src/views/common.R
+++ b/src/views/common.R
@@ -27,14 +27,16 @@ timing.stop <- function() {
 
 r2 <- function(val) {
   if (is.na(val)) {
-    return("")
+    ""
+  } else {
+    format(round(val, 2), digits = 2, nsmall = 2)
   }
-  return(round(val, 2))
 }
 
 pro <- function(val) {
   if (is.na(val)) {
-    return("")
+    ""
+  } else {
+    as.character(round(val * 100))  
   }
-  return(round(val * 100))
 }

--- a/src/views/common.R
+++ b/src/views/common.R
@@ -8,41 +8,8 @@ source("stats.R", chdir = TRUE)
 # avoid scientific notation for numbers, it's more readable to me
 options(scipen=999)
 
-# prints stack trace on error, from: http://stackoverflow.com/a/2000757/916546
-options(warn = 2, keep.source = TRUE, error =
-          quote({
-            cat("Environment:\n", file=stderr());
-
-            # TODO: setup option for dumping to a file (?)
-            # Set `to.file` argument to write this to a file for post-mortem debugging
-            dump.frames();  # writes to last.dump
-
-            #
-            # Debugging in R
-            #   http://www.stats.uwo.ca/faculty/murdoch/software/debuggingR/index.shtml
-            #
-            # Post-mortem debugging
-            #   http://www.stats.uwo.ca/faculty/murdoch/software/debuggingR/pmd.shtml
-            #
-            # Relation functions:
-            #   dump.frames
-            #   recover
-            # >>limitedLabels  (formatting of the dump with source/line numbers)
-            #   sys.frame (and associated)
-            #   traceback
-            #   geterrmessage
-            #
-            # Output based on the debugger function definition.
-
-            n <- length(last.dump)
-            calls <- names(last.dump)
-            cat(paste("  ", 1L:n, ": ", calls, sep = ""), sep = "\n", file=stderr())
-            cat("\n", file=stderr())
-
-            if (!interactive()) {
-              q(status=1) # indicate error
-            }
-          }))
+# prints stack trace on error, using rlang (tidyverse) backtraces
+options(warn = 2, keep.source = TRUE, error = quote(rlang:::entrace()))
 
 timing_data <- NULL
 timing.start <- function() {

--- a/src/views/compare.html
+++ b/src/views/compare.html
@@ -9,7 +9,6 @@
   <meta http-equiv="refresh" content="30" />
   {{/generatingReport}}
 
-  <base href="/static/reports/">
   <script>
     //@ts-check
 

--- a/src/views/compare.html
+++ b/src/views/compare.html
@@ -74,7 +74,8 @@
 </head>
 <body class="compare">
 
-<div class="jumbotron">
+<header>
+<div class="jumbotron compare">
   <h2>ReBenchDB for {{project}}</h2>
   {{#revDetails}}
   <h3>Comparing <a href="{{base.repourl}}/compare/{{baselineHash}}...{{changeHash}}">{{baselineHash6}} with {{changeHash6}}</a></h3>
@@ -84,7 +85,24 @@
   {{/revDetails}}
 </div>
 
-<div id="version-details">
+<div class="refresh">
+  <div class="flex-nowrap">
+    <button id="show-refresh-form" type="button" class="btn btn-outline-secondary btn-sm">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-repeat" viewBox="0 0 16 16">
+        <path d="M11.534 7h3.932a.25.25 0 0 1 .192.41l-1.966 2.36a.25.25 0 0 1-.384 0l-1.966-2.36a.25.25 0 0 1 .192-.41zm-11 2h3.932a.25.25 0 0 0 .192-.41L2.692 6.23a.25.25 0 0 0-.384 0L.342 8.59A.25.25 0 0 0 .534 9z"/>
+        <path fill-rule="evenodd" d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5.002 5.002 0 0 0 8 3zM3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9H3.1z"/>
+      </svg>
+    </button>
+    <form method="post" action="/admin/refresh/{{project}}/{{baselineHash}}/{{changeHash}}" class="input-group-sm">
+      <input type="password" class="form-control" name="password"
+        placeholder="Password" aria-label="Password">
+    </form>
+  </div>
+</div>
+</header>
+
+
+<div id="version-details" class="compare">
   <h2>Version Details</h2>
   <dl class="row">
     <dt class="col-sm-2">Baseline</dt>
@@ -109,28 +127,13 @@
         <input type="text" readonly class="col-4 form-control-plaintext" id="significance-val" value="5%">
       </div></dd>
   </dl>
-
 </div>
 
-<div class="refresh">
-  <div class="flex-nowrap">
-    <button id="show-refresh-form" type="button" class="btn btn-outline-secondary btn-sm">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-repeat" viewBox="0 0 16 16">
-        <path d="M11.534 7h3.932a.25.25 0 0 1 .192.41l-1.966 2.36a.25.25 0 0 1-.384 0l-1.966-2.36a.25.25 0 0 1 .192-.41zm-11 2h3.932a.25.25 0 0 0 .192-.41L2.692 6.23a.25.25 0 0 0-.384 0L.342 8.59A.25.25 0 0 0 .534 9z"/>
-        <path fill-rule="evenodd" d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5.002 5.002 0 0 0 8 3zM3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9H3.1z"/>
-      </svg>
-    </button>
-    <form method="post" action="/admin/refresh/{{project}}/{{baselineHash}}/{{changeHash}}" class="input-group-sm">
-      <input type="password" class="form-control" name="password"
-        placeholder="Password" aria-label="Password">
-    </form>
-  </div>
-</div>
 
 {{{report}}}
 
 {{#generatingReport}}
-<div class="alert alert-secondary" role="alert">
+<div class="alert alert-secondary compare" role="alert">
   <h4 class="alert-heading">Report is currently being generated</h4>
   <p>Please wait, the requested report is currently still generated.</p>
   <p>Last page reload was at {{currentTime}}</p>
@@ -145,7 +148,7 @@
 {{/generatingReport}}
 
 {{#generationFailed}}
-<div class="alert alert-warning" role="alert">
+<div class="alert alert-warning compare" role="alert">
   <h4 class="alert-heading">Report generation failed</h4>
   <hr>
   <h6>Standard Out</h6>

--- a/src/views/compare.html
+++ b/src/views/compare.html
@@ -22,12 +22,14 @@
       $('#significance-val').val(`${sig}%`);
       $(".stats-change").each((i, e) => {
         const change = parseFloat(e.textContent);
+        const parent = $(e).parent();
+        const target = (parent.find(".stats-change").length > 1) ? $(e) : parent;
         if (change < (-sig)) {
-          $(e).parent().css('background-color', '#e4ffc7');
+          target.css('background-color', '#e4ffc7');
         } else if (change > sig) {
-          $(e).parent().css('background-color', '#ffcccc');
+          target.css('background-color', '#ffcccc');
         } else {
-          $(e).parent().css('background-color', '');
+          target.css('background-color', '');
         }
       });
     }

--- a/src/views/plots.R
+++ b/src/views/plots.R
@@ -1,10 +1,11 @@
 # Plots
 library(ggplot2)
 
-warmup_plot <- function (data_b, b, s, e) {
+warmup_plot <- function (data_b, group) {
+  group_col <- enquo(group)
   ## First take the medians over the values for each commitid separately
   medians <- data_b %>%
-    group_by(commitid) %>%
+    group_by(!!group_col) %>%
     summarise(median = median(value),
     .groups = "drop")
 
@@ -12,7 +13,7 @@ warmup_plot <- function (data_b, b, s, e) {
   upperBound <- 2 * max(medians$median)
 
   plot <- ggplot(data_b, aes(x=iteration, y=value)) +
-    geom_line(aes(colour = commitid)) +
+    geom_line(aes(colour = !!group_col)) +
     scale_color_manual(values = color) +
     # ggtitle(paste(b, s, e)) +
     ylab(levels(data_b$unit)) +
@@ -56,22 +57,27 @@ compare_runtime_ratio_of_suites_plot <- function (
     theme(legend.position = "none")
 }
 
-small_inline_comparison <- function (data) {
+small_inline_comparison <- function (data, group) {
+  group_col <- enquo(group)
   # small_inline_comparison(data_b)
   # data <- data_b
-  ggplot(data, aes(x = ratio_median, y = commitid)) +
+  group_size <- (data %>% select(!!group_col) %>% unique() %>% count())$n
+  all_colors <- c(baseline_color, change_color, "#8ae234", "#ad7fa8", "#fcaf3e", "#ef2929")[1:group_size]
+  lighter_colors <- c("#97c4f0", "#efd0a7", "#b7f774", "#e0c0e4", "#ffd797", "#f78787")[1:group_size]
+  
+  ggplot(data, aes(x = ratio_median, y = !!group_col)) +
         geom_vline(aes(xintercept=1), colour="#333333", linetype="solid") +
-        geom_boxplot(aes(colour = commitid),
+        geom_boxplot(aes(colour = !!group_col),
                           outlier.size = 0.9,
                           outlier.alpha = 0.6,
                           lwd=0.2) +
-        geom_jitter(aes(colour = commitid, y = commitid), size=0.3, alpha=0.3) +
+        geom_jitter(aes(colour = !!group_col, y = !!group_col), size=0.3, alpha=0.3) +
         scale_x_log10() +
         coord_cartesian(xlim=c(0.5, 5)) +
         theme_simple(5) +
         ylab("") +
-        scale_color_manual(values = color) +
-        scale_fill_manual(values = color) +
+        scale_color_manual(values = all_colors) +
+        scale_fill_manual(values = lighter_colors) +
         theme(legend.position = "none",
               axis.ticks.y=element_blank(),
               axis.text.y=element_blank(),

--- a/src/views/plots.R
+++ b/src/views/plots.R
@@ -1,8 +1,10 @@
 # Plots
 library(ggplot2)
 
-warmup_plot <- function (data_b, group) {
+warmup_plot <- function (data_b, group, group_size) {
   group_col <- enquo(group)
+  all_colors <- c(baseline_color, change_color, "#8ae234", "#ad7fa8", "#fcaf3e", "#ef2929")[1:group_size]
+  
   ## First take the medians over the values for each commitid separately
   medians <- data_b %>%
     group_by(!!group_col) %>%
@@ -10,20 +12,20 @@ warmup_plot <- function (data_b, group) {
     .groups = "drop")
 
   # use the highest one with a little margin as an upper bound
-  upperBound <- 2 * max(medians$median)
+  upper_bound <- 2 * max(medians$median)
 
   plot <- ggplot(data_b, aes(x=iteration, y=value)) +
     geom_line(aes(colour = !!group_col)) +
-    scale_color_manual(values = color) +
+    scale_color_manual(values = all_colors) +
     # ggtitle(paste(b, s, e)) +
     ylab(levels(data_b$unit)) +
     # scale_x_continuous(breaks = seq(0, max(data_b$iteration), 10)) +
-    coord_cartesian(ylim=c(0, upperBound)) +
+    coord_cartesian(ylim=c(0, upper_bound)) +
     geom_vline(
       xintercept = seq(0, max(data_b$iteration), 50),
       linetype = "longdash", colour = "#cccccc") +
     theme_simple(8) +
-    theme(legend.position=c(0.92, .92))
+    theme(legend.position=c(0.85, .92))
   plot
 }
 

--- a/src/views/plots.R
+++ b/src/views/plots.R
@@ -1,9 +1,8 @@
 # Plots
 library(ggplot2)
 
-warmup_plot <- function (data_b, group, group_size) {
+warmup_plot <- function (data_b, group, colors) {
   group_col <- enquo(group)
-  all_colors <- c(baseline_color, change_color, "#8ae234", "#ad7fa8", "#fcaf3e", "#ef2929")[1:group_size]
   
   ## First take the medians over the values for each commitid separately
   medians <- data_b %>%
@@ -16,7 +15,7 @@ warmup_plot <- function (data_b, group, group_size) {
 
   plot <- ggplot(data_b, aes(x=iteration, y=value)) +
     geom_line(aes(colour = !!group_col)) +
-    scale_color_manual(values = all_colors) +
+    scale_color_manual(values = colors) +
     # ggtitle(paste(b, s, e)) +
     ylab(levels(data_b$unit)) +
     # scale_x_continuous(breaks = seq(0, max(data_b$iteration), 10)) +
@@ -64,13 +63,10 @@ compare_runtime_ratio_of_suites_plot <- function (
   p
 }
 
-small_inline_comparison <- function (data, group, group_size) {
+small_inline_comparison <- function (data, group, colors, colors_light) {
   group_col <- enquo(group)
   # small_inline_comparison(data_b)
   # data <- data_b
-  all_colors <- c(baseline_color, change_color, "#8ae234", "#ad7fa8", "#fcaf3e", "#ef2929")[1:group_size]
-  lighter_colors <- c("#97c4f0", "#efd0a7", "#b7f774", "#e0c0e4", "#ffd797", "#f78787")[1:group_size]
-  
   p <- ggplot(data, aes(x = ratio_median, y = !!group_col, fill = !!group_col)) +
         geom_vline(aes(xintercept=1), colour="#333333", linetype="solid") +
         geom_boxplot(aes(colour = !!group_col),
@@ -87,8 +83,8 @@ small_inline_comparison <- function (data, group, group_size) {
   p <- p + theme_simple(5) +
         ylab("") +
         scale_y_discrete(limits = rev) +
-        scale_color_manual(values = all_colors) +
-        scale_fill_manual(values = lighter_colors) +
+        scale_color_manual(values = colors) +
+        scale_fill_manual(values = colors_light) +
         theme(legend.position = "none",
               axis.ticks.y=element_blank(),
               axis.text.y=element_blank(),

--- a/src/views/plots.R
+++ b/src/views/plots.R
@@ -40,7 +40,7 @@ negative_geometric.mean <- function(d) {
 
 compare_runtime_ratio_of_suites_plot <- function (
     data, slower_runtime_ratio, faster_runtime_ratio, fast_color, slow_color, scale_color) {
-  ggplot(data, aes(ratio, suite, fill=slower)) +
+  p <- ggplot(data, aes(ratio, suite, fill=slower)) +
     geom_vline(aes(xintercept=1), colour="#999999", linetype="solid") +
     geom_vline(aes(xintercept=slower_runtime_ratio), colour="#cccccc", linetype="dashed") +
     geom_vline(aes(xintercept=faster_runtime_ratio), colour="#cccccc", linetype="dashed") +
@@ -50,34 +50,43 @@ compare_runtime_ratio_of_suites_plot <- function (
     stat_summary(fun = negative_geometric.mean,
                   size = 1, colour = "#503000", geom = "point") +
     scale_x_log10() +
-    ylab("") +
-    coord_cartesian(xlim=c(0.5, 2.5)) +
-    theme_simple(8) +
+    ylab("")
+  
+  if (min(data$ratio) > 0.5 & max(data$ratio) < 2.5) {
+    p <- p + coord_cartesian(xlim=c(0.5, 2.5))
+  }
+  
+  p <- p + theme_simple(8) +
     scale_color_manual(values = scale_color) +
     scale_fill_manual(breaks=c("slower", "faster", "indeterminate"),
                       values=c(slow_color, fast_color, NA)) +
     theme(legend.position = "none")
+  p
 }
 
-small_inline_comparison <- function (data, group) {
+small_inline_comparison <- function (data, group, group_size) {
   group_col <- enquo(group)
   # small_inline_comparison(data_b)
   # data <- data_b
-  group_size <- (data %>% select(!!group_col) %>% unique() %>% count())$n
   all_colors <- c(baseline_color, change_color, "#8ae234", "#ad7fa8", "#fcaf3e", "#ef2929")[1:group_size]
   lighter_colors <- c("#97c4f0", "#efd0a7", "#b7f774", "#e0c0e4", "#ffd797", "#f78787")[1:group_size]
   
-  ggplot(data, aes(x = ratio_median, y = !!group_col)) +
+  p <- ggplot(data, aes(x = ratio_median, y = !!group_col, fill = !!group_col)) +
         geom_vline(aes(xintercept=1), colour="#333333", linetype="solid") +
         geom_boxplot(aes(colour = !!group_col),
                           outlier.size = 0.9,
                           outlier.alpha = 0.6,
                           lwd=0.2) +
         geom_jitter(aes(colour = !!group_col, y = !!group_col), size=0.3, alpha=0.3) +
-        scale_x_log10() +
-        coord_cartesian(xlim=c(0.5, 5)) +
-        theme_simple(5) +
+        scale_x_log10()
+  
+  if (min(data$ratio_median) > 0.5 & max(data$ratio_median) < 5) {
+    p <- p + coord_cartesian(xlim=c(0.5, 5))
+  }
+  
+  p <- p + theme_simple(5) +
         ylab("") +
+        scale_y_discrete(limits = rev) +
         scale_color_manual(values = all_colors) +
         scale_fill_manual(values = lighter_colors) +
         theme(legend.position = "none",
@@ -87,6 +96,7 @@ small_inline_comparison <- function (data, group) {
               axis.text.x = element_text(margin = margin(t = 0.1, unit = "cm")),
               axis.line.y.left=element_blank(),
               axis.line.x.bottom=element_blank())
+  p
 }
 
 ##

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -267,151 +267,252 @@ if (nrow(not_in_both) > 0) {
 out("<h2>Benchmark Performance</h2>")
 
 
-
-perf_diff_table <- function(norm, stats) {
-# e <- "TruffleSOM-graal-bc"
-
-row_count <- 0
+perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, group) {
+  group_col <- enquo(group)
+  row_count <- start_row_count
   
-for (e in levels(norm$exe)) {         data_e <- norm   %>% filter(exe == e)   %>% droplevels()
-  for (s in levels(data_e$suite)) {   data_s <- data_e %>% filter(suite == s) %>% droplevels()
-    out("<h3>", s, "</h3>")
-    out('<div class="title-executor">Executor: ', e, "</div>")
-
-    out('<table class="table table-sm benchmark-details">')
-    out('<thead><tr>
+  out('<table class="table table-sm benchmark-details">')
+  out('<thead><tr>
 <th scope="col"></th>
 <th scope="col"></th>
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median in ', levels(data_s$unit), '</th>
+<th scope="col">median in ', levels(data_es$unit), '</th>
 <th scope="col">change in %</th>
 <th scope="col"></th>
 </tr></thead>')
-
-    for (b in levels(data_s$bench)) { data_b <- data_s %>% filter(bench == b) %>% droplevels()
-      for (v in levels(data_b$varvalue)) {   data_v  <- data_b %>% filter(varvalue == v)   %>% droplevels()
-      for (c in levels(data_v$cores)) {      data_c  <- data_v %>% filter(cores == c)      %>% droplevels()
-      for (i in levels(data_c$inputsize)) {  data_i  <- data_c %>% filter(inputsize == i)  %>% droplevels()
-      for (ea in levels(data_i$extraargs)) { data_ea <- data_i %>% filter(extraargs == ea) %>% droplevels()
-
-        args <- ""
-        if (length(levels(data_b$varvalue))  > 1) { args <- paste0(args, v) }
-        if (length(levels(data_v$cores))     > 1) { args <- paste0(args, c) }
-        if (length(levels(data_c$inputsize)) > 1) { args <- paste0(args, i) }
-        if (length(levels(data_i$extraargs)) > 1) { args <- paste0(args, ea) }
-        if (nchar(args) > 0) {
-          args <- paste0('<span class="all-args">', args, '</span>')
-        }
-
-        # capture the beginning of the path but leave the last element of it
-        # this regex is also used in render.js's renderBenchmark() function
-        cmdline <- str_replace_all(data_i$cmdline[[1]], "^([^\\s]*)((?:\\/\\w+)\\s.*$)", ".\\2")
-
-        stats_b <- stats %>%
-          ungroup() %>%
-          filter(bench == b, suite == s, exe == e, varvalue == v, cores == c, inputsize == i, extraargs == ea, commitid == change_hash6) %>%
-          droplevels()
-
-        if (nrow(stats_b) > 0) {
-          out('<tr>')
-          out('<th scope="row">',  b, args, '</th>')
-          out('<td>')
-          p <- small_inline_comparison(data_ea)
-          img_file <- paste0('inline-', row_count, '.svg')
-          ggsave(img_file, p, "svg", output_dir, width = 3.5, height = 0.4, units = "in")
-          out('<img src="', output_dir, '/', img_file, '">')
-          
-          row_count <- row_count + 1
-          out('</td>\n')
-
-          out('<td class="stats-samples">', stats_b$samples, '</td>\n')
-          out('<td><span class="stats-median" title="median">', r2(stats_b$median), '</span></td>\n')
-          out('<td><span class="stats-change" title="change over median">', pro(stats_b$change_m), '</span></td>\n')
-          out('<td><button type="button" class="btn btn-sm" data-toggle="popover" data-content="<code>', cmdline, '</code>"></button>\n')
-          
-          warmup_ea <- warmup %>%
-            filter(exe == e, suite == s, bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea) %>%
-            droplevels()
-          
-          if (nrow(warmup_ea) > 0) {
-            img_file <- paste0('warmup-', row_count, '.svg')
-            p <- warmup_plot(warmup_ea, b, s, e)
-            ggsave(img_file, p, "svg", output_dir, width = 6, height = 2.5, units = "in")
-            out('<button type="button" class="btn btn-sm btn-light btn-expand" data-img="', output_dir, '/', img_file, '"></button>\n')
-          }
-          
-          out('</td>');
-          out('</tr>\n')
-        } else {
-          out('<tr>')
-          out('<th scope="row">',  b, '</th><td colspan="4">missing in one of the data sets</td>\n')
-          out('</tr>')
-        }
-      } } } }
+  
+  # b <- "DeltaBlue"
+  # data_ea <- data_b
+  
+  for (b in levels(data_es$bench)) { data_b <- data_es %>% filter(bench == b) %>% droplevels()
+    for (v in levels(data_b$varvalue)) {   data_v  <- data_b %>% filter(varvalue == v)   %>% droplevels()
+    for (c in levels(data_v$cores)) {      data_c  <- data_v %>% filter(cores == c)      %>% droplevels()
+    for (i in levels(data_c$inputsize)) {  data_i  <- data_c %>% filter(inputsize == i)  %>% droplevels()
+    for (ea in levels(data_i$extraargs)) { data_ea <- data_i %>% filter(extraargs == ea) %>% droplevels()
+    
+    args <- ""
+    if (length(levels(data_b$varvalue))  > 1) { args <- paste0(args, v) }
+    if (length(levels(data_v$cores))     > 1) { args <- paste0(args, c) }
+    if (length(levels(data_c$inputsize)) > 1) { args <- paste0(args, i) }
+    if (length(levels(data_i$extraargs)) > 1) { args <- paste0(args, ea) }
+    if (nchar(args) > 0) {
+      args <- paste0('<span class="all-args">', args, '</span>')
     }
-
-    out('</table>')
+    
+    # capture the beginning of the path but leave the last element of it
+    # this regex is also used in render.js's renderBenchmark() function
+    cmdline <- str_replace_all(data_i$cmdline[[1]], "^([^\\s]*)((?:\\/\\w+)\\s.*$)", ".\\2")
+    
+    stats_b <- stats_es %>%
+      ungroup() %>%
+      filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea) %>%
+      droplevels()
+    
+    if ("commitid" %in% colnames(stats_b)) {
+      stats_b <- stats_b %>%
+        filter(commitid == change_hash6) %>%
+        droplevels()
+    }
+    
+    if (nrow(stats_b) > 0) {
+      out('<tr>')
+      out('<th scope="row">',  b, args, '</th>')
+      out('<td>')
+      p <- small_inline_comparison(data_ea, !!group_col)
+      img_file <- paste0('inline-', row_count, '.svg')
+      ggsave(img_file, p, "svg", output_dir, width = 3.5, height = 0.4, units = "in")
+      out('<img src="', output_dir, '/', img_file, '">')
+      
+      row_count <- row_count + 1
+      out('</td>\n')
+      
+      if (nrow(stats_b) == 1) {
+        out('<td class="stats-samples">', stats_b$samples, '</td>\n')
+        out('<td><span class="stats-median" title="median">', r2(stats_b$median), '</span></td>\n')
+        out('<td><span class="stats-change" title="change over median">', pro(stats_b$change_m), '</span></td>\n')
+        out('<td><button type="button" class="btn btn-sm" data-toggle="popover" data-content="<code>', cmdline, '</code>"></button>\n')
+      } else {
+        # TODO find a nice way of showing the stats for the comparison between exes, which requires more space (perhaps rows)
+        out('<td></td>',
+            '<td></td>',
+            '<td></td>',
+            '<td></td>')
+      }
+      
+      warmup_ea <- warmup_es %>%
+        filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea) %>%
+        droplevels()
+      
+      if (nrow(warmup_ea) > 0) {
+        img_file <- paste0('warmup-', row_count, '.svg')
+        p <- warmup_plot(warmup_ea, !!group_col)
+        ggsave(img_file, p, "svg", output_dir, width = 6, height = 2.5, units = "in")
+        out('<button type="button" class="btn btn-sm btn-light btn-expand" data-img="', output_dir, '/', img_file, '"></button>\n')
+      }
+      
+      out('</td>');
+      out('</tr>\n')
+    } else {
+      out('<tr>')
+      out('<th scope="row">',  b, '</th><td colspan="4">missing in one of the data sets</td>\n')
+      out('</tr>')
+    }
+    } } } }
   }
-}
-}
-
-perf_diff_table(norm, stats)
-
-
-execs <- levels(peak$exe)
-exec_name <- str_replace_all(execs, c("-jit" = "", "-interp" = ""))
-exec_name <- union(exec_name, exec_name)
-
-exe_type <- function(data) {
-  # print(data)
-  ifelse(grepl("-jit", data), "jit", ifelse(grepl("-interp", data), "interp", "other"))
+  
+  out('</table>')
+  row_count
 }
 
-# The cross comparison is designed for setups where there are two clearly
-# different sets of experiments. The current heuristic assumes that
-# interpreter (-interp) and jit-compiling (-jit) VMs are among the executors,
-# which without these name parts, form a set of two distinct names.
-if (length(exec_name) == 2) {
-  out("<h2>Cross Comparison</h2>\n")
+perf_diff_table <- function(norm, stats, start_row_count) {
+  # e <- "TruffleSOM-graal-bc"
+  
+  row_count <- start_row_count
+    
+  for (e in levels(norm$exe)) {         data_e <- norm   %>% filter(exe == e)   %>% droplevels()
+    for (s in levels(data_e$suite)) {   data_s <- data_e %>% filter(suite == s) %>% droplevels()
+      # e <- "TruffleSOM-graal"
+      # s <- "macro-steady"
+      out("<h3>", s, "</h3>")
+      out('<div class="title-executor">Executor: ', e, "</div>")
+      
+      stats_es <- stats %>%
+        ungroup() %>%
+        filter(exe == e, suite == s) %>%
+        droplevels()
+      
+      warmup_es <- warmup %>%
+        ungroup() %>%
+        filter(exe == e, suite == s) %>%
+        droplevels()
+      
+      row_count <- perf_diff_table_es(data_s, stats_es, warmup_es, row_count, commitid)
+    }
+  }
+  row_count
+}
 
-  base_exe <- exec_name[[1]]
-  out("<p>Baseline: ", base_exe, "</p>")
+row_count <- perf_diff_table(norm, stats, 0)
 
-  peak_comp <- peak %>%
-    transform(exe_type = exe_type(exe))
-  peak_comp$exe_type <- factor(peak_comp$exe_type)
 
-  base_comp <- peak_comp %>%
-    filter(commitid == change_hash6, grepl(base_exe, exe)) %>%
-    group_by(exe_type, suite, bench,
-             varvalue, cores, inputsize, extraargs,
-             commitid) %>%
-    summarise(base_mean = mean(value),
-              base_median = median(value),
-              .groups = "drop")
+# Identify possible comparison on the data of the change.
+# Within the change data, there may be different executors, which are worth
+# comparing.
 
-  norm_comp <- peak_comp %>%
-    filter(commitid == change_hash6) %>%
-    left_join(base_comp,
-              by = c("exe_type", "suite", "bench",
-                     "varvalue", "cores", "inputsize", "extraargs",
-                     "commitid")) %>%
-    group_by(exe_type, suite, bench,
-             varvalue, cores, inputsize, extraargs,
-             commitid) %>%
-    transform(ratio_mean = value / base_mean,
-              ratio_median = value / base_median)
+restrict_to_change_data <- function(data) {
+  data %>%
+    ungroup() %>%
+    filter(commitid == change_hash) %>%
+    select(!commitid) %>%
+    droplevels()
+}
 
-  stats_comp <- norm_comp %>%
-    group_by(commitid, exe, suite, bench,
-             varvalue, cores, inputsize, extraargs) %>%
-    filter(is.na(warmup) | iteration >= warmup) %>%
-    calculate_stats() %>%
-      ## Drop the things that don't have matching results
+change_data <- result %>%
+  restrict_to_change_data()
+
+# select(!c(unit, criterion, inputsize, cores,
+#           varvalue, trialid, commitid, expid,
+#           iteration, warmup, invocation, extraargs, cmdline,
+#           suite)) %>%
+
+exes_and_suites <- change_data %>%
+  select(c(exe, suite)) %>%
+  unique()
+
+suites_for_comparison <- exes_and_suites %>%
+  group_by(suite) %>%
+  count() %>%
+  filter(n > 1) %>%
+  droplevels()
+
+
+if (nrow(suites_for_comparison) > 0) {
+  out('<h2 id="exe-comparisons">Executor Comparisons</h2>\n')
+  
+  for (s in suites_for_comparison$suite) {
+    # s <- "macro-startup"
+    out('<h3 id="exe-comp-', s ,'">', s ,'</h3>\n')
+
+    change_s <- change_data %>%
+      filter(suite == s) %>%
+      droplevels()
+    exes <- sort(levels(change_s$exe))
+    baseline_exe <- exes[[1]]
+    
+    out("<p>Baseline: ", baseline_exe, "</p>")
+    
+    
+    warmup_s <- warmup %>%
+      restrict_to_change_data() %>%
+      filter(suite == s) %>%
+      droplevels()
+    
+    peak_s <- peak %>%
+      restrict_to_change_data() %>%
+      filter(suite == s) %>%
+      droplevels()
+    
+    base_s <- peak_s %>%
+      filter(exe == baseline_exe) %>%
+      group_by(bench,
+               varvalue, cores, inputsize, extraargs) %>%
+      summarise(base_mean = mean(value),
+                base_median = median(value),
+                .groups = "drop")
+    
+    norm_s <- peak_s %>%
+      left_join(base_s, by = c(
+        "bench", "varvalue", "cores", "inputsize", "extraargs")) %>%
+      group_by(bench, varvalue, cores, inputsize, extraargs) %>%
+      transform(ratio_mean = value / base_mean,
+                ratio_median = value / base_median)
+    
+    
+    stats_s <- norm_s %>%
+      group_by(exe, bench,
+               varvalue, cores, inputsize, extraargs) %>%
+      filter(is.na(warmup) | iteration >= warmup) %>%
+      calculate_stats()
+    
+    not_in_both_s <- stats_s %>%
+      filter(is.na(ratio)) %>%
+      droplevels()
+    
+    stats_s <- stats_s %>%
       filter(!is.na(ratio)) %>%
       droplevels()
-
-  perf_diff_table(norm_comp %>% filter(!grepl(base_exe, exe)), stats_comp)
+   
+    all_colors <- c(baseline_color, change_color, "#8ae234", "#ad7fa8", "#fcaf3e", "#ef2929")[1:length(exes)]
+    lighter_colors <- c("#97c4f0", "#efd0a7", "#b7f774", "#e0c0e4", "#ffd797", "#f78787")[1:length(exes)]
+    
+    p <- ggplot(stats_s, aes(ratio, exe, fill=exe)) +
+      geom_vline(aes(xintercept=1), colour="#999999", linetype="solid") +
+      geom_vline(aes(xintercept=slower_runtime_ratio), colour="#cccccc", linetype="dashed") +
+      geom_vline(aes(xintercept=faster_runtime_ratio), colour="#cccccc", linetype="dashed") +
+      geom_boxplot(aes(colour = exe),
+                   outlier.size = 0.9,
+                   outlier.alpha = 0.6) +
+      stat_summary(fun = negative_geometric.mean,
+                   size = 1, colour = "#503000", geom = "point") +
+      scale_x_log10() +
+      scale_y_discrete(limits = rev) +
+      ylab("") +
+      #coord_cartesian(xlim=c(0.5, 2.5)) +
+      theme_simple(8) +
+      scale_color_manual(values = all_colors) +
+      scale_fill_manual(values = lighter_colors) +
+      # scale_fill_manual(breaks=c("slower", "faster", "indeterminate"),
+      #                   values=c(slow_color, fast_color, NA)) +
+      theme(legend.position = "none")
+   
+    ggsave(paste0('overview.', s, '.svg'), p, "svg", output_dir, width = 4.5, height = 2.5, units = "in")
+    ggsave(paste0('overview.', s, '.png'), p, "png", output_dir, width = 4.5, height = 2.5, units = "in")
+    
+    out('<img src="', output_dir, '/overview.', s, '.svg">')
+   
+    row_count <- perf_diff_table_es(norm_s, stats_s, warmup_s, row_count + 1, exe)
+  }
+  
 }
 
 time <- timing.stop()

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -294,7 +294,7 @@ common_string_start <- function(x) {
 perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, group) {
   group_col <- enquo(group)
   row_count <- start_row_count
-  
+
   out('<table class="table table-sm benchmark-details">')
   out('<thead><tr>
 <th scope="col"></th>
@@ -304,16 +304,16 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
 <th scope="col">change in %</th>
 <th scope="col"></th>
 </tr></thead>')
-  
+
   # b <- "DeltaBlue"
   # data_ea <- data_b
-  
+
   for (b in levels(data_es$bench)) { data_b <- data_es %>% filter(bench == b) %>% droplevels()
     for (v in levels(data_b$varvalue)) {   data_v  <- data_b %>% filter(varvalue == v)   %>% droplevels()
     for (c in levels(data_v$cores)) {      data_c  <- data_v %>% filter(cores == c)      %>% droplevels()
     for (i in levels(data_c$inputsize)) {  data_i  <- data_c %>% filter(inputsize == i)  %>% droplevels()
     for (ea in levels(data_i$extraargs)) { data_ea <- data_i %>% filter(extraargs == ea) %>% droplevels()
-    
+
     args <- ""
     if (length(levels(data_b$varvalue))  > 1) { args <- paste0(args, v) }
     if (length(levels(data_v$cores))     > 1) { args <- paste0(args, c) }
@@ -322,22 +322,22 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
     if (nchar(args) > 0) {
       args <- paste0('<span class="all-args">', args, '</span>')
     }
-    
+
     # capture the beginning of the path but leave the last element of it
     # this regex is also used in render.js's renderBenchmark() function
     cmdline <- str_replace_all(data_i$cmdline[[1]], "^([^\\s]*)((?:\\/\\w+)\\s.*$)", ".\\2")
-    
+
     stats_b <- stats_es %>%
       ungroup() %>%
       filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea) %>%
       droplevels()
-    
+
     if ("commitid" %in% colnames(stats_b)) {
       stats_b <- stats_b %>%
         filter(commitid == change_hash6) %>%
         droplevels()
     }
-    
+
     group_size <- (data_ea %>% select(!!group_col) %>% unique() %>% count())$n
 
     if (nrow(stats_b) > 0) {
@@ -348,10 +348,10 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
       img_file <- paste0('inline-', row_count, '.svg')
       ggsave(img_file, p, "svg", output_dir, width = 3.5, height = 0.12 + 0.14 * group_size, units = "in")
       out('<img src="', output_dir, '/', img_file, '">')
-      
+
       row_count <- row_count + 1
       out('</td>\n')
-      
+
       if (nrow(stats_b) == 1) {
         out('<td class="stats-samples">', stats_b$samples, '</td>\n')
         out('<td><span class="stats-median" title="median">', r2(stats_b$median), '</span></td>\n')
@@ -372,7 +372,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
           out(substring(e, common_start) , " ", filter(stats_b, exe == e)$samples)
         }
         out('</td>\n')
-        
+
         out('<td><span class="stats-median" title="median">')
         first <- TRUE
         for (e in exes) {
@@ -384,8 +384,8 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
           out(r2(filter(stats_b, exe == e)$median))
         }
         out('</span></td>\n')
-        
-        
+
+
         out('<td>')
         first <- TRUE
         for (e in exes) {
@@ -397,21 +397,21 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
           out('<span class="stats-change" title="change over median">', pro(filter(stats_b, exe == e)$change_m), '</span>')
         }
         out('</td>\n')
-        
+
         out('<td><button type="button" class="btn btn-sm" data-toggle="popover" data-content="<code>', cmdline, '</code>"></button>\n')
       }
-      
+
       warmup_ea <- warmup_es %>%
         filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea) %>%
         droplevels()
-      
+
       if (nrow(warmup_ea) > 0) {
         img_file <- paste0('warmup-', row_count, '.svg')
         p <- warmup_plot(warmup_ea, !!group_col, group_size)
         ggsave(img_file, p, "svg", output_dir, width = 6, height = 2.5, units = "in")
         out('<button type="button" class="btn btn-sm btn-light btn-expand" data-img="', output_dir, '/', img_file, '"></button>\n')
       }
-      
+
       out('</td>');
       out('</tr>\n')
     } else {
@@ -421,34 +421,34 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
     }
     } } } }
   }
-  
+
   out('</table>')
   row_count
 }
 
 perf_diff_table <- function(norm, stats, start_row_count) {
   # e <- "TruffleSOM-graal-bc"
-  
+
   row_count <- start_row_count
-    
+
   for (e in levels(norm$exe)) {         data_e <- norm   %>% filter(exe == e)   %>% droplevels()
     for (s in levels(data_e$suite)) {   data_s <- data_e %>% filter(suite == s) %>% droplevels()
       # e <- "TruffleSOM-graal"
       # s <- "macro-steady"
       out("<h3>", s, "</h3>")
       out('<div class="title-executor">Executor: ', e, "</div>")
-      
+
       stats_es <- stats %>%
         ungroup() %>%
         filter(exe == e, suite == s) %>%
         droplevels()
-      
+
       warmup_es <- warmup %>%
         ungroup() %>%
         filter(exe == e, suite == s) %>%
         droplevels()
-      
       row_count <- perf_diff_table_es(data_s, stats_es, warmup_es, row_count, commitid)
+
     }
   }
   row_count
@@ -490,7 +490,7 @@ suites_for_comparison <- exes_and_suites %>%
 
 if (nrow(suites_for_comparison) > 0) {
   out('<h2 id="exe-comparisons">Executor Comparisons</h2>\n')
-  
+
   for (s in suites_for_comparison$suite) {
     # s <- "macro-startup"
     out('<h3 id="exe-comp-', s ,'">', s ,'</h3>\n')
@@ -500,20 +500,20 @@ if (nrow(suites_for_comparison) > 0) {
       droplevels()
     exes <- sort(levels(change_s$exe))
     baseline_exe <- exes[[1]]
-    
+
     out("<p>Baseline: ", baseline_exe, "</p>")
-    
-    
+
+
     warmup_s <- warmup %>%
       restrict_to_change_data() %>%
       filter(suite == s) %>%
       droplevels()
-    
+
     peak_s <- peak %>%
       restrict_to_change_data() %>%
       filter(suite == s) %>%
       droplevels()
-    
+
     base_s <- peak_s %>%
       filter(exe == baseline_exe) %>%
       group_by(bench,
@@ -521,32 +521,31 @@ if (nrow(suites_for_comparison) > 0) {
       summarise(base_mean = mean(value),
                 base_median = median(value),
                 .groups = "drop")
-    
+
     norm_s <- peak_s %>%
       left_join(base_s, by = c(
         "bench", "varvalue", "cores", "inputsize", "extraargs")) %>%
       group_by(bench, varvalue, cores, inputsize, extraargs) %>%
       transform(ratio_mean = value / base_mean,
                 ratio_median = value / base_median)
-    
-    
+
+
     stats_s <- norm_s %>%
       group_by(exe, bench,
                varvalue, cores, inputsize, extraargs) %>%
       filter(is.na(warmup) | iteration >= warmup) %>%
       calculate_stats()
-    
+
     not_in_both_s <- stats_s %>%
       filter(is.na(ratio)) %>%
       droplevels()
-    
+
     stats_s <- stats_s %>%
       filter(!is.na(ratio)) %>%
       droplevels()
-   
     all_colors <- c(baseline_color, change_color, "#8ae234", "#ad7fa8", "#fcaf3e", "#ef2929")[1:length(exes)]
     lighter_colors <- c("#97c4f0", "#efd0a7", "#b7f774", "#e0c0e4", "#ffd797", "#f78787")[1:length(exes)]
-    
+
     p <- ggplot(stats_s, aes(ratio, exe, fill=exe)) +
       geom_vline(aes(xintercept=1), colour="#999999", linetype="solid") +
       geom_vline(aes(xintercept=slower_runtime_ratio), colour="#cccccc", linetype="dashed") +
@@ -566,15 +565,15 @@ if (nrow(suites_for_comparison) > 0) {
       # scale_fill_manual(breaks=c("slower", "faster", "indeterminate"),
       #                   values=c(slow_color, fast_color, NA)) +
       theme(legend.position = "none")
-   
+
     ggsave(paste0('overview.', s, '.svg'), p, "svg", output_dir, width = 4.5, height = 2.5, units = "in")
     ggsave(paste0('overview.', s, '.png'), p, "png", output_dir, width = 4.5, height = 2.5, units = "in")
-    
+
     out('<img src="', output_dir, '/overview.', s, '.svg">')
-   
+
     row_count <- perf_diff_table_es(norm_s, stats_s, warmup_s, row_count + 1, exe)
   }
-  
+
 }
 
 time <- timing.stop()

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -1,7 +1,22 @@
 #!/usr/bin/env Rscript
 #
 # SOMns Performance Comparison Report
-args <- commandArgs(trailingOnly = TRUE)
+args <- if (Sys.getenv("RSTUDIO") == "1") {
+ c("test.html",
+   "~/Projects/ReBenchDB/tmp/rstudio/",
+   "~/Projects/ReBenchDB/src/views/",
+   "493721",
+   "d3f598",
+   "#729fcf",
+   "#e9b96e",
+   NA,  # "rdb_sm1"
+   NA,
+   NA,
+   "from-file;~/Projects/ReBenchDB/tmp/TruffleSOM-380.qs;~/Projects/ReBenchDB/tmp/TruffleSOM-381.qs"
+ ) 
+} else {
+  commandArgs(trailingOnly = TRUE)
+}
 
 if (length(args) < 11 | args[[1]] == '--help') {
   cat("Performance Comparison Report
@@ -37,14 +52,6 @@ db_user        <- args[[9]]
 db_pass        <- args[[10]]
 extra_cmd      <- args[[11]]
 
-# baseline_hash <- "b0bd089afdb2f3437c52486630ceb82e96a741d9"
-# change_hash   <- "b3d66873c97cac6d4e2f79e8b6a91e3397161b62"
-# baseline_color <- "#729fcf"
-# change_color   <- "#e9b96e"
-# db_user        <- NULL  # "rdb_sm1"
-# db_pass        <- NULL
-# db_name        <- "rdb_sm1"
-
 # Load Libraries
 source(paste0(lib_dir, "/common.R"), chdir=TRUE)
 suppressMessages(library(dplyr))
@@ -69,8 +76,12 @@ timing.start()
 ## File Output
 output_file_connection <- NULL
 
-out <- function(...) {
-  writeLines(c(...), con = output_file_connection, sep = "")
+if (Sys.getenv("RSTUDIO") == "1") {
+  out <- function(...) { writeLines(c(...), sep = "") }
+} else {
+  out <- function(...) {
+    writeLines(c(...), con = output_file_connection, sep = "")
+  }
 }
 
 ## Create Directories and Open Output File

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -299,7 +299,7 @@ if (nrow(suites_for_comparison) > 0) {
   out('<nav>\n')
   
   for (s in suites_for_comparison$suite) {
-    out('<a href="#', s ,'">', s ,'</a>\n')
+    out('<a href="#exe-comp-', s ,'">', s ,'</a>\n')
   }
   
   out('</nav>\n')

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -5,6 +5,7 @@ args <- if (Sys.getenv("RSTUDIO") == "1") {
  c("test.html",
    "~/Projects/ReBenchDB/tmp/rstudio/",
    "~/Projects/ReBenchDB/src/views/",
+   "/static/reports",
    "d9dda54b519e3a87351768878afb2c7950036260",  #"493721",
    "5fa4bdb749d3b4a621362219420947e00e108580",  #"d3f598",
    "rdb_smde", # NA,  # "rdb_sm1"
@@ -16,7 +17,7 @@ args <- if (Sys.getenv("RSTUDIO") == "1") {
   commandArgs(trailingOnly = TRUE)
 }
 
-if (length(args) < 9 | args[[1]] == '--help') {
+if (length(args) < 10 | args[[1]] == '--help') {
   cat("Performance Comparison Report
 
 Usage: somns.R outputFile outputDir baselineHash changeHash baselineColor changeColor dbName dbUser dbPass [extraCmd]
@@ -24,6 +25,7 @@ Usage: somns.R outputFile outputDir baselineHash changeHash baselineColor change
   outputFile       the name for the HTML file that is produced
   outputDir        the name for the folder with images produced
   libDir           the path where common.R can be found
+  staticBase       the base url for static resource, e.g., images
   baselineHash     the commit hash of the baseline
   changeHash       the commit hash of the change
 
@@ -39,12 +41,13 @@ Usage: somns.R outputFile outputDir baselineHash changeHash baselineColor change
 output_file    <- args[[1]]
 output_dir     <- args[[2]]
 lib_dir        <- args[[3]]
-baseline_hash  <- args[[4]]
-change_hash    <- args[[5]]
-db_name        <- args[[6]]
-db_user        <- args[[7]]
-db_pass        <- args[[8]]
-extra_cmd      <- args[[9]]
+static_base    <- args[[4]]
+baseline_hash  <- args[[5]]
+change_hash    <- args[[6]]
+db_name        <- args[[7]]
+db_user        <- args[[8]]
+db_pass        <- args[[9]]
+extra_cmd      <- args[[10]]
 
 # Load Libraries
 source(paste0(lib_dir, "/common.R"), chdir=TRUE)
@@ -61,6 +64,8 @@ fast_color <- "#e4ffc7"
 slow_color <- "#ffcccc"
 faster_runtime_ratio <- 0.95
 slower_runtime_ratio <- 1.05
+
+output_url <- paste0(static_base, '/', output_dir)
 
 # Start Timing of Report Generation
 timing.start()
@@ -316,7 +321,7 @@ ggsave('overview.png', p, "png", output_dir, width = 4.5, height = 2.5, units = 
 
 out('<h2 id="overview">Result Overview</h2>')
 
-out('<img src="', output_dir, '/overview.svg">')
+out('<img src="', output_url, '/overview.svg">')
 
 out('<dl class="row">
   <dt class="col-sm-3">Number of Benchmarks</dt>
@@ -399,7 +404,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
       p <- small_inline_comparison(data_ea, !!group_col, colors, colors_light)
       img_file <- paste0('inline-', row_count, '.svg')
       ggsave(img_file, p, "svg", output_dir, width = 3.5, height = 0.12 + 0.14 * group_size, units = "in")
-      out('<img src="', output_dir, '/', img_file, '">')
+      out('<img src="', output_url, '/', img_file, '">')
 
       row_count <- row_count + 1
       out('</td>\n')
@@ -461,7 +466,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
         img_file <- paste0('warmup-', row_count, '.svg')
         p <- warmup_plot(warmup_ea, !!group_col, colors)
         ggsave(img_file, p, "svg", output_dir, width = 6, height = 2.5, units = "in")
-        out('<button type="button" class="btn btn-sm btn-light btn-expand" data-img="', output_dir, '/', img_file, '"></button>\n')
+        out('<button type="button" class="btn btn-sm btn-light btn-expand" data-img="', output_url, '/', img_file, '"></button>\n')
       }
 
       out('</td>');
@@ -593,7 +598,7 @@ if (nrow(suites_for_comparison) > 0) {
     ggsave(paste0('overview.', s, '.svg'), p, "svg", output_dir, width = 4.5, height = 2.5, units = "in")
     ggsave(paste0('overview.', s, '.png'), p, "png", output_dir, width = 4.5, height = 2.5, units = "in")
 
-    out('<img src="', output_dir, '/overview.', s, '.svg">')
+    out('<img src="', output_url, '/overview.', s, '.svg">')
 
     row_count <- perf_diff_table_es(
       norm_s, stats_s, warmup_s, row_count + 1, exe, exes_colors, exes_colors_light)

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -266,31 +266,6 @@ if (nrow(not_in_both) > 0) {
 
 out("<h2>Benchmark Performance</h2>")
 
-common_string_start <- function(x) {
-  x <- sort(x)
-  n <- min(nchar(x))
-  x <- sapply(x, function(s) {
-    substr(s, 1, n)
-  })
-  x <- unique(x)
-  
-  # split the first and last element by character
-  d_x <- strsplit(x[c(1, length(x))], "")
-  # search for the first not common element and so, get the last matching one
-  der_com <- match(FALSE, do.call("==", d_x)) - 1
-  # if there is no matching element, return an empty vector, else return the common part
-  # if (der_com == 0) {
-  #   character(0)
-  # } else {
-  #   substr(x[1], 1, der_com)
-  # }
-  if (is.na(der_com)) {
-    n + 1
-  } else {
-    der_com  
-  }
-}
-
 perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, group) {
   group_col <- enquo(group)
   row_count <- start_row_count

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -345,7 +345,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
       
       if (nrow(warmup_ea) > 0) {
         img_file <- paste0('warmup-', row_count, '.svg')
-        p <- warmup_plot(warmup_ea, !!group_col)
+        p <- warmup_plot(warmup_ea, !!group_col, group_size)
         ggsave(img_file, p, "svg", output_dir, width = 6, height = 2.5, units = "in")
         out('<button type="button" class="btn btn-sm btn-light btn-expand" data-img="', output_dir, '/', img_file, '"></button>\n')
       }

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -555,7 +555,8 @@ if (nrow(suites_for_comparison) > 0) {
 
     out('<img src="', output_dir, '/overview.', s, '.svg">')
 
-    row_count <- perf_diff_table_es(norm_s, stats_s, warmup_s, row_count + 1, exe)
+    row_count <- perf_diff_table_es(
+      norm_s, stats_s, warmup_s, row_count + 1, exe, exes_colors, exes_colors_light)
   }
 
 }

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -56,7 +56,6 @@ extra_cmd      <- args[[11]]
 source(paste0(lib_dir, "/common.R"), chdir=TRUE)
 suppressMessages(library(dplyr))
 library(stringr)
-options(warn=1)
 
 baseline_hash6 <- substr(baseline_hash, 1, 6)
 change_hash6 <- substr(change_hash, 1, 6)

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -314,13 +314,15 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
         droplevels()
     }
     
+    group_size <- (data_ea %>% select(!!group_col) %>% unique() %>% count())$n
+
     if (nrow(stats_b) > 0) {
       out('<tr>')
       out('<th scope="row">',  b, args, '</th>')
       out('<td>')
-      p <- small_inline_comparison(data_ea, !!group_col)
+      p <- small_inline_comparison(data_ea, !!group_col, group_size)
       img_file <- paste0('inline-', row_count, '.svg')
-      ggsave(img_file, p, "svg", output_dir, width = 3.5, height = 0.4, units = "in")
+      ggsave(img_file, p, "svg", output_dir, width = 3.5, height = 0.12 + 0.14 * group_size, units = "in")
       out('<img src="', output_dir, '/', img_file, '">')
       
       row_count <- row_count + 1
@@ -336,7 +338,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, start_row_count, gr
         out('<td></td>',
             '<td></td>',
             '<td></td>',
-            '<td></td>')
+            '<td>')
       }
       
       warmup_ea <- warmup_es %>%

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -402,7 +402,7 @@ row_count <- perf_diff_table(norm, stats, 0)
 restrict_to_change_data <- function(data) {
   data %>%
     ungroup() %>%
-    filter(commitid == change_hash) %>%
+    filter(commitid == change_hash6) %>%
     select(!commitid) %>%
     droplevels()
 }

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -51,19 +51,21 @@ describe('Report Generation', () => {
       expect(content).toEqual(expect.not.stringContaining('<code>##'));
     });
 
-    it('Should have generated a summare plot', () => {
+    it('Should have generated a summary plot', () => {
       const plotFile = getSummaryPlotFileName(outputFile);
       const plotPath = `${reportFolder}/${plotFile}`;
       console.log(plotPath);
       expect(existsSync(plotPath)).toBeTruthy();
     });
 
-    it('Should not include the cross comparison', () => {
+    it('Should not include the exec comparison', () => {
       const content: string = readFileSync(
         `${__dirname}/../resources/reports/${outputFile}`,
         'utf8'
       );
-      expect(content).not.toEqual(expect.stringContaining('Cross Comparison'));
+      expect(content).not.toEqual(
+        expect.stringContaining('Executor Comparisons')
+      );
     });
 
     afterAll(async () => {
@@ -141,12 +143,12 @@ describe('Report Generation', () => {
       expect(output.code).toBe(0);
     }, 120000);
 
-    it('Should include the cross comparison', () => {
+    it('Should include the exec comparison', () => {
       const content: string = readFileSync(
         `${reportFolder}/${outputFile}`,
         'utf8'
       );
-      expect(content).toEqual(expect.stringContaining('Cross Comparison'));
+      expect(content).toEqual(expect.stringContaining('Executor Comparisons'));
     });
 
     afterAll(async () => {


### PR DESCRIPTION
This PR adds comparisons between executors in addition to the normal comparison between versions.

It's a rewrite/extension of the ad hoc comparison implemented on #46.
Though, instead of relying on a naming heuristic, this identifies suitable comparisons based on the available executors and suites.

It also adds a navigation bar for the now quite a bit longer reports.

The table contains the measurements per benchmark.
To attribute the results to the relevant executors, the common prefix of the executor names is removed.
This works quite well with names like `SOM-interp` and `SOM-jit` for instance.


This resolves #60.

Other changes:
 - make somns.R easier to use in RStudio
 - replace the custom backtrace by the one provided by rlang from the tidyverse
