### PR TITLE
Cache statistics and self-tracking results on front page for at least 5min

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -35,8 +35,10 @@ export async function dashResults(
     return resultsCache[projectId];
   }
 
+  if (resultsCacheValid === null || !resultsCacheValid.isValid()) {
+    resultsCache.length = 0;
+  }
   resultsCacheValid = db.getStatsCacheValidity();
-  resultsCache.length = 0;
 
   const q: QueryConfig = {
     name: 'all-results',

--- a/src/db.ts
+++ b/src/db.ts
@@ -435,7 +435,7 @@ export abstract class Database {
 
   private static readonly batchN = 50;
 
-  private statsValid: TimedCacheValidity;
+  protected statsValid: TimedCacheValidity;
 
   constructor(
     config: PoolConfig,
@@ -1574,6 +1574,7 @@ export class DatabaseWithPool extends Database {
   }
 
   public async close(): Promise<void> {
+    this.statsValid.invalidateAndNew();
     await this.pool.end();
     (<any>this).pool = null;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ router.get('/project/:projectId', async (ctx) => {
     respondProjectIdNotFound(ctx, Number(ctx.params.projectId));
   }
   ctx.body = processTemplate('project-data.html', {
-    project: await db.getProject(Number(ctx.params.projectId))
+    project
   });
   ctx.type = 'html';
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,12 @@ import {
   dashProfile
 } from './dashboard.js';
 import { processTemplate } from './templates.js';
-import { dbConfig, robustPath, siteConfig } from './util.js';
+import {
+  cacheInvalidationDelay,
+  dbConfig,
+  robustPath,
+  siteConfig
+} from './util.js';
 import { createGitHubClient } from './github.js';
 import { getDirname } from './util.js';
 import { log } from './logging.js';
@@ -49,7 +54,7 @@ const refreshSecret =
 
 const app = new Koa();
 const router = new Router();
-const db = new DatabaseWithPool(dbConfig, 1000, true);
+const db = new DatabaseWithPool(dbConfig, 1000, true, cacheInvalidationDelay);
 
 router.get('/', async (ctx) => {
   const projects = await db.getAllProjects();

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ router.get('/:projectSlug/data/:expId', async (ctx) => {
     ctx.redirect(data.downloadUrl);
   }
 
-  await completeRequest(start, db, 'get-exp-data');
+  completeRequest(start, db, 'get-exp-data');
 });
 
 router.get('/rebenchdb/dash/:projectId/results', async (ctx) => {
@@ -158,7 +158,7 @@ router.get('/rebenchdb/dash/:projectId/results', async (ctx) => {
   ctx.body = await dashResults(Number(ctx.params.projectId), db);
   ctx.type = 'application/json';
 
-  await completeRequest(start, db, 'get-results');
+  completeRequest(start, db, 'get-results');
 });
 
 router.get('/rebenchdb/dash/:projectId/benchmarks', async (ctx) => {
@@ -167,7 +167,7 @@ router.get('/rebenchdb/dash/:projectId/benchmarks', async (ctx) => {
   ctx.body = await dashBenchmarksForProject(db, Number(ctx.params.projectId));
   ctx.type = 'application/json';
 
-  await completeRequest(start, db, 'project-benchmarks');
+  completeRequest(start, db, 'project-benchmarks');
 });
 
 router.get('/rebenchdb/dash/:projectId/timeline/:runId', async (ctx) => {
@@ -192,7 +192,7 @@ router.get(
       db
     );
     ctx.type = 'application/json';
-    await completeRequest(start, db, 'get-profiles');
+    completeRequest(start, db, 'get-profiles');
   }
 );
 
@@ -240,7 +240,7 @@ router.get('/:projectSlug/compare/:baseline..:change', async (ctx) => {
     ctx.set('Cache-Control', 'no-cache');
   }
 
-  await completeRequest(start, db, 'change');
+  completeRequest(start, db, 'change');
 });
 
 router.get('/admin/perform-timeline-update', async (ctx) => {
@@ -441,7 +441,7 @@ router.put(
       log.error(e, e.stack);
     }
 
-    await completeRequest(start, db, 'put-results');
+    completeRequest(start, db, 'put-results');
   }
 );
 

--- a/src/perf-tracker.ts
+++ b/src/perf-tracker.ts
@@ -110,10 +110,10 @@ export async function completeRequest(
   reqStart: number,
   db: Database,
   request: string
-): Promise<void> {
+): Promise<[number, number]> {
   const time = performance.now() - reqStart;
   iterations[request] += 1;
-  await db.recordAllData(
+  return db.recordAllData(
     constructData(time, iterations[request], request),
     true
   );

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,6 +23,9 @@ export const dbConfig = {
   port: 5432
 };
 
+/** How long to still hold on to the cache after it became invalid. In ms. */
+export const cacheInvalidationDelay = 1000 * 60 * 5; /* 5 minutes */
+
 export const siteConfig = {
   reportsUrl: process.env.REPORTS_URL || '/static/reports',
   staticUrl: process.env.STATIC_URL || '/static',

--- a/tests/cache-validity.test.ts
+++ b/tests/cache-validity.test.ts
@@ -1,0 +1,64 @@
+import { TimedCacheValidity } from '../src/db.js';
+
+async function delayOf(ms): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+describe('Timed Cache Validity', () => {
+  it('should be valid on creation', () => {
+    const v = new TimedCacheValidity(0);
+    expect(v.isValid()).toBeTruthy();
+  });
+
+  it('should be immediately invalid when delay is 0', () => {
+    const v = new TimedCacheValidity(0);
+    v.invalidateAndNew();
+    expect(v.isValid()).toBeFalsy();
+  });
+
+  it('should return a new validity object on immediate invalidation', () => {
+    const v = new TimedCacheValidity(0);
+    const v2 = v.invalidateAndNew();
+    expect(v2).not.toBe(v);
+  });
+
+  it('should not be immediately invalid if delay is set', () => {
+    const v = new TimedCacheValidity(10);
+    expect(v.isValid()).toBeTruthy();
+  });
+
+  it('should not be invalid if delay is set, after delay is over', async () => {
+    const v = new TimedCacheValidity(10);
+    expect(v.isValid()).toBeTruthy();
+
+    v.invalidateAndNew();
+    await delayOf(20);
+    expect(v.isValid()).toBeFalsy();
+  });
+
+  it('should not return new validity while not yet invalid', async () => {
+    const v = new TimedCacheValidity(10);
+    expect(v.isValid()).toBeTruthy();
+
+    const vPre = v.invalidateAndNew();
+    const validPre = v.isValid();
+
+    await delayOf(5);
+
+    const vPre2 = v.invalidateAndNew();
+    const validPre2 = v.isValid();
+
+    await delayOf(10);
+
+    expect(validPre).toBeTruthy();
+    expect(vPre).toBe(v);
+
+    expect(validPre2).toBeTruthy();
+    expect(vPre2).toBe(v);
+
+    expect(v.isValid()).toBeFalsy();
+    expect(v.invalidateAndNew()).not.toBe(v);
+  });
+});

--- a/tests/db-testing.ts
+++ b/tests/db-testing.ts
@@ -80,6 +80,8 @@ export class TestDatabase extends Database {
   }
 
   public async close(): Promise<void> {
+    this.statsValid.invalidateAndNew();
+
     if (this.closingAttempted) {
       throw new Error('Already attempted to close');
     }


### PR DESCRIPTION
This is an attempt to improve the performance of the front page by caching the statistics at the bottom as well as the over-time performance results for the self-tracking.

The caching mechanism is more general, but only applied to `dashResults` and `dashStatistics` for now.

Though, there's another caching mechanism already, but that's only used for recording data.


This PR also changes how `completeRequest` is used for recording self-tracking performance.
Instead of awaiting it results, we only trigger it, but do not await it any longer.
This seems to improve performance in some cases at least on my local machine.