### PR TITLE
Sort the benchmarks in list, also based on arguments

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -190,6 +190,10 @@ th[scope=col] {
   width: auto !important;
 }
 
+.compare .all-args {
+  margin-left: 0.25ex;
+}
+
 table.benchmark-details > tbody > tr > th:nth-child(1) {
   min-width: 5em;
   max-width: 7em;

--- a/src/backend/compare/db-data.ts
+++ b/src/backend/compare/db-data.ts
@@ -96,17 +96,23 @@ function sortResultsAlphabetically(
   byExeSuiteBench: ResultsByExeSuiteBenchmark
 ) {
   const exeBySuiteBench = Array.from(byExeSuiteBench.entries());
-  exeBySuiteBench.sort((a, b) => a[0].localeCompare(b[0]));
+  exeBySuiteBench.sort((a, b) =>
+    a[0].localeCompare(b[0], undefined, { numeric: true })
+  );
 
   for (const exeSuitePair of exeBySuiteBench) {
     const bySuiteBench = exeSuitePair[1];
     const suiteByBench = Array.from(bySuiteBench.entries());
-    suiteByBench.sort((a, b) => a[0].localeCompare(b[0]));
+    suiteByBench.sort((a, b) =>
+      a[0].localeCompare(b[0], undefined, { numeric: true })
+    );
 
     for (const suiteBenchPair of suiteByBench) {
       const byBench = suiteBenchPair[1];
       const bench = Array.from(byBench.benchmarks.entries());
-      bench.sort((a, b) => a[0].localeCompare(b[0]));
+      bench.sort((a, b) =>
+        a[0].localeCompare(b[0], undefined, { numeric: true })
+      );
       byBench.benchmarks = new Map(bench);
     }
 

--- a/src/backend/compare/html/stats-row.html
+++ b/src/backend/compare/html/stats-row.html
@@ -2,14 +2,8 @@
 const stats = it.stats;
 
 let args = '';
-
-if (stats.details.numV  > 1) { args += stats.benchId.v + ' '; }
-if (stats.details.numC  > 1) { args += stats.benchId.c + ' '; }
-if (stats.details.numI  > 1) { args += stats.benchId.i + ' '; }
-if (stats.details.numEa > 1) { args += stats.benchId.ea + ' '; }
-
-if (args.length > 0) {
-  args = `<span class="all-args">${args.trim()}</span>`;
+if (stats.argumentsForDisplay.length > 0) {
+  args = `<span class="all-args">${stats.argumentsForDisplay}</span>`;
 }
 
 if (stats.missing) {

--- a/src/backend/compare/html/stats-tbl.html
+++ b/src/backend/compare/html/stats-tbl.html
@@ -4,7 +4,8 @@
   isAcrossExes: it.isAcrossExes
 }) %}
 <tbody>
-{%    for (const benchmark of it.benchmarks) {
+{%  it.benchmarks.sort(it.viewHelpers.sortByNameAndArguments);
+    for (const benchmark of it.benchmarks) {
 %}{%-   include('stats-row.html', {
           config: it.config,
           stats: benchmark,

--- a/src/backend/compare/prep-data.ts
+++ b/src/backend/compare/prep-data.ts
@@ -42,6 +42,7 @@ import { siteAesthetics } from '../../shared/aesthetics.js';
 import { collateMeasurements } from './db-data.js';
 import { HasProfile } from '../db/has-profile.js';
 import { assert } from '../../backend/logging.js';
+import { getBenchmarkArgumentsAsNamePart } from '../../shared/helpers.js';
 
 export function compareStringOrNull(
   a: string | null,
@@ -251,8 +252,10 @@ function addOrGetCompareStatsRow(
         numI: countsAndMissing === null ? 0 : countsAndMissing.numI,
         numEa: countsAndMissing === null ? 0 : countsAndMissing.numEa,
         numEnv: countsAndMissing === null ? 0 : countsAndMissing.numEnv
-      }
+      },
+      argumentsForDisplay: ''
     };
+    row.argumentsForDisplay = getBenchmarkArgumentsAsNamePart(row);
     variants.set(key, row);
   }
   return row;
@@ -329,6 +332,7 @@ export function countVariantsAndDropMissing(
         mi.details.numI = numI;
         mi.details.numEa = numEa;
         mi.details.numEnv = numEnv;
+        mi.argumentsForDisplay = getBenchmarkArgumentsAsNamePart(mi);
       }
     }
     return { numV, numC, numI, numEa, numEnv, missing };

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -1,3 +1,5 @@
+import type { CompareStatsRow } from './view-types.js';
+
 /**
  * Returns the common start of a list of strings.
  */
@@ -51,4 +53,42 @@ export class PerIterationOutput {
     }
     return this.allButFirst;
   }
+}
+
+export function getBenchmarkArgumentsAsNamePart(
+  benchmark: CompareStatsRow
+): string {
+  let args = '';
+
+  if (benchmark.details.numV > 1) {
+    args += benchmark.benchId.v + ' ';
+  }
+  if (benchmark.details.numC > 1) {
+    args += benchmark.benchId.c + ' ';
+  }
+  if (benchmark.details.numI > 1) {
+    args += benchmark.benchId.i + ' ';
+  }
+  if (benchmark.details.numEa > 1) {
+    args += benchmark.benchId.ea + ' ';
+  }
+
+  return args.trim();
+}
+
+export function sortByNameAndArguments(
+  a: CompareStatsRow,
+  b: CompareStatsRow
+): number {
+  const result = a.benchId.b.localeCompare(b.benchId.b, undefined, {
+    numeric: true
+  });
+
+  if (result !== 0) {
+    return result;
+  }
+
+  return a.argumentsForDisplay.localeCompare(b.argumentsForDisplay, undefined, {
+    numeric: true
+  });
 }

--- a/src/shared/view-types.ts
+++ b/src/shared/view-types.ts
@@ -111,6 +111,7 @@ export interface MissingData {
 export interface CompareStatsRow {
   benchId: BenchmarkId;
   details: RunDetails;
+  argumentsForDisplay: string;
 
   missing?: MissingData[];
 

--- a/tests/backend/compare/compare-view.test.ts
+++ b/tests/backend/compare/compare-view.test.ts
@@ -227,7 +227,8 @@ describe('Compare View Parts', () => {
           benchId,
           details,
           inlinePlot: 'inline.png',
-          versionStats
+          versionStats,
+          argumentsForDisplay: ''
         },
         environments,
         dataFormatters,
@@ -245,7 +246,8 @@ describe('Compare View Parts', () => {
           benchId,
           details,
           inlinePlot: 'inline.png',
-          exeStats
+          exeStats,
+          argumentsForDisplay: ''
         },
         environments,
         dataFormatters,
@@ -265,7 +267,8 @@ describe('Compare View Parts', () => {
           inlinePlot: 'inline.png',
           missing: [
             { commitId: 'aaa', criterion: { name: 'total', unit: 'ms' } }
-          ]
+          ],
+          argumentsForDisplay: ''
         },
         environments,
         dataFormatters,
@@ -291,7 +294,8 @@ describe('Compare View Parts', () => {
               criterion: { name: 'some missing criterion', unit: 'ms' }
             }
           ],
-          versionStats
+          versionStats,
+          argumentsForDisplay: ''
         },
         environments,
         dataFormatters,
@@ -320,7 +324,8 @@ describe('Compare View Parts', () => {
             benchId,
             details,
             inlinePlot: 'inline.png',
-            versionStats
+            versionStats,
+            argumentsForDisplay: ''
           }
         ],
         environments,
@@ -429,7 +434,8 @@ describe('Compare View Parts', () => {
             benchId,
             details,
             inlinePlot: 'inline.png',
-            versionStats
+            versionStats,
+            argumentsForDisplay: ''
           }
         ]
       };

--- a/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
@@ -3818,6 +3818,43 @@ graal
 </td>
 </tr>
 <tr>
+<th scope="row">Fannkuch</th>
+  <td class="inline-cmp"><img src="/static/reports/tsom/inline-exe-37.svg"></td>
+<td>
+graal-bc
+<br>interp
+<br>native-interp-ast
+<br>native-interp-bc
+</td>
+<td class="stats-samples">
+5
+<br>5
+<br>5
+<br>5
+</td>
+<td><span class="stats-median" title="median">
+194.92
+<br>123.53
+<br>44.35
+<br>71.65
+</span></td>
+<td>
+<span class="stats-change" title="change over median run time">0</span>
+<br><span class="stats-change" title="change over median run time">-37</span>
+<br><span class="stats-change" title="change over median run time">-77</span>
+<br><span class="stats-change" title="change over median run time">-63</span>
+</td>
+
+
+
+<td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
+  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
+<button type="button" class="btn btn-sm btn-environment btn-popover"
+    data-content=""></button>
+<button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
+</td>
+</tr>
+<tr>
 <th scope="row">Fibonacci</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-exe-21.svg"></td>
 <td>
@@ -4407,43 +4444,6 @@ graal
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
-</td>
-</tr>
-<tr>
-<th scope="row">Fannkuch</th>
-  <td class="inline-cmp"><img src="/static/reports/tsom/inline-exe-37.svg"></td>
-<td>
-graal-bc
-<br>interp
-<br>native-interp-ast
-<br>native-interp-bc
-</td>
-<td class="stats-samples">
-5
-<br>5
-<br>5
-<br>5
-</td>
-<td><span class="stats-median" title="median">
-194.92
-<br>123.53
-<br>44.35
-<br>71.65
-</span></td>
-<td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-37</span>
-<br><span class="stats-change" title="change over median run time">-77</span>
-<br><span class="stats-change" title="change over median run time">-63</span>
-</td>
-
-
-
-<td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
-<button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
-<button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
This PR makes sure the benchmarks are sorted, considering natural number ordering, from the name and any arguments.

It also adds a little space between name and arguments for readability.

I now concatenate the arguments early to only have to do it once, and then do the sorting in the template right before showing the data.

This resolves #150.