### PR TITLE
Add tests and a migration for the added expId in Trial’s unique constraint

### DIFF
--- a/src/db/migration.006.sql
+++ b/src/db/migration.006.sql
@@ -1,0 +1,8 @@
+-- add the envId to the unique constraint
+-- or rather, drop the old constraint, and add a new one
+ALTER TABLE Trial
+  DROP CONSTRAINT trial_username_envid_starttime_key;
+
+ALTER TABLE Trial
+  ADD CONSTRAINT trial_username_envid_expid_starttime_key
+    UNIQUE(username, envId, expId, startTime);


### PR DESCRIPTION
This completes the changes started in #115.

While just a theoretical issue, including the expId into the unique constraint prevents issues with unrelated experiments not being able to record their trial information.

This is in practice very unlikely to be an issue since the start time is part of the unique constraint. Though, for benchmarking it was noticed, and felt wrong not to fix it.