### PR TITLE
Do draw lines across data gaps in timeline plots

### DIFF
--- a/src/views/plots.ts
+++ b/src/views/plots.ts
@@ -80,7 +80,8 @@ function seriesConfig(
     label,
     stroke: color,
     value: formatMs,
-    width: width
+    width: width,
+    spanGaps: true
   };
 
   if (largerPoint) {


### PR DESCRIPTION
This gives a more consistent visual image.
And yes, line plots are theoretically not the right plot type to start with…
