### PR TITLE
Implement Benchmarks and continuous Performance Tracking using ReBench

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+stages:
+  - build-and-benchmark
+
+build-and-benchmark:
+  stage: build-and-benchmark
+  tags: [yuria2]
+  script:
+    - podman build . -f Dockerfile -t rebenchdb
+    - podman build . -f Dockerfile.rebench -t bench-rdb
+    - podman run bench-rdb:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,4 +7,4 @@ build-and-benchmark:
   script:
     - podman build . -f Dockerfile -t rebenchdb
     - podman build . -f Dockerfile.rebench -t bench-rdb
-    - podman run bench-rdb:latest
+    - podman run bench-rdb:latest -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ EXPOSE 33333
 RUN service postgresql start && \
    sudo -u postgres psql -c "CREATE USER docker with password 'docker';" \
      -c " CREATE DATABASE rebenchdb;" \
-     -c "GRANT ALL PRIVILEGES ON DATABASE rebenchdb TO docker;"
+     -c "GRANT ALL PRIVILEGES ON DATABASE rebenchdb TO docker;" \
+     -c "ALTER USER docker CREATEDB;"
 
 # Generate Script to start the image
 RUN echo 'echo Starting ReBenchDB\n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 # tools needed for docker setup
-RUN apt-get update && apt-get install -y apt-utils curl bash sudo
+RUN apt-get update && apt-get install -y apt-utils curl bash sudo tzdata
 
 # Add Node.js repo
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,7 @@ COPY . /project
 
 RUN npm run compile
 
+ENV TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 CMD ["bash", "./start-server.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 # tools needed for docker setup
-RUN apt-get update && apt-get install -y apt-utils curl bash sudo tzdata
+RUN apt-get update && apt-get install -y apt-utils curl bash sudo
 
 # Add Node.js repo
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -

--- a/Dockerfile.rebench
+++ b/Dockerfile.rebench
@@ -1,0 +1,7 @@
+# Used for benchmarking
+FROM rebenchdb:latest
+
+RUN apt-get install -y git python3-pip
+RUN pip install git+https://github.com/smarr/ReBench.git
+
+CMD ["rebench", "--help" ]

--- a/Dockerfile.rebench
+++ b/Dockerfile.rebench
@@ -4,4 +4,11 @@ FROM rebenchdb:latest
 RUN apt-get install -y git python3-pip
 RUN pip install git+https://github.com/smarr/ReBench.git
 
-CMD ["rebench", "--help" ]
+RUN echo 'echo Starting PostgreSQL Server\n\
+service postgresql start\n\
+rebench "$@"' > ./start-server-and-rebench.sh
+
+RUN npm run pretest
+
+ENTRYPOINT ["bash", "./start-server-and-rebench.sh"]
+CMD ["--help"]

--- a/rebench.conf
+++ b/rebench.conf
@@ -17,12 +17,12 @@ runs:
     min_iteration_time: 1
 
 benchmark_suites:
-    all:
+    normal:
         gauge_adapter: RebenchLog
         command: "harness.js %(benchmark)s %(iterations)s 1 %(input)s "
         location: dist/src/benchmarks
         iterations: 10
-        invocations: 3
+        invocations: 1
         input_sizes:
             - small
             - medium
@@ -30,6 +30,18 @@ benchmark_suites:
         benchmarks:
             - store-results
             - fetch-results
+            - compute-timeline
+            - render-report
+    full:
+        gauge_adapter: RebenchLog
+        command: "harness.js %(benchmark)s %(iterations)s 1 %(input)s "
+        location: dist/src/benchmarks
+        iterations: 1
+        invocations: 1
+        input_sizes:
+            - full
+        benchmarks:
+            - store-results
             - compute-timeline
             - render-report
 
@@ -47,6 +59,7 @@ experiments:
     benchmarks:
         description: All benchmarks
         suites:
-            - all
+            - normal
+            - full
         executions:
             - benchmarks

--- a/rebench.conf
+++ b/rebench.conf
@@ -35,7 +35,12 @@ benchmark_suites:
 
 executors:
     benchmarks:
-        executable: /opt/local/bin/node
+        executable: /usr/bin/node
+        env:
+            RDB_USER: docker
+            RDB_PASS: docker
+            RDB_HOST: localhost
+            RDB_DB:   rebenchdb
 
 # define the benchmarks to be executed for a re-executable benchmark run
 experiments:

--- a/rebench.conf
+++ b/rebench.conf
@@ -1,0 +1,47 @@
+# -*- mode: yaml -*-
+# Config file for ReBench
+default_experiment: benchmarks
+default_data_file: 'rebench.data'
+
+reporting:
+    # Benchmark results will be reported to ReBenchDB
+    rebenchdb:
+        # this url needs to point to the API endpoint
+        db_url: https://rebench.stefan-marr.de/rebenchdb
+        repo_url: https://github.com/smarr/ReBenchDB
+        record_all: true # make sure everything is recorded
+        project_name: ReBenchDB
+
+runs:
+    max_invocation_time: 6000
+    min_iteration_time: 1
+
+benchmark_suites:
+    all:
+        gauge_adapter: RebenchLog
+        command: "harness.js %(benchmark)s %(iterations)s 1 %(input)s "
+        location: dist/src/benchmarks
+        iterations: 10
+        invocations: 3
+        input_sizes:
+            - small
+            - medium
+            - large
+        benchmarks:
+            - store-results
+            - fetch-results
+            - compute-timeline
+            - render-report
+
+executors:
+    benchmarks:
+        executable: /opt/local/bin/node
+
+# define the benchmarks to be executed for a re-executable benchmark run
+experiments:
+    benchmarks:
+        description: All benchmarks
+        suites:
+            - all
+        executions:
+            - benchmarks

--- a/render-report.sh
+++ b/render-report.sh
@@ -5,5 +5,5 @@ popd > /dev/null
 
 exec Rscript "${BASEDIR}/src/views/somns.R" \
     test.html test.figures "${BASEDIR}/src/views" "" \
-    '' '' '' '' '' \
+    '' '' '' '' '' '' '' \
     "from-file;${BASEDIR}/$1;${BASEDIR}/$2"

--- a/src/api.ts
+++ b/src/api.ts
@@ -261,3 +261,10 @@ export interface TimelineBenchmark {
   cmdline: string;
   runId: number;
 }
+
+export interface TimelineJob {
+  timelinejobid: number;
+  trialid: number;
+  runid: number;
+  criterion: number;
+}

--- a/src/benchmarks/benchmark.ts
+++ b/src/benchmarks/benchmark.ts
@@ -1,0 +1,48 @@
+// This code is derived from the SOM benchmarks, see AUTHORS.md file.
+//
+// Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software'), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+export class Benchmark {
+  public async innerBenchmarkLoop(innerIterations: number): Promise<boolean> {
+    for (let i = 0; i < innerIterations; i++) {
+      const result = await this.benchmark();
+      if (!this.verifyResult(result)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public async benchmark(): Promise<any> {
+    throw 'benchmark is subclass responsibility';
+  }
+
+  public verifyResult(_result: any): boolean {
+    throw 'verifyResult is subclass responsibility';
+  }
+
+  public async oneTimeSetup(_problemSize: string): Promise<void> {
+    /* implemented in subclasses */
+  }
+
+  public async oneTimeTeardown(): Promise<void> {
+    /* implemented in subclasses */
+  }
+}

--- a/src/benchmarks/compute-timeline.ts
+++ b/src/benchmarks/compute-timeline.ts
@@ -1,0 +1,54 @@
+import { TimelineJob } from '../api.js';
+import { RebenchDbBenchmark } from './rebenchdb-benchmark.js';
+
+export default class ComputeTimeline extends RebenchDbBenchmark {
+  private jobs: TimelineJob[] = [];
+
+  public async oneTimeSetup(problemSize: string): Promise<void> {
+    await super.oneTimeSetup(problemSize);
+
+    this.testData.experimentName = 'Benchmark 1';
+    this.testData.source.commitId = 'commit-1';
+    await this.db?.recordAllData(this.testData);
+
+    this.testData.experimentName = 'Benchmark 2';
+    this.testData.source.commitId = 'commit-2';
+    await this.db?.recordAllData(this.testData);
+
+    const result = await this.db?.query(
+      `DELETE FROM TimelineCalcJob RETURNING *`
+    );
+    this.jobs = <TimelineJob[]>result?.rows;
+  }
+
+  public async benchmark(): Promise<any> {
+    for (const j of this.jobs) {
+      await this.db?.recordTimelineJob([j.trialid, j.runid, j.criterion]);
+    }
+    await this.db?.performTimelineUpdate();
+    const result = await this.db?.query(`SELECT count(*) FROM Timeline`);
+
+    await this.db?.query(`TRUNCATE Timeline, TimelineCalcJob`);
+
+    return {
+      timelineEntries: result?.rows[0],
+      numJobs: this.jobs.length
+    };
+  }
+
+  public verifyResult(result: any): boolean {
+    if (this.problemSize === 'small') {
+      return result.numJobs === 24 && result.timelineEntries.count === '24';
+    }
+
+    if (this.problemSize === 'medium') {
+      return result.numJobs === 52 && result.timelineEntries.count === '52';
+    }
+
+    if (this.problemSize === 'large') {
+      return result.numJobs === 920 && result.timelineEntries.count === '920';
+    }
+
+    throw new Error('not yet supported problem size ' + this.problemSize);
+  }
+}

--- a/src/benchmarks/compute-timeline.ts
+++ b/src/benchmarks/compute-timeline.ts
@@ -7,6 +7,28 @@ export default class ComputeTimeline extends RebenchDbBenchmark {
   public async oneTimeSetup(problemSize: string): Promise<void> {
     await super.oneTimeSetup(problemSize);
 
+    if (problemSize === 'full') {
+      // just use the testData as is
+    } else if (problemSize === 'large') {
+      this.testData.data.length = 50;
+    } else if (problemSize === 'medium') {
+      this.testData.data.length = 20;
+      for (const run of this.testData.data) {
+        if (run.d) {
+          run.d.length = 200;
+        }
+      }
+    } else if (problemSize === 'small') {
+      this.testData.data.length = 10;
+      for (const run of this.testData.data) {
+        if (run.d) {
+          run.d.length = 15;
+        }
+      }
+    } else {
+      throw new Error('Unsupported problem size given: ' + problemSize);
+    }
+
     this.testData.experimentName = 'Benchmark 1';
     this.testData.source.commitId = 'commit-1';
     await this.db?.recordAllData(this.testData);
@@ -46,6 +68,10 @@ export default class ComputeTimeline extends RebenchDbBenchmark {
     }
 
     if (this.problemSize === 'large') {
+      return result.numJobs === 152 && result.timelineEntries.count === '152';
+    }
+
+    if (this.problemSize === 'full') {
       return result.numJobs === 920 && result.timelineEntries.count === '920';
     }
 

--- a/src/benchmarks/fetch-results.ts
+++ b/src/benchmarks/fetch-results.ts
@@ -1,0 +1,49 @@
+import { dashResults } from '../dashboard.js';
+import { RebenchDbBenchmark } from './rebenchdb-benchmark.js';
+
+export default class RenderReport extends RebenchDbBenchmark {
+  public async oneTimeSetup(problemSize: string): Promise<void> {
+    await super.oneTimeSetup(problemSize);
+
+    this.testData.experimentName = 'Benchmark 1';
+    this.testData.source.commitId = 'commit-1';
+    await this.db?.recordAllData(this.testData);
+
+    this.testData.experimentName = 'Benchmark 2';
+    this.testData.source.commitId = 'commit-2';
+    await this.db?.recordAllData(this.testData);
+  }
+
+  public async benchmark(): Promise<any> {
+    if (!this.db) {
+      throw new Error('this.db not initialized');
+    }
+    this.db.getStatsCacheValidity().invalidateAndNew();
+    return dashResults(1, this.db);
+  }
+
+  public verifyResult(result: any): boolean {
+    if (this.problemSize === 'small') {
+      return (
+        result.length === 9 &&
+        result.every((r) => r.values.length === 30 || r.values.length === 60)
+      );
+    }
+
+    if (this.problemSize === 'medium') {
+      return (
+        result.length === 15 && result.every((r) => r.values.length === 100)
+      );
+    }
+
+    if (this.problemSize === 'large') {
+      return (
+        result.length === 32 &&
+        result.every((r) => r.values.length === 128 || r.values.length === 100)
+      );
+    }
+    console.log(result, result.length, result[1].values.length);
+
+    return false;
+  }
+}

--- a/src/benchmarks/fetch-results.ts
+++ b/src/benchmarks/fetch-results.ts
@@ -5,13 +5,31 @@ export default class RenderReport extends RebenchDbBenchmark {
   public async oneTimeSetup(problemSize: string): Promise<void> {
     await super.oneTimeSetup(problemSize);
 
-    this.testData.experimentName = 'Benchmark 1';
-    this.testData.source.commitId = 'commit-1';
-    await this.db?.recordAllData(this.testData);
+    if (problemSize === 'large') {
+      // just use the testData as is
+    } else if (problemSize === 'medium') {
+      this.testData.data.length = 20;
+      for (const run of this.testData.data) {
+        if (run.d) {
+          run.d.length = 200;
+        }
+      }
+    } else if (problemSize === 'small') {
+      this.testData.data.length = 10;
+      for (const run of this.testData.data) {
+        if (run.d) {
+          run.d.length = 15;
+        }
+      }
+    } else {
+      throw new Error('Unsupported problem size given: ' + problemSize);
+    }
 
-    this.testData.experimentName = 'Benchmark 2';
-    this.testData.source.commitId = 'commit-2';
-    await this.db?.recordAllData(this.testData);
+    for (let i = 1; i <= 2; i += 1) {
+      this.testData.experimentName = 'Benchmark ' + i;
+      this.testData.source.commitId = 'commit-' + i;
+      await this.db?.recordAllData(this.testData);
+    }
   }
 
   public async benchmark(): Promise<any> {

--- a/src/benchmarks/harness.ts
+++ b/src/benchmarks/harness.ts
@@ -1,0 +1,153 @@
+// This code is derived from the SOM benchmarks, see AUTHORS.md file.
+//
+// Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software'), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+import type { Benchmark } from './benchmark';
+
+class Run {
+  public numIterations: number;
+  public innerIterations: number;
+  public problemSize: string;
+
+  private total: number;
+  private benchmarkSuite;
+  private readonly name: string;
+
+  constructor(name: string) {
+    this.name = name;
+
+    this.numIterations = 1;
+    this.innerIterations = 1;
+    this.total = 0;
+    this.problemSize = '';
+  }
+
+  public async loadBenchmark() {
+    const filename = './' + this.name.toLowerCase() + '.js';
+    this.benchmarkSuite = await import(filename);
+  }
+
+  private reportBenchmark() {
+    process.stdout.write(
+      this.name +
+        ': iterations=' +
+        this.numIterations +
+        ' average: ' +
+        Math.round(this.total / this.numIterations) +
+        'us total: ' +
+        Math.round(this.total) +
+        'us\n\n'
+    );
+  }
+
+  private printResult(runTime: number) {
+    process.stdout.write(
+      this.name + ': iterations=1 runtime: ' + Math.round(runTime) + 'us\n'
+    );
+  }
+
+  private async measure(bench: Benchmark) {
+    const startTime = process.hrtime();
+    const result = await bench.innerBenchmarkLoop(this.innerIterations);
+    if (!result) {
+      throw 'Benchmark failed with incorrect result';
+    }
+    const diff = process.hrtime(startTime);
+
+    // truncate to integer
+    const runTime = ((diff[0] * 1e9 + diff[1]) / 1000) | 0;
+
+    this.printResult(runTime);
+    this.total += runTime;
+  }
+
+  private async doRuns(bench: Benchmark) {
+    for (let i = 0; i < this.numIterations; i++) {
+      await this.measure(bench);
+    }
+  }
+
+  public printTotal() {
+    process.stdout.write(`Total Runtime: ${this.total}us\n`);
+  }
+
+  public async runBenchmark() {
+    process.stdout.write(`Starting ${this.name} benchmark ...\n`);
+
+    const benchmark: Benchmark = new this.benchmarkSuite.default();
+
+    try {
+      await benchmark.oneTimeSetup(this.problemSize);
+      await this.doRuns(benchmark);
+    } finally {
+      await benchmark.oneTimeTeardown();
+    }
+
+    this.reportBenchmark();
+    process.stdout.write('\n');
+  }
+}
+
+async function processArguments(args) {
+  const run = new Run(args[2]);
+  await run.loadBenchmark();
+
+  if (args.length > 3) {
+    run.numIterations = parseInt(args[3]);
+    if (args.length > 4) {
+      run.innerIterations = parseInt(args[4]);
+      if (args.length > 5) {
+        run.problemSize = args[5];
+      }
+    }
+  }
+  return run;
+}
+
+function printUsage() {
+  process.stdout.write(
+    'harness.js [benchmark] [num-iterations [inner-iter [problem-size]]]\n'
+  );
+  process.stdout.write('\n');
+  process.stdout.write('  benchmark      - benchmark class name\n');
+  process.stdout.write(
+    '  num-iterations - number of times to execute benchmark, default: 1\n'
+  );
+  process.stdout.write(
+    '  inner-iter     -' +
+      ' number of times the benchmark is executed in an inner loop,\n'
+  );
+  process.stdout.write(
+    '                   which is measured in total, default: 1\n'
+  );
+  process.stdout.write(
+    '  problem-size   -' +
+      ` a problem size to be given to the benchmark, default: ''\n`
+  );
+}
+
+if (process.argv.length < 3) {
+  printUsage();
+  process.exit(1);
+}
+
+const run = await processArguments(process.argv);
+await run.runBenchmark();
+run.printTotal();

--- a/src/benchmarks/rebenchdb-benchmark.ts
+++ b/src/benchmarks/rebenchdb-benchmark.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'fs';
+import { getDirname } from '../util.js';
+import { BenchmarkData } from '../api.js';
+import { createAndInitializeDB, TestDatabase } from '../../tests/db-testing.js';
+import { Benchmark } from './benchmark.js';
+
+const __dirname = getDirname(import.meta.url);
+export class RebenchDbBenchmark extends Benchmark {
+  protected readonly testData: BenchmarkData;
+  protected db: TestDatabase | null;
+  protected problemSize: string;
+
+  constructor() {
+    super();
+    this.db = null;
+    this.problemSize = '';
+
+    this.testData = JSON.parse(
+      readFileSync(`${__dirname}/../../../tests/large-payload.json`).toString()
+    );
+  }
+
+  public async oneTimeSetup(problemSize: string): Promise<void> {
+    this.problemSize = problemSize;
+    this.db = await createAndInitializeDB('rdb_benchmark', 100, false, false);
+
+    if (!this.db) {
+      throw new Error('ReBenchDB connection was not initialized');
+    }
+
+    if (problemSize === 'large') {
+      // just use the testData as is
+    } else if (problemSize === 'medium') {
+      this.testData.data.length = 20;
+      for (const run of this.testData.data) {
+        if (run.d) {
+          run.d.length = 200;
+        }
+      }
+    } else if (problemSize === 'small') {
+      this.testData.data.length = 10;
+      for (const run of this.testData.data) {
+        if (run.d) {
+          run.d.length = 15;
+        }
+      }
+    } else {
+      throw new Error('Unsupported problem size given: ' + problemSize);
+    }
+  }
+
+  public async oneTimeTeardown(): Promise<void> {
+    if (this.db) {
+      return this.db?.close();
+    }
+  }
+}

--- a/src/benchmarks/rebenchdb-benchmark.ts
+++ b/src/benchmarks/rebenchdb-benchmark.ts
@@ -27,26 +27,6 @@ export class RebenchDbBenchmark extends Benchmark {
     if (!this.db) {
       throw new Error('ReBenchDB connection was not initialized');
     }
-
-    if (problemSize === 'large') {
-      // just use the testData as is
-    } else if (problemSize === 'medium') {
-      this.testData.data.length = 20;
-      for (const run of this.testData.data) {
-        if (run.d) {
-          run.d.length = 200;
-        }
-      }
-    } else if (problemSize === 'small') {
-      this.testData.data.length = 10;
-      for (const run of this.testData.data) {
-        if (run.d) {
-          run.d.length = 15;
-        }
-      }
-    } else {
-      throw new Error('Unsupported problem size given: ' + problemSize);
-    }
   }
 
   public async oneTimeTeardown(): Promise<void> {

--- a/src/benchmarks/render-report.ts
+++ b/src/benchmarks/render-report.ts
@@ -12,6 +12,28 @@ export default class RenderReport extends RebenchDbBenchmark {
   public async oneTimeSetup(problemSize: string): Promise<void> {
     await super.oneTimeSetup(problemSize);
 
+    if (problemSize === 'full') {
+      // use as is
+    } else if (problemSize === 'large') {
+      this.testData.data.length = 50;
+    } else if (problemSize === 'medium') {
+      this.testData.data.length = 20;
+      for (const run of this.testData.data) {
+        if (run.d) {
+          run.d.length = 200;
+        }
+      }
+    } else if (problemSize === 'small') {
+      this.testData.data.length = 10;
+      for (const run of this.testData.data) {
+        if (run.d) {
+          run.d.length = 15;
+        }
+      }
+    } else {
+      throw new Error('Unsupported problem size given: ' + problemSize);
+    }
+
     this.testData.experimentName = 'Benchmark 1';
     this.baseHash = this.testData.source.commitId = 'commit-1';
     await this.db?.recordAllData(this.testData);

--- a/src/benchmarks/render-report.ts
+++ b/src/benchmarks/render-report.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import * as path from 'path';
+import { RebenchDbBenchmark } from './rebenchdb-benchmark.js';
+import { startReportGeneration } from '../dashboard.js';
+
+export default class RenderReport extends RebenchDbBenchmark {
+  private baseHash: string | null = null;
+  private changeHash: string | null = null;
+  private tmpDir: string | null = null;
+
+  public async oneTimeSetup(problemSize: string): Promise<void> {
+    await super.oneTimeSetup(problemSize);
+
+    this.testData.experimentName = 'Benchmark 1';
+    this.baseHash = this.testData.source.commitId = 'commit-1';
+    await this.db?.recordAllData(this.testData);
+
+    this.testData.experimentName = 'Benchmark 2';
+    this.changeHash = this.testData.source.commitId = 'commit-2';
+    await this.db?.recordAllData(this.testData);
+
+    this.tmpDir = mkdtempSync(path.join(tmpdir(), '/rebenchdb-tmp'));
+  }
+
+  public async oneTimeTeardown(): Promise<void> {
+    super.oneTimeTeardown();
+    if (this.tmpDir) {
+      rmSync(this.tmpDir, { recursive: true, force: true });
+    }
+  }
+
+  public async benchmark(): Promise<any> {
+    if (!this.baseHash || !this.changeHash || !this.tmpDir || !this.db) {
+      throw new Error(
+        'RenderReport.oneTimeSetup did not set baseHash or changeHash'
+      );
+    }
+    const output = await startReportGeneration(
+      this.baseHash,
+      this.changeHash,
+      path.join(this.tmpDir, 'benchmark.html'),
+      this.db.getDatabaseConfig()
+    );
+
+    return output.code === 0;
+  }
+
+  public verifyResult(result: any): boolean {
+    const content = readFileSync(
+      path.join(<string>this.tmpDir, 'benchmark.html')
+    );
+
+    let r = result;
+
+    for (const run of this.testData.data) {
+      r &&= content.includes(run.runId.benchmark.name);
+    }
+
+    return r;
+  }
+}

--- a/src/benchmarks/store-results.ts
+++ b/src/benchmarks/store-results.ts
@@ -8,6 +8,32 @@ export default class StoreResults extends RebenchDbBenchmark {
     this.iteration = 0;
   }
 
+  public async oneTimeSetup(problemSize: string): Promise<void> {
+    await super.oneTimeSetup(problemSize);
+
+    if (problemSize === 'full') {
+      // just use the testData as is
+    } else if (problemSize === 'large') {
+      this.testData.data.length = 50;
+    } else if (problemSize === 'medium') {
+      this.testData.data.length = 20;
+      for (const run of this.testData.data) {
+        if (run.d) {
+          run.d.length = 200;
+        }
+      }
+    } else if (problemSize === 'small') {
+      this.testData.data.length = 10;
+      for (const run of this.testData.data) {
+        if (run.d) {
+          run.d.length = 15;
+        }
+      }
+    } else {
+      throw new Error('Unsupported problem size given: ' + problemSize);
+    }
+  }
+
   public async benchmark(): Promise<any> {
     this.iteration += 1;
     this.testData.experimentName = 'Benchmark ' + this.iteration;
@@ -18,8 +44,10 @@ export default class StoreResults extends RebenchDbBenchmark {
   public verifyResult(result: any): boolean {
     const [recMs, recPs] = result;
 
-    if (this.problemSize === 'large') {
+    if (this.problemSize === 'full') {
       return recMs === 459928 && recPs === 0;
+    } else if (this.problemSize === 'large') {
+      return recMs === 75987 && recPs === 0;
     } else if (this.problemSize === 'medium') {
       return recMs === 5197 && recPs === 0;
     } else if (this.problemSize === 'small') {

--- a/src/benchmarks/store-results.ts
+++ b/src/benchmarks/store-results.ts
@@ -1,0 +1,31 @@
+import { RebenchDbBenchmark } from './rebenchdb-benchmark.js';
+
+export default class StoreResults extends RebenchDbBenchmark {
+  private iteration: number;
+
+  constructor() {
+    super();
+    this.iteration = 0;
+  }
+
+  public async benchmark(): Promise<any> {
+    this.iteration += 1;
+    this.testData.experimentName = 'Benchmark ' + this.iteration;
+    this.testData.source.commitId = 'commit-' + this.iteration;
+    return this.db?.recordAllData(this.testData);
+  }
+
+  public verifyResult(result: any): boolean {
+    const [recMs, recPs] = result;
+
+    if (this.problemSize === 'large') {
+      return recMs === 459928 && recPs === 0;
+    } else if (this.problemSize === 'medium') {
+      return recMs === 5197 && recPs === 0;
+    } else if (this.problemSize === 'small') {
+      return recMs === 179 && recPs === 0;
+    } else {
+      throw new Error('Unsupported problem size given: ' + this.problemSize);
+    }
+  }
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -228,6 +228,8 @@ export function startReportGeneration(
     dbConfig.database,
     dbConfig.user,
     dbConfig.password,
+    dbConfig.host,
+    String(dbConfig.port),
     extraCmd
   ];
 
@@ -444,6 +446,8 @@ export async function dashGetExpData(
         dbConfig.user,
         dbConfig.password,
         dbConfig.database,
+        dbConfig.host,
+        String(dbConfig.port),
         expDataFile
       ];
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1222,6 +1222,8 @@ export abstract class Database {
         this.dbConfig.database,
         this.dbConfig.user,
         this.dbConfig.password,
+        this.dbConfig.host,
+        this.dbConfig.port,
         this.numBootstrapSamples
       ];
       const start = startRequest();

--- a/src/db.ts
+++ b/src/db.ts
@@ -271,9 +271,9 @@ export abstract class Database {
                   hostname, osType, memory, cpu, clockSpeed)
                 VALUES ($1, $2, $3, $4, $5) RETURNING *`,
 
-    fetchTrialByUserEnvStart: `SELECT * FROM Trial
+    fetchTrialByUserEnvStartExp: `SELECT * FROM Trial
                                WHERE username = $1 AND envId = $2 AND
-                                     startTime = $3`,
+                                     startTime = $3 AND expId = $4`,
     insertTrial: `INSERT INTO Trial (manualRun, startTime, expId, username,
                                      envId, sourceId, denoise)
                   VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
@@ -687,19 +687,18 @@ export abstract class Database {
     exp: Experiment
   ): Promise<Trial> {
     const e = data.env;
-    const cacheKey = `${e.userName}-${env.id}-${data.startTime}`;
+    const cacheKey = `${e.userName}-${env.id}-${data.startTime}-${exp.id}`;
 
     if (this.trials.has(cacheKey)) {
       return <Trial>this.trials.get(cacheKey);
     }
-
     const source = await this.recordSource(data.source);
 
     return this.recordCached(
       this.trials,
       cacheKey,
-      this.queries.fetchTrialByUserEnvStart,
-      [e.userName, env.id, data.startTime],
+      this.queries.fetchTrialByUserEnvStartExp,
+      [e.userName, env.id, data.startTime, exp.id],
       this.queries.insertTrial,
       [
         e.manualRun,

--- a/src/db/db.sql
+++ b/src/db/db.sql
@@ -131,10 +131,10 @@ CREATE TABLE Trial (
   endTime timestamp with time zone NULL,
 
   -- We assume that there is only
-  -- a single experiment per user/environment/startTime.
+  -- a single trial per user/environment/startTime/experiment.
   -- sourceId is not included, since it should be
   -- functionally dependent on startTime in the intended scenarios.
-  unique (username, envId, startTime),
+  unique (username, envId, expId, startTime),
 
   foreign key (expId) references Experiment (id),
   foreign key (envId) references Environment (id),

--- a/src/stats/get-exp-data.R
+++ b/src/stats/get-exp-data.R
@@ -8,12 +8,14 @@ lib_dir <- cmd_args[2] # lib_dir <- "."
 db_user <- cmd_args[3] # db_user <- NULL
 db_pass <- cmd_args[4] # db_pass <- NULL
 db_name <- cmd_args[5] # db_name <- "rdb_smde" # rdb_sm1
-out_file <- cmd_args[6]
+db_host <- cmd_args[6]
+db_port <- cmd_args[7]
+out_file <- cmd_args[8]
 
 
 source(paste0(lib_dir, "/rebenchdb.R"), chdir=TRUE)
 
-rebenchdb <- connect_to_rebenchdb(db_name, db_user, db_pass)
+rebenchdb <- connect_to_rebenchdb(db_name, db_user, db_pass, db_host, db_port)
 result <- get_measures_for_experiment(rebenchdb, exp_id)
 disconnect_rebenchdb(rebenchdb)
 qsave(result, out_file)

--- a/src/stats/timeline.R
+++ b/src/stats/timeline.R
@@ -13,7 +13,9 @@ if (Sys.getenv("RSTUDIO") == "1" & Sys.getenv("LOGNAME") == "smarr") {
   db_name <- args[1]
   db_user <- args[2]
   db_pass <- args[3]
-  num_replicates <- as.numeric(args[4])
+  db_host <- args[4]
+  db_port <- args[5]
+  num_replicates <- as.numeric(args[6])
 }
 
 source("../views/rebenchdb.R", chdir = TRUE)
@@ -21,11 +23,11 @@ source("../views/stats.R", chdir = TRUE)
 
 suppressMessages(library(dplyr))
 
-rebenchdb <- connect_to_rebenchdb(db_name, db_user, db_pass)
+rebenchdb <- connect_to_rebenchdb(db_name, db_user, db_pass, db_host, db_port)
 
 dbBegin(rebenchdb)
 qry <- dbSendQuery(rebenchdb, "
-WITH deletedJobs AS ( 
+WITH deletedJobs AS (
     DELETE FROM TimelineCalcJob tcj
     RETURNING tcj.trialId, tcj.runId, tcj.criterion
 )

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -37,7 +37,8 @@ connect_to_rebenchdb <- function(dbname, user, pass, host, port) {
     port = port,
     dbname = dbname,
     user = user,
-    password = pass)
+    password = pass,
+    sslmode = 'disable')
 }
 
 main_data_select <- "

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -28,9 +28,9 @@ load_data_url <- function(url) {
 }
 
 
-connect_to_rebenchdb <- function(dbname, user, pass) {
-  host <- if (Sys.getenv("DB_HOST") == "") { NULL } else { Sys.getenv("DB_HOST") }
-  port <- if (Sys.getenv("DB_PORT") == "") { NULL } else { Sys.getenv("DB_PORT") }
+connect_to_rebenchdb <- function(dbname, user, pass, host, port) {
+  host <- if (host == "") { NULL } else { host }
+  port <- if (port == "") { NULL } else { port }
   DBI::dbConnect(
     RPostgres::Postgres(),
     host = host,

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -5,18 +5,18 @@ library(DBI)
 suppressMessages(library(qs))
 
 load_data_file <- function(filename) {
-  qread(filename)  
+  qread(filename)
 }
 
 load_data_url <- function(url) {
   # url <- "https://rebench.stefan-marr.de/rebenchdb/get-exp-data/37"
   safe_name <- str_replace_all(url, "[:/.]", "-")
   cache_file <- paste0(str_replace_all(safe_name, "-+", "-"), ".qs")
-  
+
   if(!file.exists(cache_file)) {
     download.file(url=url, destfile=cache_file)
   }
-  
+
   tryCatch(
     qread(cache_file),
     error = function(c) {
@@ -79,7 +79,7 @@ get_measures_for_experiment <- function(rebenchdb, exp_id) {
   dbBind(qry, list(exp_id))
   result <- dbFetch(qry)
   dbClearResult(qry)
-  
+
   factorize_result(result)
 }
 
@@ -129,7 +129,7 @@ get_profile_availability <- function(rebenchdb, hash_1, hash_2) {
   dbBind(qry, list(hash_1, hash_2))
   result <- dbFetch(qry)
   dbClearResult(qry)
-  
+
   factorize_result(result)
 }
 
@@ -150,8 +150,8 @@ factorize_result <- function(result) {
   if ("envid" %in% colnames(result)) {
      result$envid <- factor(result$envid)
   }
-  
-  
+
+
   if ("criterion" %in% colnames(result)) {
     result$criterion <- factor(result$criterion)
     result$unit <- factor(result$unit)

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -31,14 +31,14 @@ load_data_url <- function(url) {
 connect_to_rebenchdb <- function(dbname, user, pass, host, port) {
   host <- if (host == "") { NULL } else { host }
   port <- if (port == "") { NULL } else { port }
-  DBI::dbConnect(
+  suppressWarnings(DBI::dbConnect(
     RPostgres::Postgres(),
     host = host,
     port = port,
     dbname = dbname,
     user = user,
     password = pass,
-    sslmode = 'disable')
+    sslmode = 'disable'))
 }
 
 main_data_select <- "

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -31,14 +31,14 @@ load_data_url <- function(url) {
 connect_to_rebenchdb <- function(dbname, user, pass, host, port) {
   host <- if (host == "") { NULL } else { host }
   port <- if (port == "") { NULL } else { port }
-  suppressWarnings(DBI::dbConnect(
+  DBI::dbConnect(
     RPostgres::Postgres(),
     host = host,
     port = port,
     dbname = dbname,
     user = user,
     password = pass,
-    sslmode = 'disable'))
+    sslmode = 'disable')
 }
 
 main_data_select <- "

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -11,16 +11,18 @@ args <- if (Sys.getenv("RSTUDIO") == "1") {
    "rdb_smde", # NA,  # "rdb_sm1"
    "", # NA,
    "", # NA,
+   "", # NA,
+   "", # NA,
    ""  # "from-file;~/Projects/ReBenchDB/tmp/TruffleSOM-380.qs;~/Projects/ReBenchDB/tmp/TruffleSOM-381.qs"
  )
 } else {
   commandArgs(trailingOnly = TRUE)
 }
 
-if (length(args) < 10 | args[[1]] == '--help') {
+if (length(args) < 12 | args[[1]] == '--help') {
   cat("Performance Comparison Report
 
-Usage: somns.R outputFile outputDir baselineHash changeHash baselineColor changeColor dbName dbUser dbPass [extraCmd]
+Usage: somns.R outputFile outputDir baselineHash changeHash baselineColor changeColor dbName dbUser dbPass dbHost dbPort [extraCmd]
 
   outputFile       the name for the HTML file that is produced
   outputDir        the name for the folder with images produced
@@ -32,6 +34,8 @@ Usage: somns.R outputFile outputDir baselineHash changeHash baselineColor change
   dbName           name of the database
   dbUser           name of the user used to connect to the DB
   dbPass           password used for the DB
+  dbHost           name of database host
+  dbPort           number of database port
 
   extraCmd         a command interpreted by the script
                    as a ; separated list
@@ -47,7 +51,9 @@ change_hash    <- args[[6]]
 db_name        <- args[[7]]
 db_user        <- args[[8]]
 db_pass        <- args[[9]]
-extra_cmd      <- args[[10]]
+db_host        <- args[[10]]
+db_port        <- args[[11]]
+extra_cmd      <- args[[12]]
 
 # Load Libraries
 source(paste0(lib_dir, "/common.R"), chdir=TRUE)
@@ -101,7 +107,7 @@ if (cmds[1] == "from-file") {
   environments <- NULL
 } else {
   # load_and_install_if_necessary("psych")   # uses only geometric.mean
-  rebenchdb <- connect_to_rebenchdb(db_name, db_user, db_pass)
+  rebenchdb <- connect_to_rebenchdb(db_name, db_user, db_pass, db_host, db_port)
   result <- get_measures_for_comparison(rebenchdb, baseline_hash, change_hash)
   profiles <- get_profile_availability(rebenchdb, baseline_hash, change_hash)
   environments <- get_environments(rebenchdb, baseline_hash, change_hash)

--- a/tests/db-testing.ts
+++ b/tests/db-testing.ts
@@ -29,6 +29,16 @@ export class TestDatabase extends Database {
     this.client = null;
   }
 
+  public getDatabaseConfig(): DatabaseConfig {
+    return {
+      user: <string>this.dbConfig.user,
+      password: <string>this.dbConfig.password,
+      host: <string>this.dbConfig.host,
+      database: <string>this.dbConfig.database,
+      port: <number>this.dbConfig.port
+    };
+  }
+
   public query<R extends QueryResultRow = any, I extends any[] = any[]>(
     queryTextOrConfig: string | QueryConfig<I>,
     values?: I

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es2018",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "es2020",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "module": "es2022",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
This PR adds the necessary setup and benchmarks to track performance of the following operations:

- storing results from a benchmarking client
- fetching results for display on the line chart (main page, self tracking)
- computing timeline statistics
- rendering a report with differences

The benchmarking is setup using Docker, or rather podman, as a root-less, daemon-less alternative. The goal was to have a self-contained setup, that does not require installing and managing Postgres on the benchmarking machine.

The benchmark harness is taken from the AreWeFastYet project.

All benchmarks come with three different workload sizes, small, medium, and large, which scales the run-time of the from few milliseconds to minutes.

### Code Changes

 - rearrange dockerfile to maximize the use of caching, avoid including frequently changing files early
 - explicitly pass all database parameters to the R script, which was incomplete before
 - include experiment id in the alternate key of Trial, since a trial belongs to a specific experiment (**this is work in progress, not tested, and no migration support provided here. will follow in a separate PR to document it properly**)

### Docker

Implicitly, this PR also fixes issues with the Docker setup, which wasn't really tested before.