### PR TITLE
Added missing migration file (PR #78 adding profiling information)

### DIFF
--- a/src/db/migration.003.sql
+++ b/src/db/migration.003.sql
@@ -1,0 +1,13 @@
+-- migration to add support for storing profiling data
+CREATE TABLE ProfileData (
+  runId smallint,
+  trialId smallint,
+  invocation smallint,
+  numIterations smallint,
+
+  value text NOT NULL,
+
+  primary key (numIterations, invocation, runId, trialId),
+  foreign key (trialId) references Trial (id),
+  foreign key (runId) references Run (id)
+);


### PR DESCRIPTION
This is a missing migration file for PR #78, which added the recording of profiling information and the `ProfileData` table.
This is mostly of historic interest, but was clashing with another migration file.