### PR TITLE
Improve Timeline View

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "@types/koa-router": "7.4.4",
         "@types/mustache": "4.2.1",
         "@types/pg": "8.6.5",
-        "@types/plotly.js": "1.54.22",
         "@typescript-eslint/eslint-plugin": "5.30.7",
         "@typescript-eslint/parser": "5.30.7",
         "ajv": "8.11.0",
@@ -1692,12 +1691,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/d3": {
-      "version": "3.5.47",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-3.5.47.tgz",
-      "integrity": "sha512-VkWIQoZXLFdcBGe5pdBKJmTU3fmpXvo/KV6ixvTzOMl1yJ2hbTXpfvsziag0kcaerPDwas2T0vxojwQG3YwivQ==",
-      "dev": true
-    },
     "node_modules/@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -1878,15 +1871,6 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
-      }
-    },
-    "node_modules/@types/plotly.js": {
-      "version": "1.54.22",
-      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-1.54.22.tgz",
-      "integrity": "sha512-/xL9++eA7VnIIZqNQOw6sZ7DtEmfoHj5rAD2CjU2LCOqem/BxTA1KlpdUWEHOiou6za4HKnM+Nvho3jTBPYJ/w==",
-      "dev": true,
-      "dependencies": {
-        "@types/d3": "^3"
       }
     },
     "node_modules/@types/prettier": {
@@ -8128,12 +8112,6 @@
         "@types/node": "*"
       }
     },
-    "@types/d3": {
-      "version": "3.5.47",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-3.5.47.tgz",
-      "integrity": "sha512-VkWIQoZXLFdcBGe5pdBKJmTU3fmpXvo/KV6ixvTzOMl1yJ2hbTXpfvsziag0kcaerPDwas2T0vxojwQG3YwivQ==",
-      "dev": true
-    },
     "@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -8314,15 +8292,6 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
-      }
-    },
-    "@types/plotly.js": {
-      "version": "1.54.22",
-      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-1.54.22.tgz",
-      "integrity": "sha512-/xL9++eA7VnIIZqNQOw6sZ7DtEmfoHj5rAD2CjU2LCOqem/BxTA1KlpdUWEHOiou6za4HKnM+Nvho3jTBPYJ/w==",
-      "dev": true,
-      "requires": {
-        "@types/d3": "^3"
       }
     },
     "@types/prettier": {

--- a/resources/style.css
+++ b/resources/style.css
@@ -95,6 +95,10 @@ nav.compare.show {
   font-size: 75%;
 }
 
+.benchmark h4 a {
+  color: initial;
+}
+
 .card {
   margin-top: 1em;
 }

--- a/resources/style.css
+++ b/resources/style.css
@@ -87,6 +87,14 @@ nav.compare.show {
   }
 }
 
+.benchmark .arguments {
+  font-size: 80%;
+}
+
+.benchmark code {
+  font-size: 75%;
+}
+
 .card {
   margin-top: 1em;
 }

--- a/resources/style.css
+++ b/resources/style.css
@@ -503,3 +503,15 @@ td.warmup-plot {
 .u-cursor-pt.u-off {
 	display: none;
 }
+
+.u-tooltip {
+  font-size: 10pt;
+  position: absolute;
+  background: #fff;
+  display: none;
+  border: 2px solid black;
+  padding: 4px;
+  pointer-events: none;
+  z-index: 100;
+  min-width: 250px;
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -193,6 +193,7 @@ export interface TimelineResponse {
   baseTimestamp: number | null;
   changeTimestamp: number | null;
   data: PlotData;
+  sourceIds: number[];
 }
 
 export type FullPlotData = [

--- a/src/api.ts
+++ b/src/api.ts
@@ -260,6 +260,10 @@ export interface TimelineBenchmark {
   benchName: string;
   cmdline: string;
   runId: number;
+  varValue?: string;
+  cores?: string;
+  inputSize?: string;
+  extraArgs?: string;
 }
 
 export interface TimelineJob {

--- a/src/db.ts
+++ b/src/db.ts
@@ -113,7 +113,7 @@ export interface Source {
   commitmessage: string;
   authorname: string;
   authoremail: string;
-  committereame: string;
+  committername: string;
   committeremail: string;
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -420,7 +420,11 @@ export abstract class Database {
                 exe.id as execId, exe.name as execName,
                 b.id as benchId, b.name as benchmark,
                 r.cmdline,
-                r.id as runId
+                r.id as runId,
+                r.varValue,
+                r.cores,
+                r.inputSize,
+                r.extraArgs
               FROM Project p
                 JOIN Experiment exp    ON exp.projectId = p.id
                 JOIN Trial t           ON t.expId = exp.id
@@ -1350,7 +1354,11 @@ export abstract class Database {
         benchId: r.benchid,
         benchName: r.benchmark,
         cmdline: simplifyCmdline(r.cmdline),
-        runId: r.runid
+        runId: r.runid,
+        varValue: r.varvalue,
+        cores: r.cores,
+        inputSize: r.inputsize,
+        extraArgs: r.extraargs
       });
     }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -828,6 +828,29 @@ export abstract class Database {
     }
   }
 
+  public async getSourceById(
+    projectSlug: string,
+    sourceId: string
+  ): Promise<Source | null> {
+    const q: QueryConfig = {
+      name: 'get-source-by-slug-id',
+      text: `SELECT DISTINCT s.*
+              FROM Source s
+                JOIN Trial t       ON t.sourceId = s.id
+                JOIN Experiment e  ON e.id = t.expId
+                JOIN Project p     ON p.id = e.projectId
+              WHERE p.name = $1 AND s.id = $2
+              LIMIT 1`,
+      values: [projectSlug, sourceId]
+    };
+
+    const result = await this.query(q);
+    if (result.rowCount < 1) {
+      return null;
+    }
+    return result.rows[0];
+  }
+
   public async getSourceByNames(
     projectName: string,
     experimentName: string

--- a/src/db.ts
+++ b/src/db.ts
@@ -1438,6 +1438,7 @@ export abstract class Database {
   ): TimelineResponse {
     let baseTimestamp: number | null = null;
     let changeTimestamp: number | null = null;
+    const sourceIds: number[] = [];
     const data: PlotData =
       baseBranchName !== null
         ? [
@@ -1458,6 +1459,7 @@ export abstract class Database {
 
     for (const row of rows) {
       data[0].push(row.starttime);
+      sourceIds.push(<number>parseInt(row.sourceid));
       if (baseBranchName === null || row.branch == baseBranchName) {
         if (baseBranchName !== null && row.iscurrent) {
           baseTimestamp = row.starttime;
@@ -1490,7 +1492,8 @@ export abstract class Database {
       changeBranchName,
       baseTimestamp,
       changeTimestamp,
-      data
+      data,
+      sourceIds
     };
   }
 
@@ -1502,6 +1505,7 @@ export abstract class Database {
       SELECT
         extract(epoch from tr.startTime at time zone 'UTC')::int as startTime,
         s.branchOrTag as branch,
+        s.id as sourceId,
         ti.median, ti.bci95low, ti.bci95up
       FROM Timeline ti
         JOIN Trial      tr ON tr.id = ti.trialId
@@ -1533,6 +1537,7 @@ export abstract class Database {
       SELECT
         extract(epoch from tr.startTime at time zone 'UTC')::int as startTime,
         s.branchOrTag as branch, s.commitid IN ($1, $2) as isCurrent,
+        s.id as sourceId,
         ti.median, ti.bci95low, ti.bci95up
       FROM Timeline ti
         JOIN Trial      tr ON tr.id = ti.trialId

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,18 @@ function respondProjectNotFound(ctx, projectSlug: string) {
   ctx.type = 'text';
 }
 
+function respondProjectAndSourceNotFound(
+  ctx,
+  projectSlug: string,
+  sourceId: string
+) {
+  ctx.body =
+    `Requested combination of project "${projectSlug}"` +
+    ` and source ${sourceId} not found`;
+  ctx.status = 404;
+  ctx.type = 'text';
+}
+
 function respondExpIdNotFound(ctx, expId: string) {
   ctx.body = `Requested experiment ${expId} not found`;
   ctx.status = 404;
@@ -236,6 +248,24 @@ router.get('/compare/:project/:baseline/:change', async (ctx) => {
     );
   } else {
     respondProjectNotFound(ctx, ctx.params.project);
+  }
+});
+
+router.get('/:projectSlug/source/:sourceId', async (ctx) => {
+  const result = await db.getSourceById(
+    ctx.params.projectSlug,
+    ctx.params.sourceId
+  );
+
+  if (result !== null) {
+    ctx.body = result;
+    ctx.type = 'application/json';
+  } else {
+    respondProjectAndSourceNotFound(
+      ctx,
+      ctx.params.projectSlug,
+      ctx.params.sourceId
+    );
   }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,8 @@ import {
   dashGetExpData,
   reportCompletion,
   dashDeleteOldReport,
-  dashProfile
+  dashProfile,
+  dashLatestBenchmarksForTimelineView
 } from './dashboard.js';
 import { processTemplate } from './templates.js';
 import {
@@ -105,7 +106,7 @@ router.get('/:projectSlug/timeline', async (ctx) => {
   if (project) {
     ctx.body = processTemplate('timeline.html', {
       project,
-      benchmarks: await db.getLatestBenchmarksForTimelineView(project.id)
+      benchmarks: await dashLatestBenchmarksForTimelineView(project.id, db)
     });
     ctx.type = 'html';
   } else {

--- a/src/views/plots.ts
+++ b/src/views/plots.ts
@@ -186,10 +186,7 @@ function tooltipPlugin({
   const tooltip = document.createElement('div');
   tooltip.className = 'u-tooltip';
 
-  const fmtDate = uPlot.fmtDate('{YYYY}-{MM}-{DD} {HH}:{mm}:{ss}');
-
   let over;
-
   let tooltipVisible = false;
 
   function showTooltip() {
@@ -269,11 +266,11 @@ function tooltipPlugin({
         }
       ],
       setSeries: [
-        (u, sidx) => {
-          if (seriesIdx != sidx) {
-            seriesIdx = sidx;
+        (u, sIdx) => {
+          if (seriesIdx != sIdx) {
+            seriesIdx = sIdx;
 
-            if (sidx === null) {
+            if (sIdx === null) {
               hideTooltip();
             } else if (dataIdx !== null && seriesIdx !== null) {
               setTooltip(u, seriesIdx, dataIdx);

--- a/src/views/render.ts
+++ b/src/views/render.ts
@@ -1,7 +1,7 @@
 import type { AllResults } from 'api.js';
 import { renderResultsPlots } from './plots.js';
 
-function filterCommitMessage(msg) {
+export function filterCommitMessage(msg: string): string {
   const result = msg.replace(/Signed-off-by:.*?\n/g, '');
   return result;
 }

--- a/src/views/timeline.html
+++ b/src/views/timeline.html
@@ -64,8 +64,8 @@
     <div class="title-executor">Executor: {{execName}}</div>
 
     {{#benchmarks}}
-    <div class="benchmark">
-    <h4>{{benchName}}<span class="arguments">{{varValue}} {{cores}} {{inputSize}} {{extraArgs}}</span></h4>
+    <div class="benchmark" id="b-{{suiteId}}-{{execId}}-{{benchId}}-{{runId}}">
+    <h4><a href="#b-{{suiteId}}-{{execId}}-{{benchId}}-{{runId}}">{{benchName}}<span class="arguments">{{varValue}} {{cores}} {{inputSize}} {{extraArgs}}</span></a></h4>
     <p><code>{{cmdline}}</code></p>
 
     <div class="timeline-plot" data-runid="{{runId}}"></div>

--- a/src/views/timeline.html
+++ b/src/views/timeline.html
@@ -64,8 +64,8 @@
     <div class="title-executor">Executor: {{execName}}</div>
 
     {{#benchmarks}}
-    <div class="benchmark" id="b-{{suiteId}}-{{execId}}-{{benchId}}-{{runId}}">
-    <h4><a href="#b-{{suiteId}}-{{execId}}-{{benchId}}-{{runId}}">{{benchName}}<span class="arguments">{{varValue}} {{cores}} {{inputSize}} {{extraArgs}}</span></a></h4>
+    <div class="benchmark" id="b-{{benchName}}-{{runId}}">
+    <h4><a href="#b-{{benchName}}-{{runId}}">{{benchName}}<span class="arguments">{{varValue}} {{cores}} {{inputSize}} {{extraArgs}}</span></a></h4>
     <p><code>{{cmdline}}</code></p>
 
     <div class="timeline-plot" data-runid="{{runId}}"></div>

--- a/src/views/timeline.html
+++ b/src/views/timeline.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta id="project-id" value="{{project.id}}">
+  <meta id="project-slug" value="{{project.slug}}">
   <title>ReBench: Timeline {{project.name}}</title>
   {{{headerHtml}}}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.appear/0.4.1/jquery.appear.min.js" integrity="sha256-19/eyBKQKb8IPrt7321hbLkI1+xyM8d/DpzjyiEKnCE=" crossorigin="anonymous"></script>

--- a/src/views/timeline.html
+++ b/src/views/timeline.html
@@ -64,8 +64,8 @@
 
     {{#benchmarks}}
     <div class="benchmark">
-    <h4>{{benchName}}</h4>
-    <p>{{cmdline}}</p>
+    <h4>{{benchName}}<span class="arguments">{{varValue}} {{cores}} {{inputSize}} {{extraArgs}}</span></h4>
+    <p><code>{{cmdline}}</code></p>
 
     <div class="timeline-plot" data-runid="{{runId}}"></div>
     </div>

--- a/src/views/timeline.ts
+++ b/src/views/timeline.ts
@@ -3,6 +3,7 @@ import { initializeFilters } from './filter.js';
 import { renderTimelinePlot } from './plots.js';
 
 const projectId = $('#project-id').attr('value');
+const projectSlug = <string>$('#project-slug').attr('value');
 
 async function loadPlotOnce(this: any) {
   const thisJq = $(this);
@@ -17,7 +18,7 @@ async function loadPlotOnce(this: any) {
     `/rebenchdb/dash/${projectId}/timeline/${runId}`
   );
   const response = <TimelineResponse>await timelineP.json();
-  renderTimelinePlot(response, thisJq);
+  renderTimelinePlot(response, thisJq, projectSlug);
   thisJq.off('appear', onPlotAppearing);
 }
 

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -203,7 +203,11 @@ describe('Test Dashboard with basic test data loaded', () => {
                 benchName: 'NBody',
                 cmdline:
                   'som -t1   core-lib/Benchmarks/Harness.ns NBody  1 0 10000',
-                runId: 1
+                runId: 1,
+                cores: '1',
+                extraArgs: '1 0 10000',
+                inputSize: null,
+                varValue: null
               }
             ],
             execId: 1,
@@ -230,7 +234,8 @@ describe('Test Dashboard with basic test data loaded', () => {
         [null, null],
         [432.783, 432.783],
         [null, null]
-      ]
+      ],
+      sourceIds: [1, 3]
     });
   });
 


### PR DESCRIPTION
This PR includes a number of usability improvements for the timeline view:

 - show a tooltip with the commit details when hovering over a datapoint
 - indicate parameters to the benchmark in the benchmark name, instead of solely in the command line
 - make the benchmark name a link, which is revealed on hover to be able to deep-link to a specific plot