### PR TITLE
Add required node version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "pg": "8.7.3",
     "promisify-child-process": "4.1.1"
   },
+  "engines": {
+    "node": ">=18.4.0"
+  },
   "devDependencies": {
     "@octokit/types": "6.34.0",
     "@types/jest": "28.1.4",


### PR DESCRIPTION
This encodes the required minimum Node.js version.
I don't really know what the supported minimum is, so, I'll go with what I have locally.

@HumphreyHCB does this work for you?