### PR TITLE
Add support to filter by selecting/unselecting benchmarks in the change view

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -5,7 +5,12 @@ body {
 
 body.compare {
   max-width: initial;
-  padding-left: 10%;
+}
+
+@media (min-width: 576px) {
+  body.compare {
+    padding-left: 10%;
+  }
 }
 
 .compare {
@@ -312,3 +317,13 @@ td.warmup-plot {
   content: "-";
 }
 
+@media (max-width: 576px) {
+  .inline-cmp {
+    max-width: 100px;
+    overflow: hidden;
+  }
+
+  .inline-cmp img {
+    margin-left: -70px;
+  }
+}

--- a/src/views/compare.html
+++ b/src/views/compare.html
@@ -26,17 +26,24 @@
 
 <div class="refresh">
   <div class="flex-nowrap navbar-light">
-    <button class="navbar-toggler" type="button" data-toggle="collapse"
-        data-target="nav.compare" aria-controls="nav.compare"
-        aria-expanded="false" aria-label="Toggle Outline"
-        id="report-nav-toggler">
-      <span class="navbar-toggler-icon"></span>
+    <button type="button" class="btn btn-outline-secondary btn-sm"
+        data-toggle="collapse" data-target="#filters" aria-controls="#filters"
+        aria-expanded="false" aria-label="Toggle Filters">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-funnel" viewBox="0 0 16 16">
+        <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5v-2zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2h-11z"/>
+      </svg>
     </button>
     <button id="show-refresh-form" type="button" class="btn btn-outline-secondary btn-sm">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-repeat" viewBox="0 0 16 16">
         <path d="M11.534 7h3.932a.25.25 0 0 1 .192.41l-1.966 2.36a.25.25 0 0 1-.384 0l-1.966-2.36a.25.25 0 0 1 .192-.41zm-11 2h3.932a.25.25 0 0 0 .192-.41L2.692 6.23a.25.25 0 0 0-.384 0L.342 8.59A.25.25 0 0 0 .534 9z"/>
         <path fill-rule="evenodd" d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5.002 5.002 0 0 0 8 3zM3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9H3.1z"/>
       </svg>
+    </button>
+    <button class="navbar-toggler" type="button" data-toggle="collapse"
+        data-target="nav.compare" aria-controls="nav.compare"
+        aria-expanded="false" aria-label="Toggle Outline"
+        id="report-nav-toggler">
+      <span class="navbar-toggler-icon"></span>
     </button>
     <form method="post" action="/admin/refresh/{{project}}/{{baselineHash}}/{{changeHash}}" class="input-group-sm">
       <input type="password" class="form-control" name="password"
@@ -46,6 +53,10 @@
 </div>
 </header>
 
+<div class="collapse" id="filters">
+  <div class="card card-body text-white bg-secondary">
+  </div>
+</div>
 
 <div id="version-details" class="compare">
   <h2>Version Details</h2>

--- a/src/views/compare.html
+++ b/src/views/compare.html
@@ -53,9 +53,12 @@
 </div>
 </header>
 
-<div class="collapse" id="filters">
-  <div class="card card-body text-white bg-secondary">
+<div class="collapse card-columns" id="filters">
+  <div>
+    <button type="button" class="btn btn-secondary" id="filter-all">All</button>
+    <button type="button" class="btn btn-secondary" id="filter-none">None</button>
   </div>
+  <div id="filter-groups"></div>
 </div>
 
 <div id="version-details" class="compare">

--- a/src/views/compare.ts
+++ b/src/views/compare.ts
@@ -122,6 +122,51 @@ function insertProfiles(e) {
   }
 }
 
+function initializeFilters(): void {
+  const allBenchmarkNameElements = $(
+    '.benchmark-details tbody th:nth-child(1)'
+  );
+
+  const byName = new Map();
+
+  allBenchmarkNameElements.each((_, element) => {
+    const name = element.textContent?.trim();
+    if (!byName.has(name)) {
+      byName.set(name, []);
+    }
+
+    byName.get(name).push(element);
+  });
+
+  let nameCheckBoxes = '';
+  const sortedNames = Array.from(byName.keys()).sort();
+  for (const name of sortedNames) {
+    nameCheckBoxes += `
+      <div class="form-check">
+      <input type="checkbox"
+        class="form-check-input" id="filter-${name}" value="${name}" checked>
+      <label class="form-check-label" for="filter-${name}">${name}</label>
+      </div>`;
+  }
+  $('#filters .card-body').html(
+    '<div class="card-text">' + nameCheckBoxes + '</div>'
+  );
+  $('#filters .card-body input').on('change', (e) => {
+    const jE = $(e.currentTarget);
+    const name = jE.val();
+    const nameElements = byName.get(name);
+    if (jE.is(':checked')) {
+      for (const nameElem of nameElements) {
+        $(nameElem).parent().show();
+      }
+    } else {
+      for (const nameElem of nameElements) {
+        $(nameElem).parent().hide();
+      }
+    }
+  });
+}
+
 $(() => {
   $('#significance').on('input', determineAndDisplaySignificance);
   determineAndDisplaySignificance();
@@ -147,4 +192,6 @@ $(() => {
       .find('.btn-expand');
     expandButtons.each((i, elm) => insertWarmupPlot(elm));
   });
+
+  initializeFilters();
 });

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -600,6 +600,7 @@ perf_diff_table <- function(norm, stats, start_row_count) {
     for (s in levels(data_e$suite)) {   data_s <- data_e |> filter(suite == s) |> droplevels()
       # e <- "TruffleSOM-graal"
       # s <- "macro-steady"
+      out('<div class="exe-suite-group">')
       out('<h3 id="', s, '-', e, '">', s, '</h3>')
       out('<div class="title-executor">Executor: ', e, "</div>")
 
@@ -621,6 +622,8 @@ perf_diff_table <- function(norm, stats, start_row_count) {
       row_count <- perf_diff_table_es(
         data_s, stats_es, warmup_es, profiles_es,
         row_count, commitid, chg_colors, chg_colors_light, TRUE)
+
+      out('</div>') # exe-suite-group
     }
   }
   row_count

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -469,7 +469,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
     if (nrow(stats_b_total) > 0) {
       out('<tr>')
       out('<th scope="row">',  b, args, '</th>')
-      out('<td>')
+      out('<td class="inline-cmp">')
       p <- small_inline_comparison(data_en, !!group_col, colors, colors_light)
       img_file <- paste0('inline-', row_count, '.svg')
       ggsave(img_file, p, "svg", output_dir, width = 3.5, height = 0.12 + 0.14 * group_size, units = "in")


### PR DESCRIPTION
This adds an icon at the top, which will show the benchmark names, grouped as found in the report.

It also adds buttons to select all or none of the benchmarks.

@HumphreyHCB I'll rebase this on master after the other bits are merged. So, there are still changes in here currently, that are part of a separate PR. Would be great if you could have a look at these changes, too.