### PR TITLE
Fix the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:15-bullseye
+FROM postgres:15-bookworm
 # this allows the setup to ignore all of the ubuntu OS setup
 # thats not needed for this docker image (Time Zone for example)
 ARG DEBIAN_FRONTEND=noninteractive
@@ -12,7 +12,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # Add Node.js repo
 RUN curl -sL https://deb.nodesource.com/setup_19.x | bash -
 
-RUN sh -c 'echo "deb http://cloud.r-project.org/bin/linux/debian bullseye-cran40/" > /etc/apt/sources.list.d/r-project.list' && \
+RUN sh -c 'echo "deb http://cloud.r-project.org/bin/linux/debian bookworm-cran40/" > /etc/apt/sources.list.d/r-project.list' && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Add Node.js repo
-RUN curl -sL https://deb.nodesource.com/setup_19.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 
 RUN sh -c 'echo "deb http://cloud.r-project.org/bin/linux/debian bookworm-cran40/" > /etc/apt/sources.list.d/r-project.list' && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'

--- a/Dockerfile.rebench
+++ b/Dockerfile.rebench
@@ -2,7 +2,7 @@
 FROM rebenchdb:latest
 
 RUN apt-get install -y git python3-pip
-RUN pip install git+https://github.com/smarr/ReBench.git
+RUN pip install --break-system-packages git+https://github.com/smarr/ReBench.git
 
 RUN echo 'echo Starting PostgreSQL Server\n\
 docker-entrypoint.sh postgres &\n\


### PR DESCRIPTION
The docker image didn't build anymore, because it got a 404 downloading some dependency.

So, I thought, we may as well upgrade the base image to the latest Debian.

Interestingly, Python doesn't like `pip install` anymore: https://peps.python.org/pep-0668/
Not sure that's really useful for a docker image and/or ReBench, so, I'll just override the behavior with `pip install --break-system-packages`