### PR TITLE
Redesign user-visible URLs

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync, unlinkSync, rmSync } from 'fs';
 import { execFile, ChildProcessPromise } from 'promisify-child-process';
-import { Database, DatabaseConfig, Project, Source } from './db.js';
+import { Database, DatabaseConfig, Source } from './db.js';
 import { startRequest, completeRequest } from './perf-tracker.js';
 import { AllResults, BenchmarkCompletion } from './api.js';
 import { GitHub } from './github.js';
@@ -19,13 +19,6 @@ JOIN Experiment exp ON exp.sourceId = s.id
 JOIN Measurement m ON  m.expId = exp.id
 WHERE repoURL = 'https://github.com/smarr/ReBenchDB'
  */
-
-export async function dashProjects(
-  db: Database
-): Promise<{ projects: Project[] }> {
-  const result = await db.query(`SELECT * from Project`);
-  return { projects: result.rows };
-}
 
 export async function dashResults(
   projectId: number,
@@ -270,7 +263,11 @@ export async function dashCompare(
     completionPromise: Promise.resolve()
   };
 
-  const revDetails = await db.revisionsExistInProject(projectSlug, base, change);
+  const revDetails = await db.revisionsExistInProject(
+    projectSlug,
+    base,
+    change
+  );
   if (!revDetails.dataFound) {
     data.generationFailed = true;
     data.stdout =

--- a/src/db.ts
+++ b/src/db.ts
@@ -482,7 +482,7 @@ export abstract class Database {
     projectSlug: string,
     base: string,
     change: string
-  ): Promise<any> {
+  ): Promise<{ dataFound: boolean; base?: any; change?: any }> {
     const result = await this.query(this.queries.fetchRevsInProject, [
       projectSlug,
       base,

--- a/src/db.ts
+++ b/src/db.ts
@@ -246,8 +246,12 @@ export abstract class Database {
                          WHERE expId = $1 AND endTime IS NULL`,
 
     fetchProjectByName: 'SELECT * from Project WHERE name = $1',
-    fetchProjectBySlugName: `SELECT * from Project
-                               WHERE lower($1) = lower(slug)`,
+    fetchProjectBySlugName: {
+      name: 'fetchProjectBySlugName',
+      text: `SELECT * from Project
+              WHERE lower($1) = lower(slug)`,
+      values: ['']
+    },
     fetchProjectById: 'SELECT * from Project WHERE id = $1',
     fetchAllProjects: {
       name: 'fetchAllProjects',
@@ -675,9 +679,9 @@ export abstract class Database {
   public async getProjectBySlug(
     projectNameSlug: string
   ): Promise<Project | undefined> {
-    const result = await this.query(this.queries.fetchProjectBySlugName, [
-      projectNameSlug
-    ]);
+    const q = { ...this.queries.fetchProjectBySlugName };
+    q.values = [projectNameSlug];
+    const result = await this.query(q);
 
     if (result.rowCount !== 1) {
       return undefined;

--- a/src/db.ts
+++ b/src/db.ts
@@ -249,6 +249,10 @@ export abstract class Database {
     fetchProjectBySlugName: `SELECT * from Project
                                WHERE lower($1) = lower(slug)`,
     fetchProjectById: 'SELECT * from Project WHERE id = $1',
+    fetchAllProjects: {
+      name: 'fetchAllProjects',
+      text: 'SELECT * FROM Project'
+    },
     insertProject: `INSERT INTO Project (name, slug)
                       VALUES ($1, regexp_replace($1, '[^0-9a-zA-Z-]', '-', 'g'))
                     RETURNING *`,
@@ -692,6 +696,11 @@ export abstract class Database {
       return undefined;
     }
     return result.rows[0];
+  }
+
+  public async getAllProjects(): Promise<Project[]> {
+    const result = await this.query(this.queries.fetchAllProjects);
+    return result.rows;
   }
 
   public async getProject(projectId: number): Promise<Project | undefined> {

--- a/src/db.ts
+++ b/src/db.ts
@@ -258,7 +258,7 @@ export abstract class Database {
       text: 'SELECT * FROM Project'
     },
     insertProject: `INSERT INTO Project (name, slug)
-                      VALUES ($1, regexp_replace($1, '[^0-9a-zA-Z-]', '-', 'g'))
+                      VALUES ($1, regexp_replace($2, '[^0-9a-zA-Z-]', '-', 'g'))
                     RETURNING *`,
 
     fetchExpByNames: `SELECT e.* FROM Experiment e
@@ -672,7 +672,7 @@ export abstract class Database {
       this.queries.fetchProjectByName,
       [projectName],
       this.queries.insertProject,
-      [projectName]
+      [projectName, projectName]
     );
   }
 

--- a/src/db/db.sql
+++ b/src/db/db.sql
@@ -67,6 +67,7 @@ CREATE TABLE Criterion (
 CREATE TABLE Project (
   id serial primary key,
   name varchar unique,
+  slug varchar unique,
   description text,
   logo varchar,
   showChanges bool DEFAULT true,

--- a/src/db/migration.005.sql
+++ b/src/db/migration.005.sql
@@ -1,0 +1,5 @@
+-- add slug column
+ALTER TABLE Project ADD COLUMN slug varchar unique;
+
+-- populate the slug column by replacing all non-save-characters with a dash
+UPDATE Project SET slug = regexp_replace(name, '[^0-9a-zA-Z-]', '-', 'g');

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ import {
   dashStatistics,
   dashChanges,
   dashCompare,
-  dashProjects,
   dashBenchmarksForProject,
   dashDataOverview,
   dashGetExpData,
@@ -53,7 +52,8 @@ const router = new Router();
 const db = new DatabaseWithPool(dbConfig, 1000, true);
 
 router.get('/', async (ctx) => {
-  ctx.body = processTemplate('index.html');
+  const projects = await db.getAllProjects();
+  ctx.body = processTemplate('index.html', { projects });
   ctx.type = 'html';
 });
 
@@ -145,11 +145,6 @@ router.get('/:projectSlug/data/:expId', async (ctx) => {
   }
 
   await completeRequest(start, db, 'get-exp-data');
-});
-
-router.get(`/rebenchdb/dash/projects`, async (ctx) => {
-  ctx.body = await dashProjects(db);
-  ctx.type = 'application/json';
 });
 
 router.get('/rebenchdb/dash/:projectId/results', async (ctx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,33 +57,83 @@ router.get('/', async (ctx) => {
   ctx.type = 'html';
 });
 
-router.get('/:projectName', async (ctx) => {
-  ctx.body = processTemplate('project.html', {
-    project: await db.getProjectBySlug(ctx.params.projectName)
-  });
-  ctx.type = 'html';
+router.get('/:projectSlug', async (ctx) => {
+  const project = await db.getProjectBySlug(ctx.params.projectSlug);
+  if (project) {
+    ctx.body = processTemplate('project.html', { project });
+    ctx.type = 'html';
+  } else {
+    respondProjectNotFound(ctx, ctx.params.projectSlug);
+  }
 });
 
+function respondProjectIdNotFound(ctx, projectId: number) {
+  ctx.body = `Requested project with id ${projectId} not found`;
+  ctx.status = 404;
+  ctx.type = 'text';
+}
+
+function respondProjectNotFound(ctx, projectSlug: string) {
+  ctx.body = `Requested project "${projectSlug}" not found`;
+  ctx.status = 404;
+  ctx.type = 'text';
+}
+
 router.get('/timeline/:projectId', async (ctx) => {
-  const projectId = Number(ctx.params.projectId);
-  ctx.body = processTemplate('timeline.html', {
-    project: await db.getProject(projectId),
-    benchmarks: await db.getLatestBenchmarksForTimelineView(projectId)
-  });
-  ctx.type = 'html';
+  const project = await db.getProject(Number(ctx.params.projectId));
+  if (project) {
+    ctx.redirect(`/${project.slug}/timeline`);
+  } else {
+    respondProjectIdNotFound(ctx, Number(ctx.params.projectId));
+  }
+});
+
+router.get('/:projectSlug/timeline', async (ctx) => {
+  const project = await db.getProjectBySlug(ctx.params.projectSlug);
+
+  if (project) {
+    ctx.body = processTemplate('timeline.html', {
+      project,
+      benchmarks: await db.getLatestBenchmarksForTimelineView(project.id)
+    });
+    ctx.type = 'html';
+  } else {
+    respondProjectNotFound(ctx, ctx.params.projectSlug);
+  }
 });
 
 router.get('/project/:projectId', async (ctx) => {
+  const project = await db.getProject(Number(ctx.params.projectId));
+  if (project) {
+    ctx.redirect(`/${project.slug}/data`);
+  } else {
+    respondProjectIdNotFound(ctx, Number(ctx.params.projectId));
+  }
   ctx.body = processTemplate('project-data.html', {
     project: await db.getProject(Number(ctx.params.projectId))
   });
   ctx.type = 'html';
 });
 
-router.get('/rebenchdb/get-exp-data/:expId', async (ctx) => {
+router.get('/:projectSlug/data', async (ctx) => {
+  const project = await db.getProjectBySlug(ctx.params.projectSlug);
+  if (project) {
+    ctx.body = processTemplate('project-data.html', { project });
+    ctx.type = 'html';
+  } else {
+    respondProjectNotFound(ctx, ctx.params.projectSlug);
+  }
+});
+
+router.get('/:projectSlug/data/:expId', async (ctx) => {
   const start = startRequest();
 
-  const data = await dashGetExpData(Number(ctx.params.expId), dbConfig, db);
+  const data = await dashGetExpData(
+    ctx.params.projectSlug,
+    Number(ctx.params.expId),
+    dbConfig,
+    db
+  );
 
   if (data.preparingData) {
     ctx.body = processTemplate('get-exp-data.html', data);
@@ -163,12 +213,23 @@ router.get('/rebenchdb/dash/:projectId/data-overview', async (ctx) => {
 });
 
 router.get('/compare/:project/:baseline/:change', async (ctx) => {
+  const project = await db.getProjectByName(ctx.params.project);
+  if (project) {
+    ctx.redirect(
+      `/${project.slug}/compare/${ctx.params.baseline}..${ctx.params.change}`
+    );
+  } else {
+    respondProjectNotFound(ctx, ctx.params.project);
+  }
+});
+
+router.get('/:projectSlug/compare/:baseline..:change', async (ctx) => {
   const start = startRequest();
 
   const data = await dashCompare(
     ctx.params.baseline,
     ctx.params.change,
-    ctx.params.project,
+    ctx.params.projectSlug,
     dbConfig,
     db
   );

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -23,7 +23,55 @@
     <a href="https://rebench.readthedocs.io/"><img src="https://img.shields.io/badge/Documentation-Go-informational"></a>
   </div>
 
-  <div id="projects"></div>
+  <div id="projects">
+    {{#projects}}
+    <div class="card project-data" data-id="{{ id }}" data-showchanges="{{ showchanges }}" data-allresults="{{ allresults }}">
+      <h5 class="card-header" id="{{ slug }}"><a
+        href="/{{ slug }}/data">{{ name }}</a></h5>
+      <div class="card-body">
+        {{#showchanges}}
+        <h5>Changes</h5>
+        <div class="container min-padding"><div class="row">
+          <div class="col-sm min-padding scroll-list">
+            <div class="list-group baseline" id="p{{ id }}-baseline"
+              data-project-slug="{{ slug }}"></div>
+          </div>
+          <div class="col-sm min-padding scroll-list">
+            <div class="list-group change" id="p{{ id }}-change"></div>
+          </div>
+        </div></div>
+
+        <a class="btn btn-primary" id="p{{ id }}-compare">Compare</a>
+        {{/showchanges}}
+        {{#allresults}}
+        <div id="p{{ id }}-results" class="timeline-single"></div>
+        {{/allresults}}
+        <a href="/{{ slug }}/timeline">Timeline</a>
+      </div>
+    </div>
+    {{/projects}}
+    {{^projects}}
+    <div class="card">
+      <h5 class="card-header" id="setup-info">
+        Welcome to your ReBenchDB Instance</h5>
+      <div class="card-body">
+        <p>Currently, there are no projects available.</p>
+
+        <p>To get started, run your benchmarks with
+        <a href="https://rebench.readthedocs.io/">ReBench</a>
+        and add the following to your project's ReBench configuration file:</p>
+        <code><pre>reporting:
+  rebenchdb:
+    db_url: <span id="host-url"></span>rebenchdb
+    repo_url: https://url-to-your-project-repository
+    record_all: true # make sure everything is recorded
+    project_name: Your-Project-Name</pre></code>
+      </div></div>
+      <script>
+        document.getElementById('host-url').textContent = window.location.href;
+      </script>
+    {{/projects}}
+  </div>
 
   <div class="row">
     <div class="col-sm-6">

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -1,24 +1,26 @@
-import type { Project } from 'db.js';
 import {
   populateStatistics,
-  renderProject,
-  renderWelcomeAndSetupSuggestions
+  renderAllResults,
+  renderChanges
 } from './render.js';
 
-const projectsP = fetch(`/rebenchdb/dash/projects`);
 const statsP = fetch(`/rebenchdb/stats`);
 
 $(async () => {
-  const projectsResponse = await projectsP;
-  const projects = <Project[]>(await projectsResponse.json()).projects;
+  $('.project-data').each((_i, elem) => {
+    const elemJq = $(elem);
+    const showChanges = elemJq.data('showchanges');
+    const allResults = elemJq.data('allresults');
+    const projectId = elemJq.data('id');
 
-  if (projects.length > 0) {
-    for (const project of projects) {
-      $('#projects').append(renderProject(project));
+    if (showChanges) {
+      renderChanges(projectId);
     }
-  } else {
-    $('#projects').append(renderWelcomeAndSetupSuggestions());
-  }
+
+    if (allResults) {
+      renderAllResults(projectId);
+    }
+  });
 
   await populateStatistics(statsP);
 });

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -1,3 +1,4 @@
+import type { Project } from 'db.js';
 import {
   populateStatistics,
   renderProject,
@@ -9,7 +10,7 @@ const statsP = fetch(`/rebenchdb/stats`);
 
 $(async () => {
   const projectsResponse = await projectsP;
-  const projects = (await projectsResponse.json()).projects;
+  const projects = <Project[]>(await projectsResponse.json()).projects;
 
   if (projects.length > 0) {
     for (const project of projects) {

--- a/src/views/project.html
+++ b/src/views/project.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
   <title>ReBench: {{project.name}}</title>
-  <meta id="project-name" value="{{project.name}}">
   <meta id="project-id" value="{{project.id}}">
   <meta id="project-showchanges" value="{{project.showchanges}}">
   <meta id="project-allresults" value="{{project.allresults}}">
@@ -18,6 +17,32 @@
     {{/project.description}}
   </div>
 
-  <div id="project"></div>
+  <div id="project">
+    <div class="card">
+      <h5 class="card-header" id="{{ project.slug }}"><a
+        href="/{{ project.slug }}/data">{{ project.name }}</a></h5>
+      <div class="card-body">
+        {{#project.showchanges}}
+        <h5>Changes</h5>
+        <div class="container min-padding"><div class="row">
+          <div class="col-sm min-padding scroll-list">
+            <div class="list-group baseline" id="p{{ project.id }}-baseline"
+              data-project-slug="{{ project.slug }}"></div>
+          </div>
+          <div class="col-sm min-padding scroll-list">
+            <div class="list-group change" id="p{{ project.id }}-change"></div>
+          </div>
+        </div></div>
+
+        <a class="btn btn-primary" id="p{{ project.id }}-compare">Compare</a>
+        {{/project.showchanges}}
+        {{#project.allresults}}
+        <div id="p{{ project.id }}-results" class="timeline-single"></div>
+        {{/project.allresults}}
+        <div class="project-card-content"></div>
+        <a href="/{{ project.slug }}/timeline">Timeline</a>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/src/views/project.ts
+++ b/src/views/project.ts
@@ -1,12 +1,15 @@
-import { renderProject } from './render.js';
+import { renderChanges, renderAllResults } from './render.js';
 
 $(async () => {
-  const project = {
-    name: $('#project-name').attr('value'),
-    id: $('#project-id').attr('value'),
-    showchanges: $('#project-showchanges').attr('value') === 'true',
-    allresults: $('#project-allresults').attr('value') === 'true'
-  };
+  const projectId = <string>$('#project-id').attr('value');
+  const showChanges = $('#project-showchanges').attr('value') === 'true';
+  const allResults = $('#project-allresults').attr('value') === 'true';
 
-  $('#project').html(renderProject(project));
+  if (showChanges) {
+    renderChanges(projectId);
+  }
+
+  if (allResults) {
+    renderAllResults(projectId);
+  }
 });

--- a/src/views/render.ts
+++ b/src/views/render.ts
@@ -1,4 +1,5 @@
-import { AllResults } from 'api.js';
+import type { AllResults } from 'api.js';
+import type { Project } from 'db.js';
 import { renderResultsPlots } from './plots.js';
 
 function filterCommitMessage(msg) {
@@ -182,17 +183,17 @@ function renderAllResults(project) {
   return `<div id="p${project.id}-results" class="timeline-single"></div>`;
 }
 
-export function renderProject(project: any): string {
+export function renderProject(project: Project): string {
   const changes = renderChanges(project);
   const allResults = renderAllResults(project);
 
   const result = `<div class="card">
     <h5 class="card-header" id="${project.name}"><a
-      href="/project/${project.id}">${project.name}</a></h5>
+      href="/${project.slug}/data">${project.name}</a></h5>
     <div class="card-body">
       ${changes}
       ${allResults}
-      <a href="/timeline/${project.id}">Timeline</a>
+      <a href="/${project.slug}/timeline">Timeline</a>
     </div></div>`;
   return result;
 }

--- a/src/views/render.ts
+++ b/src/views/render.ts
@@ -1,5 +1,4 @@
 import type { AllResults } from 'api.js';
-import type { Project } from 'db.js';
 import { renderResultsPlots } from './plots.js';
 
 function filterCommitMessage(msg) {
@@ -82,34 +81,15 @@ export function renderProjectDataOverview(data: any[]): void {
   }
 }
 
-function renderChanges(project) {
-  if (!project.showchanges) {
-    return '';
-  }
-
-  const changesP = fetch(`/rebenchdb/dash/${project.id}/changes`);
+export function renderChanges(projectId: string): void {
+  const changesP = fetch(`/rebenchdb/dash/${projectId}/changes`);
   changesP.then(
     async (changesDetailsResponse) =>
-      await renderChangeDetails(changesDetailsResponse, project.id)
+      await renderChangeDetails(changesDetailsResponse, projectId)
   );
-
-  const changes = `
-    <h5>Changes</h5>
-    <div class="container min-padding"><div class="row">
-      <div class="col-sm min-padding scroll-list">
-        <div class="list-group baseline" id="p${project.id}-baseline"
-          data-project="${project.name}"></div>
-      </div>
-      <div class="col-sm min-padding scroll-list">
-        <div class="list-group change" id="p${project.id}-change"></div>
-      </div>
-    </div></div>
-
-    <a class="btn btn-primary" id="p${project.id}-compare">Compare</a>`;
-  return changes;
 }
 
-async function renderChangeDetails(changesDetailsResponse, projectId) {
+async function renderChangeDetails(changesDetailsResponse, projectId: string) {
   const details = await changesDetailsResponse.json();
 
   const p1baseline = $(`#p${projectId}-baseline`);
@@ -145,7 +125,7 @@ function setHref(event, projectId, isBaseline) {
   // every time a commit is clicked, check to see if both left and right
   // commit are defined. set link if that is true
   const baseJQ = $(`#p${projectId}-baseline`);
-  const projectName = baseJQ.data('project');
+  const projectSlug = baseJQ.data('project-slug');
 
   const clicked = $(event.currentTarget).data('hash');
   let baseline;
@@ -165,57 +145,16 @@ function setHref(event, projectId, isBaseline) {
 
   $(`#p${projectId}-compare`).attr(
     'href',
-    `/compare/${projectName}/${baseline}/${change}`
+    `/${projectSlug}/compare/${baseline}..${change}`
   );
 }
 
-function renderAllResults(project) {
-  if (!project.allresults) {
-    return '';
-  }
-
-  const resultsP = fetch(`/rebenchdb/dash/${project.id}/results`);
+export function renderAllResults(projectId: string): void {
+  const resultsP = fetch(`/rebenchdb/dash/${projectId}/results`);
   resultsP.then(async (resultsResponse) => {
     const results = <AllResults[]>await resultsResponse.json();
-    renderResultsPlots(results, project.id);
+    renderResultsPlots(results, projectId);
   });
-
-  return `<div id="p${project.id}-results" class="timeline-single"></div>`;
-}
-
-export function renderProject(project: Project): string {
-  const changes = renderChanges(project);
-  const allResults = renderAllResults(project);
-
-  const result = `<div class="card">
-    <h5 class="card-header" id="${project.name}"><a
-      href="/${project.slug}/data">${project.name}</a></h5>
-    <div class="card-body">
-      ${changes}
-      ${allResults}
-      <a href="/${project.slug}/timeline">Timeline</a>
-    </div></div>`;
-  return result;
-}
-
-export function renderWelcomeAndSetupSuggestions(): string {
-  const result = `<div class="card">
-  <h5 class="card-header" id="setup-info">
-    Welcome to your ReBenchDB Instance</h5>
-  <div class="card-body">
-    <p>Currently, there are no projects available.</p>
-
-    <p>To get started, run your benchmarks with
-    <a href="https://rebench.readthedocs.io/">ReBench</a>
-    and add the following to your project's ReBench configuration file:</p>
-    <code><pre>reporting:
-  rebenchdb:
-    db_url: ${window.location.href}rebenchdb
-    repo_url: https://url-to-your-project-repository
-    record_all: true # make sure everything is recorded
-    project_name: Your-Project-Name</pre></code>
-  </div></div>`;
-  return result;
 }
 
 export async function populateStatistics(statsP: any): Promise<void> {

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -7,7 +7,6 @@ import {
   dashStatistics,
   dashResults,
   dashChanges,
-  dashProjects,
   dashDataOverview,
   dashBenchmarksForProject
 } from '../src/dashboard';
@@ -102,7 +101,7 @@ describe('Test Dashboard with basic test data loaded', () => {
   });
 
   it('Should get a project', async () => {
-    const projects = (await dashProjects(db)).projects;
+    const projects = await db.getAllProjects();
     expect(projects).toHaveLength(1);
     expect(projects[0].name).toEqual('Small Example Project');
     expect(projects[0].id).toEqual(1);


### PR DESCRIPTION
The PR resolves #107.

Inspired by GitHub and GitLab, the new URL structure is:

- `/Project-Slug` - the project page
- `/Project-Slug/data` - for the data page
- `/Project-Slug/data/1836` - to generate the download
- `/Project-Slug/timeline`
- `/Project-Slug/compare/sha1..sha2`

The old URLs remain supported, since people have access to them on various archives/Slack instances, but the redirect to the new ones.

#### Code Changes

This introduces a `slug` column in the project table, which is a converted version of the name, replacing all non-trivial characters ([^0-9a-zA-Z-]) with a dash `-`. One may want to relax that in the future...

Slugs are always compared case-insensitively.

If a project isn't found, we show now a proper error.

Much of the client-side rendering is now moved to the server to reduce the number of round-trips.