### PR TITLE
Implemented environment information Button

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -206,6 +206,18 @@ td.warmup-plot {
   background-size: 1rem;
 }
 
+.btn-environment {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-left: auto;
+  content: "";
+  /* src https://icons.getbootstrap.com/icons/cpu/ */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-motherboard' viewBox='0 0 16 16'%3E%3Cpath d='M5 0a.5.5 0 0 1 .5.5V2h1V.5a.5.5 0 0 1 1 0V2h1V.5a.5.5 0 0 1 1 0V2h1V.5a.5.5 0 0 1 1 0V2A2.5 2.5 0 0 1 14 4.5h1.5a.5.5 0 0 1 0 1H14v1h1.5a.5.5 0 0 1 0 1H14v1h1.5a.5.5 0 0 1 0 1H14v1h1.5a.5.5 0 0 1 0 1H14a2.5 2.5 0 0 1-2.5 2.5v1.5a.5.5 0 0 1-1 0V14h-1v1.5a.5.5 0 0 1-1 0V14h-1v1.5a.5.5 0 0 1-1 0V14h-1v1.5a.5.5 0 0 1-1 0V14A2.5 2.5 0 0 1 2 11.5H.5a.5.5 0 0 1 0-1H2v-1H.5a.5.5 0 0 1 0-1H2v-1H.5a.5.5 0 0 1 0-1H2v-1H.5a.5.5 0 0 1 0-1H2A2.5 2.5 0 0 1 4.5 2V.5A.5.5 0 0 1 5 0zm-.5 3A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13h7a1.5 1.5 0 0 0 1.5-1.5v-7A1.5 1.5 0 0 0 11.5 3h-7zM5 6.5A1.5 1.5 0 0 1 6.5 5h3A1.5 1.5 0 0 1 11 6.5v3A1.5 1.5 0 0 1 9.5 11h-3A1.5 1.5 0 0 1 5 9.5v-3zM6.5 6a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: 1rem;
+}
+
 .card-columns {
   column-count: 2;
 }
@@ -251,3 +263,4 @@ td.warmup-plot {
 .glyph-minus:before {
   content: "-";
 }
+

--- a/src/views/compare.ts
+++ b/src/views/compare.ts
@@ -128,7 +128,7 @@ $(() => {
 
   $('#show-refresh-form').click(() => $('input[name=password]').show());
 
-  (<any>$)('.btn-cmdline').popover({ html: true, placement: 'top' });
+  (<any>$)('.btn-popover').popover({ html: true, placement: 'top' });
   $('.btn-expand').click(insertWarmupPlot);
   $('.btn-profile').click(insertProfiles);
 

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -100,18 +100,23 @@ profile_available_from <- "
     JOIN Executor ON execId = executor.id "
 
 # fetch all benchmarks information from the database
-get_environments <- function(){
-  qry <- dbSendQuery(rebenchdb, "SELECT id, hostname, ostype, memory, cpu, clockspeed FROM environment")
+get_environments <- function(rebenchdb, hash_1, hash_2) {
+  qry <- dbSendQuery(rebenchdb, "
+    SELECT env.id as envid, env.hostname, env.ostype, env.memory,
+          env.cpu, env.clockspeed
+    FROM Source src
+      JOIN Trial t on t.sourceId = src.id
+      JOIN Environment env   ON t.envId = env.id
+    WHERE commitId = $1 OR commitid = $2")
+  dbBind(qry, list(hash_1, hash_2))
   result <- dbFetch(qry)
   dbClearResult(qry)
-  result$id <- factor(result$id)
+  result$envid <- factor(result$envid)
   result$hostname <- factor(result$hostname)
   result$ostype <- factor(result$ostype)
   result$memory <- factor(result$memory)
   result$cpu <- factor(result$cpu)
   result$clockspeed <- factor(result$clockspeed)
-
-  result <- data.frame(result)
   result
 }
 

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -106,17 +106,18 @@ get_environments <- function(rebenchdb, hash_1, hash_2) {
           env.cpu, env.clockspeed
     FROM Source src
       JOIN Trial t on t.sourceId = src.id
-      JOIN Environment env   ON t.envId = env.id
+      JOIN Environment env ON t.envId = env.id
     WHERE commitId = $1 OR commitid = $2")
   dbBind(qry, list(hash_1, hash_2))
   result <- dbFetch(qry)
   dbClearResult(qry)
   result$envid <- factor(result$envid)
-  result$hostname <- factor(result$hostname)
-  result$ostype <- factor(result$ostype)
-  result$memory <- factor(result$memory)
-  result$cpu <- factor(result$cpu)
-  result$clockspeed <- factor(result$clockspeed)
+  # do not need to turn them into factors, because we just want to display them
+  # result$hostname <- result$hostname
+  # result$ostype <- result$ostype
+  # result$memory <- result$memory
+  # result$cpu <- result$cpu
+  # result$clockspeed <- result$clockspeed
   result
 }
 

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -111,6 +111,7 @@ get_environments <- function(){
   result$cpu <- factor(result$cpu)
   result$clockspeed <- factor(result$clockspeed)
 
+  result <- data.frame(result)
   result
 }
 
@@ -149,7 +150,7 @@ factorize_result <- function(result) {
     result$criterion <- factor(result$criterion)
     result$unit <- factor(result$unit)
   }
-  
+
   result
 }
 

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -46,7 +46,7 @@ main_data_select <- "
       cmdline, varValue, cores, inputSize, extraArgs,
       invocation, iteration, warmup,
       criterion.name as criterion, criterion.unit as unit,
-      value,  warmup, envid"
+      value, envid"
 
 main_data_from <- "
     FROM Measurement
@@ -57,8 +57,7 @@ main_data_from <- "
       JOIN Run ON runId = run.id
       JOIN Suite ON suiteId = suite.id
       JOIN Benchmark ON benchmarkId = benchmark.id
-      JOIN Executor ON execId = executor.id 
-      "
+      JOIN Executor ON execId = executor.id "
 
 get_measures_for_comparison <- function(rebenchdb, hash_1, hash_2) {
   qry <- dbSendQuery(rebenchdb,
@@ -88,7 +87,7 @@ profile_available_select <- "
   SELECT expId, runId, trialId, substring(commitId, 1, 6) as commitid,
     benchmark.name as bench, executor.name as exe, suite.name as suite,
     cmdline, varValue, cores, inputSize, extraArgs,
-    invocation, numIterations"
+    invocation, numIterations, warmup"
 
 profile_available_from <- "
   FROM ProfileData
@@ -98,8 +97,7 @@ profile_available_from <- "
     JOIN Run ON runId = run.id
     JOIN Suite ON suiteId = suite.id
     JOIN Benchmark ON benchmarkId = benchmark.id
-    JOIN Executor ON execId = executor.id 
-    "
+    JOIN Executor ON execId = executor.id "
 
 # fetch all benchmarks information from the database
 get_environments <- function(){

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -215,6 +215,28 @@ slower_category <- function(data) {
   return("indeterminate")
 }
 
+as_human_mem <- function(x) {
+  m <- x
+  mem <- c("b", "kb", "MB", "GB")
+  i <- 1
+  while (i <= 4 && m > 1024) {
+    m <- m / 1024
+    i <- i + 1
+  }
+  paste0(format(m, digits = 3), mem[[i]])
+}
+
+as_human_hz <- function(x) {
+  h <- x
+  hz <- c("Hz", "kHz", "MHz", "GHz")
+  i <- 1
+  while (i <= 4 && h > 1000) {
+    h <- h / 1000
+    i <- i + 1
+  }
+  paste0(format(h, digits = 3), hz[[i]])
+}
+
 
 if (nrow(stats %>% filter(commitid == change_hash6)) == 0) {
   out('<div class="compare">')
@@ -417,11 +439,11 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
     # format all environment information into a single string
     env <- environments %>%
       filter(envid == levels(data_en$envid)) %>%
-      unique() %>%
+      unique(incomparables = FALSE) %>%
       droplevels()
-    environment_str <- paste0("Hostname: ", env$hostname,
-      " |  OS Type: ", env$ostype, " |  Memory: ", env$memory,
-      " |  CPU: ", env$cpu, " |  Clockspeed: ", env$clockspeed)
+    environment_str <- paste0(env$hostname,
+      " | ", env$ostype, " | ", as_human_mem(env$memory),
+      " | ", env$cpu, " | ", as_human_hz(env$clockspeed))
 
     stats_b_total <- stats_es %>%
       ungroup() %>%

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -369,12 +369,11 @@ if (nrow(not_in_both) > 0) {
 
 out("<h2>Benchmark Performance</h2>")
 
-perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_row_count, group, colors, colors_light, environments) {
+perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_row_count, group, colors, colors_light) {
   group_col <- enquo(group)
   row_count <- start_row_count
   
 
-  environmentsframe <- data.frame(environments)
 
   out('<table class="table table-sm benchmark-details">')
   out('<thead><tr>
@@ -414,9 +413,9 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
     # capture the beginning of the path but leave the last element of it
     # this regex is also used in render.js's renderBenchmark() function
     cmdline <- str_replace_all(data_i$cmdline[[1]], "^([^\\s]*)((?:\\/\\w+)\\s.*$)", ".\\2")
-
+    
     # format all environment information into a single string
-    environmentStr <- paste0("Hostname: ", as.character(environmentsframe[levels(data_en$envid), 2])," |  OS Type: ", as.character(environmentsframe[levels(data_en$envid), 3])," |  Memory: ", as.character(environmentsframe[levels(data_en$envid), 4]), " |  CPU: ", as.character(environmentsframe[levels(data_en$envid), 5]), " |  Clockspeed: " ,as.character(environmentsframe[levels(data_en$envid), 6]))
+    environmentStr <- paste0("Hostname: ", as.character(environments[levels(data_en$envid), which(colnames(environments)=="hostname")])," |  OS Type: ", as.character(environments[levels(data_en$envid), which(colnames(environments)=="ostype")])," |  Memory: ", as.character(environments[levels(data_en$envid), which(colnames(environments)=="memory")]), " |  CPU: ", as.character(environments[levels(data_en$envid), which(colnames(environments)=="cpu")]), " |  Clockspeed: " ,as.character(environments[levels(data_en$envid), which(colnames(environments)=="clockspeed")]))
     
     stats_b_total <- stats_es %>%
       ungroup() %>%     
@@ -600,7 +599,7 @@ perf_diff_table <- function(norm, stats, start_row_count) {
 
       row_count <- perf_diff_table_es(
         data_s, stats_es, warmup_es, profiles_es,
-        row_count, commitid, chg_colors, chg_colors_light, environments)
+        row_count, commitid, chg_colors, chg_colors_light)
     }
   }
   row_count
@@ -694,7 +693,7 @@ if (nrow(suites_for_comparison) > 0) {
     out('<img src="', output_url, '/overview.', s, '.svg">')
 
     row_count <- perf_diff_table_es(
-      norm_s, stats_s, warmup_s, NULL, row_count + 1, exe, exes_colors, exes_colors_light, environments)
+      norm_s, stats_s, warmup_s, NULL, row_count + 1, exe, exes_colors, exes_colors_light)
   }
 
 }

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -391,7 +391,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
   # b <- "DeltaBlue"
   # data_ea <- data_b
 
-  for (b in levels(data_es$bench)) { data_b <- data_es %>% filter(bench == b) %>% droplevels() # nolint
+  for (b in levels(data_es$bench)) { data_b <- data_es %>% filter(bench == b) %>% droplevels()
     for (v in levels(data_b$varvalue)) {   data_v  <- data_b %>% filter(varvalue == v)   %>% droplevels()
     for (c in levels(data_v$cores)) {      data_c  <- data_v %>% filter(cores == c)      %>% droplevels()
     for (i in levels(data_c$inputsize)) {  data_i  <- data_c %>% filter(inputsize == i)  %>% droplevels()
@@ -528,15 +528,9 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
         out('</td>\n')
       }
 
-      out('<td><button type="button" class="btn btn-sm btn-cmdline" data-content="<code>', cmdline, '</code>"></button>\n')
-      out('<button type="button" class="btn btn-sm btn-environment" data-toggle="popover" data-placement="top" data-content="',environmentStr,'" ></button>')
+      out('<td><button type="button" class="btn btn-sm btn-cmdline btn-popover" data-content="<code>', cmdline, '</code>"></button>\n')
+      out('<button type="button" class="btn btn-sm btn-environment btn-popover" data-content="',environmentStr,'" ></button>')
       
-      # script to implement the popover for the environment button
-      out('<script>
-          $(document).ready(function(){
-          $(', paste0( "'", '[data-toggle="popover"]' , "'" ) ,').popover();   
-          });
-          </script>')
        warmup_ea <- warmup_es %>%
         filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea) %>%
         droplevels()


### PR DESCRIPTION
Display the details of the environment in which a benchmark ran.
The info is shown as popover on an icon, similar to the command line.

- Added HTML & CSS for Environment Button
- Changes to sql to capture Environment information
- SQL and Button Changes to capture environments
- Added popover CSS & formatted Text for environment

All benchmarks now have an addition information button (A CPU icon). It will display:
	Hostname - Name of the machine this specific benchmark was run on
	OS type – the operating system of the machine
	Memory – the amount of the memory the machine has
	CPU – the type of CPU the machine has
	Clockspeed – the Clock speed of the CPU

The List of Environments is queried once per comparison and stored in memory, which should result in a minimal effect on [ReBenchDB](https://github.com/HumphreyHCB/HBReBenchDB) performance.