### PR TITLE
Improve Space use on Mobile

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -59,7 +59,13 @@ nav.compare {
 }
 
 #project .scroll-list {
-  max-height: 55vh;
+  max-height: calc((100vh - 320px) / 2);
+}
+
+@media (min-width: 576px) {
+  #project .scroll-list {
+    max-height: 55vh;
+  }
 }
 
 .baseline .list-group-item.active, .baseline-badge {

--- a/resources/style.css
+++ b/resources/style.css
@@ -40,6 +40,48 @@ nav.compare {
   padding-bottom: 10px;
 }
 
+#report-nav-toggler {
+  display: inline-block;
+}
+
+main {
+  max-width: 100%;
+}
+
+@media (min-width: 1200px) {
+  #report-nav-toggler {
+    display: none;
+  }
+  main {
+    max-width: 67%;
+  }
+}
+
+nav.compare {
+  display: none;
+}
+
+nav.compare.show {
+  display: block;
+}
+
+@media (max-width: 1199px) {
+  nav.compare.show {
+    flex: none;
+    height: fit-content;
+    min-width: 160px;
+    order: 0;
+    position: relative;
+  }
+}
+
+@media (min-width: 1200px) {
+  nav.compare {
+    /* overriding the collapse CSS to make it always visible */
+    display: block !important;
+  }
+}
+
 .card {
   margin-top: 1em;
 }

--- a/src/views/compare.html
+++ b/src/views/compare.html
@@ -25,7 +25,13 @@
 </div>
 
 <div class="refresh">
-  <div class="flex-nowrap">
+  <div class="flex-nowrap navbar-light">
+    <button class="navbar-toggler" type="button" data-toggle="collapse"
+        data-target="nav.compare" aria-controls="nav.compare"
+        aria-expanded="false" aria-label="Toggle Outline"
+        id="report-nav-toggler">
+      <span class="navbar-toggler-icon"></span>
+    </button>
     <button id="show-refresh-form" type="button" class="btn btn-outline-secondary btn-sm">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-repeat" viewBox="0 0 16 16">
         <path d="M11.534 7h3.932a.25.25 0 0 1 .192.41l-1.966 2.36a.25.25 0 0 1-.384 0l-1.966-2.36a.25.25 0 0 1 .192-.41zm-11 2h3.932a.25.25 0 0 0 .192-.41L2.692 6.23a.25.25 0 0 0-.384 0L.342 8.59A.25.25 0 0 0 .534 9z"/>


### PR DESCRIPTION
This PR improves how the page looks on smaller, more narrow screens/windows.
Specifically, it:

 - makes sure that the change list fits exactly on the screen without scrolling, when accessing `/ProjectName` 
 - it improves the handling of the navigation. Instead of being in the way, it's hidden on narrow screens, but can be shown before the actual content when desired

@HumphreyHCB would be great if you could review on Monday.