### PR TITLE
Added a project setting to disable github notifications

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -538,6 +538,11 @@ export async function reportCompletion(
 ): Promise<void> {
   await db.reportCompletion(data);
 
+  const project = await db.getProjectByName(data.projectName);
+  if (!project) {
+    throw new Error(`No project with name ${data.projectName} found.`);
+  }
+
   const change = await db.getSourceByNames(
     data.projectName,
     data.experimentName
@@ -576,7 +581,7 @@ export async function reportCompletion(
     db
   );
 
-  if (github !== null) {
+  if (github !== null && project.githubnotification) {
     reportCompletionToGitHub(
       github,
       reportId,

--- a/src/db.ts
+++ b/src/db.ts
@@ -101,6 +101,7 @@ export interface Project {
   logo: string;
   showchanges: boolean;
   allresults: boolean;
+  githubnotification: boolean;
   basebranch: string;
 }
 

--- a/src/db/db.sql
+++ b/src/db/db.sql
@@ -72,6 +72,7 @@ CREATE TABLE Project (
   logo varchar,
   showChanges bool DEFAULT true,
   allResults bool DEFAULT false,
+  githubNotification bool DEFAULT true,
 
   -- display projects in descending order of position
   position integer DEFAULT 0,

--- a/src/db/migration.009.sql
+++ b/src/db/migration.009.sql
@@ -1,0 +1,3 @@
+-- Add a column to indicate whether we want notifications on github for this
+-- project.
+ALTER TABLE Project ADD COLUMN githubNotification bool DEFAULT true;


### PR DESCRIPTION
Currently, GitHub comments would have been always created when the project seemed to be hosted on GitHub, though, for some projects that's not desired.

Using the new `githubNotification` column in the project database table, they can be disabled.