### PR TITLE
Fix ordering of the results returned by dashResults, i.e., the results view on the index/project pages

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -47,7 +47,10 @@ export async function dashResults(
                     value, b.name as benchmark,
                     rank() OVER (
                       PARTITION BY b.id
-                      ORDER BY t.startTime DESC, m.iteration DESC
+                      ORDER BY
+                        t.startTime DESC,
+                        m.invocation DESC,
+                        m.iteration DESC
                     )
                     FROM Measurement m
                       JOIN Trial t ON  m.trialId = t.id
@@ -57,13 +60,13 @@ export async function dashResults(
                       JOIN Criterion c ON m.criterion = c.id
                     WHERE projectId = $1 AND
                       c.name = 'total'
-                    ORDER BY t.startTime, m.iteration
+                    ORDER BY t.startTime, m.invocation, m.iteration
             ),
             LastHundred AS (
               SELECT rank, value, benchmark
               FROM Results
               WHERE rank <= 100
-              ORDER BY benchmark, rank ASC
+              ORDER BY benchmark, rank DESC
             )
             SELECT array_agg(value) as values, benchmark
             FROM LastHundred

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -365,7 +365,7 @@ describe('dashResults', () => {
       data: createRunData(1, 200, 'trivial', 'test', 'testExec'),
       criteria: createCriteria()
     };
-    await db.recordAllData(trivialData);
+    await db.recordAllData(trivialData, true);
 
     const result = await dashResults(1, db);
 
@@ -390,7 +390,7 @@ describe('dashResults', () => {
       data: createRunData(4, 50, '4runs50it', 'test', 'testExec'),
       criteria: createCriteria()
     };
-    await db.recordAllData(data4runs50it);
+    await db.recordAllData(data4runs50it, true);
 
     const result = await dashResults(2, db);
 
@@ -415,7 +415,7 @@ describe('dashResults', () => {
       data: createRunData(2, 25, 'multi-trial', 'test', 'testExec'),
       criteria: createCriteria()
     };
-    await db.recordAllData(multiTrial);
+    await db.recordAllData(multiTrial, true);
 
     multiTrial = {
       env,
@@ -426,7 +426,7 @@ describe('dashResults', () => {
       data: createRunData(2, 25, 'multi-trial', 'test', 'testExec', 2),
       criteria: createCriteria()
     };
-    await db.recordAllData(multiTrial);
+    await db.recordAllData(multiTrial, true);
 
     const result = await dashResults(3, db);
 
@@ -453,11 +453,23 @@ describe('dashResults', () => {
 
   it(`should get results in the correct order
       cross multiple experiments`, async () => {
-    await db.recordAllData(createData('Exp 1', '2022-01-01 10:00 UTC', 0));
-    await db.recordAllData(createData('Exp 1', '2022-01-01 12:00 UTC', 2));
+    await db.recordAllData(
+      createData('Exp 1', '2022-01-01 10:00 UTC', 0),
+      true
+    );
+    await db.recordAllData(
+      createData('Exp 1', '2022-01-01 12:00 UTC', 2),
+      true
+    );
 
-    await db.recordAllData(createData('Exp 2', '2022-02-02 10:00 UTC', 4));
-    await db.recordAllData(createData('Exp 2', '2022-02-02 12:00 UTC', 6));
+    await db.recordAllData(
+      createData('Exp 2', '2022-02-02 10:00 UTC', 4),
+      true
+    );
+    await db.recordAllData(
+      createData('Exp 2', '2022-02-02 12:00 UTC', 6),
+      true
+    );
 
     const result = await dashResults(4, db);
 

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -29,7 +29,7 @@ describe('Test Dashboard on empty DB', () => {
   });
 
   afterAll(async () => {
-    await db.close();
+    return db.close();
   });
 
   it('Should get empty results request', async () => {
@@ -97,7 +97,7 @@ describe('Test Dashboard with basic test data loaded', () => {
   });
 
   afterAll(async () => {
-    await db.close();
+    return db.close();
   });
 
   it('Should get a project', async () => {
@@ -250,6 +250,7 @@ describe('Test Dashboard with basic test data loaded', () => {
   // dashGetExpData
 });
 
-afterAll(() => {
-  closeMainDb();
+
+afterAll(async () => {
+  return closeMainDb();
 });

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -10,7 +10,15 @@ import {
   dashDataOverview,
   dashBenchmarksForProject
 } from '../src/dashboard';
-import { BenchmarkData } from '../src/api.js';
+import {
+  BenchmarkData,
+  Criterion,
+  DataPoint,
+  Environment,
+  Run,
+  RunId,
+  Source
+} from '../src/api.js';
 import { readFileSync } from 'fs';
 import { getDirname } from '../src/util.js';
 
@@ -113,8 +121,8 @@ describe('Test Dashboard with basic test data loaded', () => {
     expect(nBody.benchmark).toEqual('NBody');
     expect(nBody.values).toHaveLength(numExperiments * 3);
     expect(nBody.values).toEqual([
-      383.821, 482.53, 432.783, 432.783, 383.821, 482.53, 432.783, 482.53,
-      383.821
+      383.821, 432.783, 482.53, 383.821, 432.783, 482.53, 383.821, 432.783,
+      482.53
     ]);
   });
 
@@ -250,6 +258,218 @@ describe('Test Dashboard with basic test data loaded', () => {
   // dashGetExpData
 });
 
+describe('dashResults', () => {
+  const env: Environment = {
+    hostName: 'Host1',
+    cpu: 'Processor1',
+    clockSpeed: 10,
+    memory: 20,
+    osType: 'OsType',
+    software: [],
+    userName: 'TestUser',
+    manualRun: false
+  };
+
+  const source: Source = {
+    repoURL: 'https://repo',
+    branchOrTag: 'main',
+    commitId: 'commit-1',
+    commitMsg: 'commit msg 1',
+    authorName: 'commit author',
+    authorEmail: 'foo@bar',
+    committerName: 'committer',
+    committerEmail: 'bar@foo'
+  };
+
+  function createRunData(
+    numRuns: number,
+    numDataPoints: number,
+    benchmark: string,
+    suite: string,
+    executor: string,
+    runOffset = 0
+  ): Run[] {
+    const result: Run[] = [];
+
+    const runId: RunId = {
+      benchmark: {
+        name: benchmark,
+        runDetails: {
+          maxInvocationTime: 1,
+          minIterationTime: 1,
+          warmup: null
+        },
+        suite: {
+          name: suite,
+          desc: null,
+          executor: {
+            name: executor,
+            desc: null
+          }
+        }
+      },
+      cmdline: `${benchmark}-${suite}-${executor}`,
+      location: '',
+      varValue: null,
+      cores: null,
+      inputSize: null,
+      extraArgs: null
+    };
+
+    for (let i = 0; i < numRuns; i += 1) {
+      const d: DataPoint[] = [];
+      for (let j = 1; j <= numDataPoints; j += 1) {
+        d.push({
+          in: i,
+          it: j,
+          m: [
+            { c: 1, v: j + numDataPoints * (i + runOffset) },
+            { c: 2, v: 100 + j + numDataPoints * (i + runOffset) }
+          ]
+        });
+      }
+      result.push({
+        d,
+        runId
+      });
+    }
+
+    return result;
+  }
+
+  function createCriteria(): Criterion[] {
+    return [
+      { i: 1, c: 'total', u: 'ms' },
+      { i: 2, c: 'somethingElse', u: 'ms' }
+    ];
+  }
+
+  let db: TestDatabase;
+  beforeAll(async () => {
+    db = await createAndInitializeDB('dash_basic', 25, true, false);
+  });
+
+  afterAll(async () => {
+    return db.close();
+  });
+
+  it(`should only consider the total criterion
+      and get results in the correct order for trivial,
+      single shot sets of measurements`, async () => {
+    const trivialData: BenchmarkData = {
+      env,
+      source,
+      experimentName: 'Exp 1',
+      startTime: new Date('2022-01-01 10:00 UTC').toISOString(),
+      projectName: 'Test dashResults trivial',
+      data: createRunData(1, 200, 'trivial', 'test', 'testExec'),
+      criteria: createCriteria()
+    };
+    await db.recordAllData(trivialData);
+
+    const result = await dashResults(1, db);
+
+    expect(result.length).toEqual(1);
+    expect(result[0].benchmark).toEqual('trivial');
+    expect(result[0].values.length).toEqual(100);
+
+    for (let i = 0; i < 100; i += 1) {
+      // only the last 100 results, so 101-200
+      expect(result[0].values[i]).toEqual(i + 101);
+    }
+  });
+
+  it(`should get results in the correct order for multiple invocations
+      in the same trial`, async () => {
+    const data4runs50it = {
+      env,
+      source,
+      experimentName: 'Exp 2',
+      startTime: new Date('2022-01-01 10:00 UTC').toISOString(),
+      projectName: 'Test dashResults 4 runs 50 iterations',
+      data: createRunData(4, 50, '4runs50it', 'test', 'testExec'),
+      criteria: createCriteria()
+    };
+    await db.recordAllData(data4runs50it);
+
+    const result = await dashResults(2, db);
+
+    expect(result.length).toEqual(1);
+    expect(result[0].benchmark).toEqual('4runs50it');
+    expect(result[0].values.length).toEqual(100);
+
+    for (let i = 0; i < 100; i += 1) {
+      // only the last 100 results, so 101-200
+      expect(result[0].values[i]).toEqual(i + 101);
+    }
+  });
+
+  it(`should get results in the correct order for multiple trials
+      of the same experiment`, async () => {
+    let multiTrial = {
+      env,
+      source,
+      experimentName: 'Exp 1',
+      startTime: new Date('2022-01-01 10:00 UTC').toISOString(),
+      projectName: 'Test multi-trial',
+      data: createRunData(2, 25, 'multi-trial', 'test', 'testExec'),
+      criteria: createCriteria()
+    };
+    await db.recordAllData(multiTrial);
+
+    multiTrial = {
+      env,
+      source,
+      experimentName: 'Exp 1',
+      startTime: new Date('2022-01-01 12:00 UTC').toISOString(),
+      projectName: 'Test multi-trial',
+      data: createRunData(2, 25, 'multi-trial', 'test', 'testExec', 2),
+      criteria: createCriteria()
+    };
+    await db.recordAllData(multiTrial);
+
+    const result = await dashResults(3, db);
+
+    expect(result.length).toEqual(1);
+    expect(result[0].benchmark).toEqual('multi-trial');
+    expect(result[0].values.length).toEqual(100);
+
+    for (let i = 0; i < 100; i += 1) {
+      expect(result[0].values[i]).toEqual(i + 1);
+    }
+  });
+
+  function createData(expName: string, date: string, offset: number) {
+    return {
+      env,
+      source,
+      experimentName: expName,
+      startTime: new Date(date).toISOString(),
+      projectName: 'Test multi-exp',
+      data: createRunData(2, 10, 'multi-exp', 'test', 'testExec', offset),
+      criteria: createCriteria()
+    };
+  }
+
+  it(`should get results in the correct order
+      cross multiple experiments`, async () => {
+    await db.recordAllData(createData('Exp 1', '2022-01-01 10:00 UTC', 0));
+    await db.recordAllData(createData('Exp 1', '2022-01-01 12:00 UTC', 2));
+
+    await db.recordAllData(createData('Exp 2', '2022-02-02 10:00 UTC', 4));
+    await db.recordAllData(createData('Exp 2', '2022-02-02 12:00 UTC', 6));
+
+    const result = await dashResults(4, db);
+
+    expect(result.length).toEqual(1);
+    expect(result[0].benchmark).toEqual('multi-exp');
+    expect(result[0].values.length).toEqual(80);
+
+    for (let i = 0; i < 80; i += 1) {
+      expect(result[0].values[i]).toEqual(i + 1);
+    }
+  });
+});
 
 afterAll(async () => {
   return closeMainDb();

--- a/tests/db-setup.test.ts
+++ b/tests/db-setup.test.ts
@@ -37,7 +37,7 @@ describe('Setup of PostgreSQL DB', () => {
   });
 
   afterAll(async () => {
-    await db.close();
+    return db.close();
   });
 
   it('should load the database scheme without error', async () => {
@@ -72,11 +72,11 @@ describe('Recording a ReBench execution data fragments', () => {
   });
 
   afterAll(async () => {
-    await db.close();
+    return db.close();
   });
 
   afterEach(async () => {
-    await db.rollback();
+    return db.rollback();
   });
 
   it('should accept executor information', async () => {
@@ -241,7 +241,7 @@ describe('Recording a ReBench execution from payload files', () => {
   });
 
   afterAll(async () => {
-    await db.close();
+    return db.close();
   });
 
   it(`should accept all data (small-payload),
@@ -360,6 +360,6 @@ describe('Recording a ReBench execution from payload files', () => {
   });
 });
 
-afterAll(() => {
-  closeMainDb();
+afterAll(async () => {
+  return closeMainDb();
 });

--- a/tests/db-testing.ts
+++ b/tests/db-testing.ts
@@ -169,7 +169,7 @@ function getMainDB(): Database {
 
 export async function closeMainDb(): Promise<void> {
   if (mainDB !== null) {
-    await mainDB.close();
+    return mainDB.close();
   }
 }
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -26,7 +26,7 @@ describe('Record Trial', () => {
   });
 
   afterAll(async () => {
-    await db.close();
+    return db.close();
   });
 
   it('the database should not have any trials', async () => {
@@ -125,7 +125,7 @@ describe('Timeline-plot Queries', () => {
   });
 
   afterAll(async () => {
-    await db.close();
+    return db.close();
   });
 
   describe('Retrieving branch names based on commit ids', () => {
@@ -255,6 +255,6 @@ describe('Timeline-plot Queries', () => {
   });
 });
 
-afterAll(() => {
-  closeMainDb();
+afterAll(async () => {
+  return closeMainDb();
 });


### PR DESCRIPTION
The results were not correctly ordered.
The didn't consider invocation ordering, and were ordered newest to oldest, which is not what's expected.

Add a bunch of tests to make sure we consider most permutations possible.