### PR TITLE
Set the hostname in the GitLab CI setup for running the image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,4 +7,4 @@ build-and-benchmark:
   script:
     - podman build . -f Dockerfile -t rebenchdb
     - podman build . -f Dockerfile.rebench -t bench-rdb
-    - podman run bench-rdb:latest -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf
+    - podman run --hostname yuria2-podman bench-rdb:latest -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf


### PR DESCRIPTION
This makes sure we have a predictable hostname for recording results in ReBenchDB.