### PR TITLE
Use uPlot also for timeline and for the result view of projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@types/koa": "2.13.5",
     "@types/koa-router": "7.4.4",
     "@types/mustache": "4.2.1",
-    "@types/plotly.js": "1.54.22",
     "@types/pg": "8.6.5",
     "@typescript-eslint/eslint-plugin": "5.30.7",
     "@typescript-eslint/parser": "5.30.7",

--- a/resources/style.css
+++ b/resources/style.css
@@ -3,25 +3,25 @@ body {
   margin: 0 auto;
 }
 
-body.compare {
+body.compare, body.timeline {
   max-width: initial;
 }
 
 @media (min-width: 576px) {
-  body.compare {
+  body.compare, body.timeline {
     padding-left: 10%;
   }
 }
 
-.compare {
+.compare, .timeline {
   max-width: 900px;
 }
 
-.compare nav a {
+.compare nav a, .timeline nav a {
   display: block;
 }
 
-.compare nav span {
+.compare nav span, .timeline nav span {
   margin-left: -10px;
 }
 
@@ -36,11 +36,11 @@ nav.compare {
   order: 2;
 }
 
-.compare main {
+.compare main, .timeline main {
   order: 1;
 }
 
-.compare nav {
+.compare nav, .timeline nav {
   padding-left: 20px;
   padding-bottom: 10px;
 }

--- a/resources/style.css
+++ b/resources/style.css
@@ -324,7 +324,10 @@ td.warmup-plot {
   display: none !important;
 }
 
-.u-legend tr:nth-child(1), .u-legend tr:nth-child(3), .u-legend tr:nth-child(6) {
+.timeline-multi .u-legend tr:nth-child(1),
+.timeline-multi .u-legend tr:nth-child(3),
+.timeline-multi .u-legend tr:nth-child(6),
+.timeline-single .u-legend tr:nth-child(2) {
   display: table-row !important;
 }
 

--- a/resources/style.css
+++ b/resources/style.css
@@ -315,6 +315,10 @@ td.warmup-plot {
   }
 }
 
+.timeline .exe-suite-group {
+  padding-bottom: 60px;
+}
+
 .uplot {
   margin-left: auto;
   margin-right: auto;

--- a/src/api.ts
+++ b/src/api.ts
@@ -188,14 +188,14 @@ export interface TimelineRequest {
 }
 
 export interface TimelineResponse {
-  baseBranchName: string;
-  changeBranchName: string;
+  baseBranchName: string | null;
+  changeBranchName: string | null;
   baseTimestamp: number | null;
   changeTimestamp: number | null;
   data: PlotData;
 }
 
-export type PlotData = [
+export type FullPlotData = [
   number[] /** UNIX time stamps */,
 
   /** Baseline Branch */
@@ -220,3 +220,25 @@ export type PlotData = [
   /** bootstrap confidence interval, 95th, high, millisecond values */
   (number | null)[]
 ];
+
+export type BasePlotData = [
+  number[] /** UNIX time stamps */,
+
+  /** Baseline Branch */
+
+  /** bootstrap confidence interval, 95th, low,  millisecond values */
+  (number | null)[],
+
+  /** median, millisecond values */
+  (number | null)[],
+
+  /** bootstrap confidence interval, 95th, high, millisecond values */
+  (number | null)[]
+];
+
+export interface AllResults {
+  benchmark: string;
+  values: number[];
+}
+
+export type PlotData = FullPlotData | BasePlotData;

--- a/src/api.ts
+++ b/src/api.ts
@@ -242,3 +242,22 @@ export interface AllResults {
 }
 
 export type PlotData = FullPlotData | BasePlotData;
+
+export interface TimelineSuite {
+  suiteId: number;
+  suiteName: string;
+  exec: TimelineExecutor[];
+}
+
+export interface TimelineExecutor {
+  execId: number;
+  execName: string;
+  benchmarks: TimelineBenchmark[];
+}
+
+export interface TimelineBenchmark {
+  benchId: number;
+  benchName: string;
+  cmdline: string;
+  runId: number;
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -474,60 +474,6 @@ export async function dashBenchmarksForProject(
   return { benchmarks: result.rows };
 }
 
-export async function dashTimelineForProject(
-  db: Database,
-  projectId: number
-): Promise<{ timeline; details }> {
-  const timelineP = db.query(
-    `
-  SELECT tl.*, src.id as sourceId, b.id as benchmarkId, exe.id as execId,
-      s.id as suiteId, hostname
-    FROM Timeline tl
-    JOIN Run r          ON tl.runId = r.id
-    JOIN Benchmark b    ON r.benchmarkId = b.id
-    JOIN Suite s        ON r.suiteId = s.id
-    JOIN Executor exe   ON r.execId = exe.id
-    JOIN Trial t        ON trialId = t.id
-    JOIN Environment env ON t.envId = env.id
-    JOIN Experiment exp ON expId = exp.id
-      JOIN Source src     ON sourceId = src.id
-      JOIN Criterion      ON criterion = criterion.id
-      JOIN Project p      ON exp.projectId = p.id
-
-    WHERE
-      criterion.name = 'total' AND
-      p.id = $1
-    ORDER BY
-      s.name, exe.name, b.name, hostname, startTime`,
-    [projectId]
-  );
-
-  const timelineDetailsP = db.query(
-    `
-      SELECT DISTINCT src.*, t.id as trialId, t.manualRun, t.startTime,
-        t.userName, exp.name as expName, exp.description as expDesc
-      FROM Timeline tl
-      JOIN Run r          ON tl.runId = r.id
-      JOIN Benchmark b    ON r.benchmarkId = b.id
-      JOIN Suite s        ON r.suiteId = s.id
-      JOIN Executor exe   ON r.execId = exe.id
-      JOIN Trial t        ON trialId = t.id
-      JOIN Experiment exp ON expId = exp.id
-        JOIN Source src     ON sourceId = src.id
-        JOIN Criterion      ON criterion = criterion.id
-        JOIN Project p      ON exp.projectId = p.id
-
-      WHERE
-        criterion.name = 'total' AND
-        p.id = $1`,
-    [projectId]
-  );
-  return {
-    timeline: (await timelineP).rows,
-    details: (await timelineDetailsP).rows
-  };
-}
-
 export async function reportCompletion(
   dbConfig: DatabaseConfig,
   db: Database,

--- a/src/db.ts
+++ b/src/db.ts
@@ -21,6 +21,7 @@ import { SingleRequestOnly } from './single-requester.js';
 import { startRequest, completeRequest } from './perf-tracker.js';
 import { getDirname } from './util.js';
 import { assert, log } from './logging.js';
+import { simplifyCmdline } from './views/util.js';
 
 const __dirname = getDirname(import.meta.url);
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -15,7 +15,8 @@ import {
   TimelineRequest,
   TimelineResponse,
   PlotData,
-  FullPlotData
+  FullPlotData,
+  TimelineSuite
 } from './api';
 import pg, { PoolConfig, QueryConfig, QueryResultRow } from 'pg';
 import { SingleRequestOnly } from './single-requester.js';
@@ -1212,7 +1213,7 @@ export abstract class Database {
 
   public async getLatestBenchmarksForTimelineView(
     projectId: number
-  ): Promise<any[] | null> {
+  ): Promise<TimelineSuite[] | null> {
     const q = { ...this.queries.fetchLatestBenchmarksForProject };
     q.values = [projectId];
 
@@ -1224,14 +1225,14 @@ export abstract class Database {
     let suiteId: number | null = null;
     let exeId: number | null = null;
 
-    const suites: any = [];
-    let currentSuite: any = null;
+    const suites: TimelineSuite[] = [];
+    let currentSuite: TimelineSuite | null = null;
     let currentExec: any = null;
 
     for (const r of result.rows) {
       if (r.suiteid !== suiteId) {
         currentSuite = {
-          suiteId: r.suiteId,
+          suiteId: r.suiteid,
           suiteName: r.suitename,
           exec: []
         };
@@ -1245,7 +1246,7 @@ export abstract class Database {
           execName: r.execname,
           benchmarks: []
         };
-        currentSuite.exec.push(currentExec);
+        currentSuite?.exec.push(currentExec);
         exeId = r.execid;
       }
 
@@ -1367,7 +1368,8 @@ export abstract class Database {
   }
 
   private constructTimelineQueryForRun(
-    projectId: number, runId: number
+    projectId: number,
+    runId: number
   ): QueryConfig {
     const sql = `
       SELECT

--- a/src/db.ts
+++ b/src/db.ts
@@ -14,7 +14,8 @@ import {
   BenchmarkCompletion,
   TimelineRequest,
   TimelineResponse,
-  PlotData
+  PlotData,
+  FullPlotData
 } from './api';
 import pg, { PoolConfig, QueryConfig, QueryResultRow } from 'pg';
 import { SingleRequestOnly } from './single-requester.js';
@@ -345,6 +346,43 @@ export abstract class Database {
                p.name = $1 AND
                (s.commitid = $2 OR s.commitid = $3)`,
       values: <any[]>[]
+    },
+    fetchLatestBenchmarksForProject: {
+      name: 'fetchLatestBenchmarksForProject',
+      text: `WITH LatestExperiment AS (
+                SELECT exp.id as expId, max(t.startTime) as newest
+                FROM Project p
+                  JOIN Experiment exp    ON exp.projectId = p.id
+                  JOIN Trial t           ON t.expId = exp.id
+                  JOIN Source src        ON t.sourceId = src.id
+                WHERE p.id = $1 AND
+                  p.baseBranch = src.branchOrTag
+                GROUP BY exp.id
+                ORDER BY newest DESC
+                LIMIT 1
+              )
+              SELECT DISTINCT
+                s.id as suiteId, s.name as suiteName,
+                exe.id as execId, exe.name as execName,
+                b.id as benchId, b.name as benchmark,
+                r.cmdline,
+                r.id as runId
+              FROM Project p
+                JOIN Experiment exp    ON exp.projectId = p.id
+                JOIN Trial t           ON t.expId = exp.id
+                JOIN Source src        ON t.sourceId = src.id
+                JOIN Environment env   ON t.envId = env.id
+                JOIN Timeline tl       ON tl.trialId = t.id
+                JOIN Run r             ON tl.runId = r.id
+                JOIN Benchmark b       ON r.benchmarkId = b.id
+                JOIN Suite s           ON r.suiteId = s.id
+                JOIN Executor exe      ON r.execId = exe.id
+                JOIN LatestExperiment le ON exp.id = le.expId
+              WHERE
+                p.id = $1 AND
+                p.baseBranch = src.branchOrTag
+              ORDER BY suiteName, execName, benchmark, cmdline;`,
+      values: <number[]>[]
     }
   };
 
@@ -1172,6 +1210,70 @@ export abstract class Database {
     };
   }
 
+  public async getLatestBenchmarksForTimelineView(
+    projectId: number
+  ): Promise<any[] | null> {
+    const q = { ...this.queries.fetchLatestBenchmarksForProject };
+    q.values = [projectId];
+
+    const result = await this.query(q);
+    if (result.rowCount < 1) {
+      return null;
+    }
+
+    let suiteId: number | null = null;
+    let exeId: number | null = null;
+
+    const suites: any = [];
+    let currentSuite: any = null;
+    let currentExec: any = null;
+
+    for (const r of result.rows) {
+      if (r.suiteid !== suiteId) {
+        currentSuite = {
+          suiteId: r.suiteId,
+          suiteName: r.suitename,
+          exec: []
+        };
+        suites.push(currentSuite);
+        suiteId = r.suiteId;
+      }
+
+      if (r.execid !== exeId) {
+        currentExec = {
+          execId: r.execid,
+          execName: r.execname,
+          benchmarks: []
+        };
+        currentSuite.exec.push(currentExec);
+        exeId = r.execid;
+      }
+
+      currentExec.benchmarks.push({
+        benchId: r.benchid,
+        benchName: r.benchmark,
+        cmdline: simplifyCmdline(r.cmdline),
+        runId: r.runid
+      });
+    }
+
+    return suites;
+  }
+
+  public async getTimelineForRun(
+    projectId: number,
+    runId: number
+  ): Promise<TimelineResponse | null> {
+    const q = this.constructTimelineQueryForRun(projectId, runId);
+    const result = await this.query(q);
+
+    if (result.rowCount < 1) {
+      return null;
+    }
+
+    return this.convertToTimelineResponse(result.rows, null, null);
+  }
+
   public async getTimelineData(
     projectName: string,
     request: TimelineRequest
@@ -1203,33 +1305,43 @@ export abstract class Database {
 
   private convertToTimelineResponse(
     rows: any[],
-    baseBranchName: string,
-    changeBranchName: string
+    baseBranchName: string | null,
+    changeBranchName: string | null
   ): TimelineResponse {
     let baseTimestamp: number | null = null;
     let changeTimestamp: number | null = null;
-    const data: PlotData = [
-      [], // time stamp
-      [], // baseline bci low
-      [], // baseline median
-      [], // baseline bci high
-      [], // change bci low
-      [], // change median
-      [] // change bci high
-    ];
+    const data: PlotData =
+      baseBranchName !== null
+        ? [
+            [], // time stamp
+            [], // baseline bci low
+            [], // baseline median
+            [], // baseline bci high
+            [], // change bci low
+            [], // change median
+            [] // change bci high
+          ]
+        : [
+            [], // time stamp
+            [], // baseline bci low
+            [], // baseline median
+            [] // baseline bci high
+          ];
 
     for (const row of rows) {
       data[0].push(row.starttime);
-      if (row.branch == baseBranchName) {
-        if (row.iscurrent) {
+      if (baseBranchName === null || row.branch == baseBranchName) {
+        if (baseBranchName !== null && row.iscurrent) {
           baseTimestamp = row.starttime;
         }
         data[1].push(row.bci95low);
         data[2].push(row.median);
         data[3].push(row.bci95up);
-        data[4].push(null);
-        data[5].push(null);
-        data[6].push(null);
+        if (baseBranchName !== null) {
+          (<FullPlotData>data)[4].push(null);
+          (<FullPlotData>data)[5].push(null);
+          (<FullPlotData>data)[6].push(null);
+        }
       } else {
         if (row.iscurrent) {
           changeTimestamp = row.starttime;
@@ -1237,9 +1349,11 @@ export abstract class Database {
         data[1].push(null);
         data[2].push(null);
         data[3].push(null);
-        data[4].push(row.bci95low);
-        data[5].push(row.median);
-        data[6].push(row.bci95up);
+        if (baseBranchName !== null) {
+          (<FullPlotData>data)[4].push(row.bci95low);
+          (<FullPlotData>data)[5].push(row.median);
+          (<FullPlotData>data)[6].push(row.bci95up);
+        }
       }
     }
 
@@ -1249,6 +1363,35 @@ export abstract class Database {
       baseTimestamp,
       changeTimestamp,
       data
+    };
+  }
+
+  private constructTimelineQueryForRun(
+    projectId: number, runId: number
+  ): QueryConfig {
+    const sql = `
+      SELECT
+        extract(epoch from tr.startTime at time zone 'UTC')::int as startTime,
+        s.branchOrTag as branch,
+        ti.median, ti.bci95low, ti.bci95up
+      FROM Timeline ti
+        JOIN Trial      tr ON tr.id = ti.trialId
+        JOIN Source     s  ON tr.sourceId = s.id
+        JOIN Experiment e  ON tr.expId = e.id
+        JOIN Project    p  ON p.id = e.projectId
+        JOIN Run        r  ON r.id = ti.runId
+        JOIN Criterion  c  ON ti.criterion = c.id
+      WHERE
+        s.branchOrTag = p.baseBranch AND
+        p.id = $1   AND
+        r.id = $2   AND
+        c.name   = 'total'
+      ORDER BY tr.startTime ASC;
+    `;
+    return {
+      name: 'get-timeline-data-for-pid-runid',
+      text: sql,
+      values: [projectId, runId]
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,8 +66,10 @@ router.get('/:projectName', async (ctx) => {
 });
 
 router.get('/timeline/:projectId', async (ctx) => {
+  const projectId = Number(ctx.params.projectId);
   ctx.body = processTemplate('timeline.html', {
-    project: await db.getProject(Number(ctx.params.projectId))
+    project: await db.getProject(projectId),
+    benchmarks: await db.getLatestBenchmarksForTimelineView(projectId)
   });
   ctx.type = 'html';
 });
@@ -119,8 +121,14 @@ router.get('/rebenchdb/dash/:projectId/benchmarks', async (ctx) => {
   await completeRequest(start, db, 'project-benchmarks');
 });
 
-router.get('/rebenchdb/dash/:projectId/timeline', async (ctx) => {
-  ctx.body = await dashTimelineForProject(db, Number(ctx.params.projectId));
+router.get('/rebenchdb/dash/:projectId/timeline/:runId', async (ctx) => {
+  ctx.body = await db.getTimelineForRun(
+    Number(ctx.params.projectId),
+    Number(ctx.params.runId)
+  );
+  if (ctx.body === null) {
+    ctx.status = 500;
+  }
   ctx.type = 'application/json';
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ import {
   dashCompare,
   dashProjects,
   dashBenchmarksForProject,
-  dashTimelineForProject,
   dashDataOverview,
   dashGetExpData,
   reportCompletion,

--- a/src/views/compare.html
+++ b/src/views/compare.html
@@ -14,7 +14,7 @@
 
   <script src="/static/compare.js" type="module"></script>
 </head>
-<body class="compare">
+<body class="compare timeline-multi">
 
 <header>
 <div class="jumbotron compare">

--- a/src/views/compare.ts
+++ b/src/views/compare.ts
@@ -1,3 +1,4 @@
+import { initializeFilters } from './filter.js';
 import { renderComparisonTimelinePlot } from './plots.js';
 
 function determineAndDisplaySignificance() {
@@ -125,80 +126,6 @@ function insertProfiles(e) {
   }
 }
 
-function initializeFilters(): void {
-  const allGroups = $('.exe-suite-group');
-  const byName = new Map();
-  const groups: string[][] = [];
-
-  allGroups.each((_, group) => {
-    const namesInGroup: string[] = [];
-    groups.push(namesInGroup);
-
-    $(group)
-      .find('.benchmark-details tbody th:nth-child(1)')
-      .each((_, element) => {
-        const name = <string>element.textContent?.trim();
-        if (!byName.has(name)) {
-          byName.set(name, []);
-          namesInGroup.push(name);
-        }
-
-        byName.get(name).push(element);
-      });
-
-    // make sure we don't have empty groups
-    if (namesInGroup.length == 0) {
-      groups.pop();
-    }
-  });
-
-  let nameCheckBoxes = '';
-
-  for (const group of groups) {
-    nameCheckBoxes += '<div class="card card-body text-white bg-secondary">';
-    nameCheckBoxes += '<div class="card-text">';
-
-    for (const name of group) {
-      nameCheckBoxes += `
-        <div class="form-check">
-        <input type="checkbox"
-          class="form-check-input" id="filter-${name}" value="${name}" checked>
-        <label class="form-check-label" for="filter-${name}">${name}</label>
-        </div>`;
-    }
-
-    nameCheckBoxes += '</div></div>';
-  }
-  $('#filter-groups').html(nameCheckBoxes);
-  $('#filter-groups .card-body input').on('change', (e) => {
-    const checkBoxJQ = $(e.currentTarget);
-    const name = checkBoxJQ.val();
-    const nameElements = byName.get(name);
-    if (checkBoxJQ.is(':checked')) {
-      for (const nameElem of nameElements) {
-        const nameElemJQ = $(nameElem);
-        nameElemJQ.parent().show();
-        nameElemJQ.closest('.exe-suite-group').show();
-      }
-    } else {
-      for (const nameElem of nameElements) {
-        const nameElemJQ = $(nameElem);
-        nameElemJQ.parent().hide();
-        if (nameElemJQ.closest('tbody').find('tr:visible').length == 0) {
-          nameElemJQ.closest('.exe-suite-group').hide();
-        }
-      }
-    }
-  });
-
-  $('#filter-all').on('click', () =>
-    $('#filter-groups input').prop('checked', true).trigger('change')
-  );
-  $('#filter-none').on('click', () =>
-    $('#filter-groups input').prop('checked', false).trigger('change')
-  );
-}
-
 async function fetchPost(url: string, data: any): Promise<any> {
   const response = await fetch(url, {
     method: 'POST',
@@ -275,5 +202,5 @@ $(() => {
     expandButtons.each((i, elm) => insertWarmupPlot(elm));
   });
 
-  initializeFilters();
+  initializeFilters('.benchmark-details tbody th:nth-child(1)');
 });

--- a/src/views/filter.ts
+++ b/src/views/filter.ts
@@ -1,0 +1,74 @@
+export function initializeFilters(benchmarkNameSelector: string): void {
+  const allGroups = $('.exe-suite-group');
+  const byName = new Map();
+  const groups: string[][] = [];
+
+  allGroups.each((_, group) => {
+    const namesInGroup: string[] = [];
+    groups.push(namesInGroup);
+
+    $(group)
+      .find(benchmarkNameSelector)
+      .each((_, element) => {
+        const name = <string>element.textContent?.trim();
+        if (!byName.has(name)) {
+          byName.set(name, []);
+          namesInGroup.push(name);
+        }
+
+        byName.get(name).push(element);
+      });
+
+    // make sure we don't have empty groups
+    if (namesInGroup.length == 0) {
+      groups.pop();
+    }
+  });
+
+  let nameCheckBoxes = '';
+
+  for (const group of groups) {
+    nameCheckBoxes += '<div class="card card-body text-white bg-secondary">';
+    nameCheckBoxes += '<div class="card-text">';
+
+    for (const name of group) {
+      nameCheckBoxes += `
+        <div class="form-check">
+        <input type="checkbox"
+          class="form-check-input" id="filter-${name}" value="${name}" checked>
+        <label class="form-check-label" for="filter-${name}">${name}</label>
+        </div>`;
+    }
+
+    nameCheckBoxes += '</div></div>';
+  }
+
+  $('#filter-groups').html(nameCheckBoxes);
+  $('#filter-groups .card-body input').on('change', (e) => {
+    const checkBoxJQ = $(e.currentTarget);
+    const name = checkBoxJQ.val();
+    const nameElements = byName.get(name);
+    if (checkBoxJQ.is(':checked')) {
+      for (const nameElem of nameElements) {
+        const nameElemJQ = $(nameElem);
+        nameElemJQ.parent().show();
+        nameElemJQ.closest('.exe-suite-group').show();
+      }
+    } else {
+      for (const nameElem of nameElements) {
+        const nameElemJQ = $(nameElem);
+        nameElemJQ.parent().hide();
+        if (nameElemJQ.closest('tbody').find('tr:visible').length == 0) {
+          nameElemJQ.closest('.exe-suite-group').hide();
+        }
+      }
+    }
+  });
+
+  $('#filter-all').on('click', () =>
+    $('#filter-groups input').prop('checked', true).trigger('change')
+  );
+  $('#filter-none').on('click', () =>
+    $('#filter-groups input').prop('checked', false).trigger('change')
+  );
+}

--- a/src/views/header.html
+++ b/src/views/header.html
@@ -8,6 +8,4 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 
-<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-
 <link rel="stylesheet" href="/static/style.css">

--- a/src/views/plots.ts
+++ b/src/views/plots.ts
@@ -158,7 +158,7 @@ function formatMs(_, val) {
 }
 
 function seriesConfig(
-  branchName: string,
+  branchName: string | null,
   metric: string,
   color: string,
   width: number,
@@ -166,7 +166,9 @@ function seriesConfig(
   largerPointFill: string | undefined = undefined
 ) {
   let label;
-  if (branchName !== '' && metric !== '') {
+  if (branchName === null && metric !== '') {
+    label = metric;
+  } else if (branchName !== '' && metric !== '') {
     label = `${branchName} ${metric}`;
   } else {
     label = '';
@@ -237,6 +239,40 @@ function addDataSeriesToHighlightResult(
   }
 }
 
+export function renderTimelinePlot(
+  response: TimelineResponse,
+  jqInsert: any
+): any {
+  const series = [
+    {},
+    seriesConfig(null, 'BCI 95th, low', baselineLight, 1),
+    seriesConfig(null, 'Median', baselineColor, 2),
+    seriesConfig(null, 'BCI 95th, high', baselineLight, 1),
+  ];
+
+  const options = {
+    width: 800,
+    height: 240,
+    title: 'Run time in ms',
+    tzDate: (ts: number) => uPlot.tzDate(new Date(ts * 1000), 'UTC'),
+    scales: { x: {}, y: {} },
+    series,
+    bands: [
+      { series: [1, 2], fill: baselineLight, dir: 1 },
+      { series: [2, 3], fill: baselineLight, dir: 1 }
+    ],
+    axes: [
+      {},
+      {
+        values: (_, vals) => vals.map((v) => v + 'ms'),
+        size: computeAxisLabelSpace
+      }
+    ]
+  };
+
+  return new uPlot(options, response.data, jqInsert[0]);
+}
+
 export function renderComparisonTimelinePlot(
   response: TimelineResponse,
   jqInsert: any
@@ -274,7 +310,7 @@ export function renderComparisonTimelinePlot(
   const options = {
     width: 576,
     height: 240,
-    title: 'Runtime in ms',
+    title: 'Run time in ms',
     tzDate: (ts: number) => uPlot.tzDate(new Date(ts * 1000), 'UTC'),
     scales: { x: {}, y: {} },
     series,

--- a/src/views/plots.ts
+++ b/src/views/plots.ts
@@ -1,6 +1,4 @@
 import type { PlotData, TimelineResponse } from 'api';
-import type { Data } from 'plotly.js';
-declare const Plotly: any;
 import uPlot from '/static/uPlot.esm.min.js';
 
 function simpleSlug(str) {

--- a/src/views/render.ts
+++ b/src/views/render.ts
@@ -1,5 +1,5 @@
 import { AllResults } from 'api.js';
-import { renderResultsPlots, renderTimelinePlot } from './plots.js';
+import { renderResultsPlots } from './plots.js';
 
 function filterCommitMessage(msg) {
   const result = msg.replace(/Signed-off-by:.*?\n/g, '');
@@ -228,54 +228,4 @@ export async function populateStatistics(statsP: any): Promise<void> {
   table.append(
     `<tr class="table-info"><td>Version</td><td>${stats.version}</td></tr>`
   );
-}
-
-export function renderTimelinePlots(data: any): void {
-  // prepare data
-  const benchmarks = new Map();
-  const trials = new Map();
-
-  for (const trial of data.details) {
-    trial.start = new Date(trial.starttime);
-    trials.set(trial.trialid, trial);
-  }
-
-  for (const result of data.timeline) {
-    const key =
-      `plot-${result.benchmarkid}-${result.suiteid}` +
-      `-${result.execid}-${result.hostname}`;
-    if (!benchmarks.has(key)) {
-      benchmarks.set(key, []);
-    }
-
-    const results = benchmarks.get(key);
-    result.trial = trials.get(result.trialid);
-    results.push(result);
-  }
-
-  (<any>$).appear('.timeline-plot');
-  $('.timeline-plot').on('appear', function (_event, allAppearedElements) {
-    let delay = 0;
-    allAppearedElements.each(function (this: any) {
-      triggerRendering($(this), benchmarks, delay);
-      delay += 1;
-    });
-  });
-
-  // and force render first 6
-  let delay = 0;
-  $('.timeline-plot')
-    .slice(0, 5)
-    .each(function () {
-      triggerRendering($(this), benchmarks, delay);
-      delay += 1;
-    });
-}
-
-function triggerRendering(elem, benchmarks, delay) {
-  const id = elem.prop('id');
-  const results = benchmarks.get(id);
-  setTimeout(() => {
-    renderTimelinePlot(id, results);
-  }, 130 * delay);
 }

--- a/src/views/render.ts
+++ b/src/views/render.ts
@@ -1,3 +1,4 @@
+import { AllResults } from 'api.js';
 import { renderResultsPlots, renderTimelinePlot } from './plots.js';
 
 function filterCommitMessage(msg) {
@@ -174,11 +175,11 @@ function renderAllResults(project) {
 
   const resultsP = fetch(`/rebenchdb/dash/${project.id}/results`);
   resultsP.then(async (resultsResponse) => {
-    const results = await resultsResponse.json();
-    renderResultsPlots(results.timeSeries, project.id);
+    const results = <AllResults[]>await resultsResponse.json();
+    renderResultsPlots(results, project.id);
   });
 
-  return `<div id="p${project.id}-results"></div>`;
+  return `<div id="p${project.id}-results" class="timeline-single"></div>`;
 }
 
 export function renderProject(project: any): string {
@@ -227,54 +228,6 @@ export async function populateStatistics(statsP: any): Promise<void> {
   table.append(
     `<tr class="table-info"><td>Version</td><td>${stats.version}</td></tr>`
   );
-}
-
-export function renderBenchmarks(benchmarks: any): void {
-  let suiteName = null;
-  let content = '';
-  for (const benchmark of benchmarks) {
-    if (suiteName !== benchmark.suitename) {
-      if (content !== '') {
-        content += '</div>'; // closing card-columns
-        $('#benchmarks').append(content);
-        content = '';
-      }
-
-      content += `<h3>${benchmark.suitename}</h3>`;
-      suiteName = benchmark.suitename;
-      content += `<div class="card-columns">`;
-    }
-
-    content += renderBenchmark(benchmark);
-  }
-
-  // handling the last benchmark suite
-  if (content !== '') {
-    content += '</div>'; // closing card-columns
-    $('#benchmarks').append(content);
-  }
-}
-
-function renderBenchmark(benchmark) {
-  const cmdline = simplifyCmdline(benchmark.cmdline);
-
-  const plotId =
-    `${benchmark.benchid}-${benchmark.suiteid}` +
-    `-${benchmark.execid}-${benchmark.hostname}`;
-  const result = `
-    <div class="card">
-      <div class="card-body">
-        <h5 class="card-title">${benchmark.benchmark}</h5>
-        <p class="card-text"><small class="text-muted">
-        ${benchmark.execname}, ${benchmark.hostname}<br/>
-        <code>${cmdline}</code></small></p>
-        <div class="timeline-plot"
-          id="plot-${plotId}"
-          class="card-img-top"></div>
-      </div>
-    </div>`;
-
-  return result;
 }
 
 export function renderTimelinePlots(data: any): void {

--- a/src/views/render.ts
+++ b/src/views/render.ts
@@ -255,13 +255,6 @@ export function renderBenchmarks(benchmarks: any): void {
   }
 }
 
-export function simplifyCmdline(cmdline: string): string {
-  // remove the beginning of the path, leaving only the last element of it
-  // this regex is also used in somns.Rmd, the suites part, for creating a table
-  const pathRegex = /^([^\s]*)\/([^\s]+\s.*$)/;
-  return cmdline.replace(pathRegex, '$2');
-}
-
 function renderBenchmark(benchmark) {
   const cmdline = simplifyCmdline(benchmark.cmdline);
 

--- a/src/views/timeline.html
+++ b/src/views/timeline.html
@@ -7,14 +7,35 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.appear/0.4.1/jquery.appear.min.js" integrity="sha256-19/eyBKQKb8IPrt7321hbLkI1+xyM8d/DpzjyiEKnCE=" crossorigin="anonymous"></script>
   <script src="/static/timeline.js" type="module"></script>
 </head>
-<body class="timeline-multi">
+<body class="timeline-multi timeline">
 
+<header>
   <div class="jumbotron">
     <h1 class="display-4">ReBench: Timeline {{project.name}}</h1>
     {{#project.description}}
     <h2 class="display-5">{{project.description}}</h2>
     {{/project.description}}
   </div>
+  <div class="refresh">
+    <div class="flex-nowrap navbar-light">
+      <button type="button" class="btn btn-outline-secondary btn-sm"
+          data-toggle="collapse" data-target="#filters" aria-controls="#filters"
+          aria-expanded="false" aria-label="Toggle Filters">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-funnel" viewBox="0 0 16 16">
+          <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5v-2zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2h-11z"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+</header>
+
+<div class="collapse card-columns" id="filters">
+  <div>
+    <button type="button" class="btn btn-secondary" id="filter-all">All</button>
+    <button type="button" class="btn btn-secondary" id="filter-none">None</button>
+  </div>
+  <div id="filter-groups"></div>
+</div>
 
   {{#benchmarks}}
   {{#exec}}
@@ -23,10 +44,12 @@
     <div class="title-executor">Executor: {{execName}}</div>
 
     {{#benchmarks}}
+    <div class="benchmark">
     <h4>{{benchName}}</h4>
     <p>{{cmdline}}</p>
 
     <div class="timeline-plot" data-runid="{{runId}}"></div>
+    </div>
     {{/benchmarks}}
   </div>
 

--- a/src/views/timeline.html
+++ b/src/views/timeline.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.appear/0.4.1/jquery.appear.min.js" integrity="sha256-19/eyBKQKb8IPrt7321hbLkI1+xyM8d/DpzjyiEKnCE=" crossorigin="anonymous"></script>
   <script src="/static/timeline.js" type="module"></script>
 </head>
-<body>
+<body class="timeline-multi">
 
   <div class="jumbotron">
     <h1 class="display-4">ReBench: Timeline {{project.name}}</h1>

--- a/src/views/timeline.html
+++ b/src/views/timeline.html
@@ -25,6 +25,12 @@
           <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5v-2zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2h-11z"/>
         </svg>
       </button>
+      <button class="navbar-toggler" type="button" data-toggle="collapse"
+          data-target="nav.compare" aria-controls="nav.compare"
+          aria-expanded="false" aria-label="Toggle Outline"
+          id="report-nav-toggler">
+        <span class="navbar-toggler-icon"></span>
+      </button>
     </div>
   </div>
 </header>
@@ -37,6 +43,19 @@
   <div id="filter-groups"></div>
 </div>
 
+
+<div class="container-fluid"><div class="row flex-xl-nowrap">
+  <nav class="compare">
+  {{#benchmarks}}
+  {{#exec}}
+      <nav><span>{{execName}}</span>
+      <a href="#se-{{suiteId}}-{{execId}}">{{suiteName}}</a>
+      </nav>
+  {{/exec}}
+  {{/benchmarks}}
+  </nav>
+
+  <main role="main">
   {{#benchmarks}}
   {{#exec}}
   <div class="exe-suite-group">
@@ -55,5 +74,7 @@
 
   {{/exec}}
   {{/benchmarks}}
+  </main>
+  </div></div> <!-- closing class="row flex-nowrap" and class="container-fluid" -->
 </body>
 </html>

--- a/src/views/timeline.html
+++ b/src/views/timeline.html
@@ -16,6 +16,21 @@
     {{/project.description}}
   </div>
 
-  <div id="benchmarks"></div>
+  {{#benchmarks}}
+  {{#exec}}
+  <div class="exe-suite-group">
+    <h3 id="se-{{suiteId}}-{{execId}}">{{suiteName}}</h3>
+    <div class="title-executor">Executor: {{execName}}</div>
+
+    {{#benchmarks}}
+    <h4>{{benchName}}</h4>
+    <p>{{cmdline}}</p>
+
+    <div class="timeline-plot" data-runid="{{runId}}"></div>
+    {{/benchmarks}}
+  </div>
+
+  {{/exec}}
+  {{/benchmarks}}
 </body>
 </html>

--- a/src/views/timeline.ts
+++ b/src/views/timeline.ts
@@ -1,4 +1,5 @@
 import type { TimelineResponse } from 'api.js';
+import { initializeFilters } from './filter.js';
 import { renderTimelinePlot } from './plots.js';
 
 const projectId = $('#project-id').attr('value');
@@ -35,4 +36,6 @@ $(async () => {
       loadPlotOnce.call(e);
     }
   });
+
+  initializeFilters('.benchmark > h4');
 });

--- a/src/views/util.ts
+++ b/src/views/util.ts
@@ -1,0 +1,7 @@
+const pathRegex = /^([^\s]*)\/([^\s]+\s.*$)/;
+
+export function simplifyCmdline(cmdline: string): string {
+  // remove the beginning of the path, leaving only the last element of it
+  // this regex is also used in somns.Rmd, the suites part, for creating a table
+  return cmdline.replace(pathRegex, '$2');
+}

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-import { simplifyCmdline } from '../src/views/render';
+import { simplifyCmdline } from '../src/views/util';
 
 describe('Helper Functions for Rendering', () => {
   describe('Simplifying the command-line for display', () => {


### PR DESCRIPTION
The main motivation of this change is to improve the performance of the timeline view.
Since there are hundreds of timelines, Plotly.js ends up being very slow.
Because it uses SVG, it takes much more resources than uPlot, which renders directly on the canvas, and which we used already in the comparison view.

The other goal was the bring the different ways of requesting "over time" data closer together.
There are:
 - the timeline view
 - the timeline plots on the comparison view
 - and the result view on the main page and project page

The code now uses mostly the same data format, except for the result view, where we avoid transferring arrays filled with nulls and indexes to minimize the data transfer.

### Minor Features
 - added the same filter mechanism as on comparison view
 - added the navigation features as on comparison view

### Other Changes

- the SQL query in `dashResults` was refactored a little for readability, includes the check for the criterion, and aggregates the result into the result array directly.
- `constructTimelineQueryForRun` is basically the same as the sql query for the timeline view, but uses the run id to identify the data
- removed Plotly
- render the list of benchmarks for the timeline view on the server to avoid another roundtrip
