### PR TITLE
Fix overview labelling and base table columns on available data

### DIFF
--- a/src/backend/compare/html/stats-row-across-exes.html
+++ b/src/backend/compare/html/stats-row-across-exes.html
@@ -18,12 +18,30 @@ const commonStart = h.commonStringStart(it.exes.map((e) => e.exeName));
   %}{%= e.criteria.total.samples %}
 {% }
 %}</td>
+{% for (const i of it.criteriaOrder) {
+  const cssClassForTotal = i === 'total' ? ' stats-total' : '';
+  let medianFmtFn;
+  if (i === 'total') {
+    medianFmtFn = f.r2;
+  } else {
+    switch (it.criteria[i].unit) {
+      case 'bytes':
+        medianFmtFn = f.asHumanMem;
+        break;
+      default:
+        medianFmtFn = f.r0;
+        break;
+    }
+  }
+
+  const changeFmtFn = f.per;
+%}
 <td><span class="stats-median" title="median">
 {%
   itOut = new h.PerIterationOutput('', '<br>');
   for (const e of it.exes) {
   %}{%- itOut.next()
-  %}{%= f.r2(e.criteria.total.median) %}
+  %}{%= medianFmtFn(e.criteria[i].median) %}
 {% }
 %}</span></td>
 <td>
@@ -31,39 +49,7 @@ const commonStart = h.commonStringStart(it.exes.map((e) => e.exeName));
   itOut = new h.PerIterationOutput('', '<br>');
   for (const e of it.exes) {
   %}{%- itOut.next()
-  %}<span class="stats-change" title="change over median run time">{%= f.per(e.criteria.total.change_m) %}</span>
+  %}<span class="stats-change{%= cssClassForTotal %}" title="diff %">{%= changeFmtFn(e.criteria[i].change_m) %}</span>
 {% }
-%}</td>
-{% if (it.exes[0].criteria.gcTime) {
-%}<td><span class="stats-median" title="median">
-{%
-  itOut = new h.PerIterationOutput('', '<br>');
-  for (const e of it.exes) {
-  %}{%- itOut.next()
-  %}{%= f.r0(e.criteria.gcTime.median) %}
-{% }
-%}</span></td>
-<td>
-{%
-  itOut = new h.PerIterationOutput('', '<br>');
-  for (const e of it.exes) {
-  %}{%- itOut.next()
-  %}<span class="stats-change" title="change over median GC time">{%= f.per(e.criteria.gcTime.change_m) %}</span>
-{% }
-%}</td>{% } %}
-{% if (it.exes[0].criteria.allocated) { %}<td><span class="stats-median" title="median">
-{%
-  itOut = new h.PerIterationOutput('', '<br>');
-  for (const e of it.exes) {
-  %}{%- itOut.next()
-  %}{%= f.asHumanMem(e.criteria.allocated.median) %}
-{% }
-%}</span></td>
-<td>
-{%
-  itOut = new h.PerIterationOutput('', '<br>');
-  for (const e of it.exes) {
-  %}{%- itOut.next()
-  %}<span class="stats-change" title="change over median allocated">{%= f.per(e.criteria.allocated.change_m) %}</span>
-{% }
-%}</td>{% } %}
+%}</td>{%
+  } %}

--- a/src/backend/compare/html/stats-row-across-versions.html
+++ b/src/backend/compare/html/stats-row-across-versions.html
@@ -1,14 +1,26 @@
 {%
 const f = it.dataFormatters;
 const s = it.stats;
+
 %}<td class="stats-samples">{%= s.total.samples %}</td>
-<td><span class="stats-median" title="median">{%= f.r2(s.total.median) %}</span></td>
-<td><span class="stats-change" title="change over median run time">{%= f.per(s.total.change_m) %}</span></td>
-{% if (s.gcTime) {
-%}<td><span class="stats-median" title="median">{%= f.r0(s.gcTime.median) %}</span></td>
-<td><span class="stats-gc-change" title="change over median GC time">{%= f.per(s.gcTime.change_m) %}</span></td>
-{% }
-   if (s.allocated) {
-  %}<td><span class="stats-median" title="median">{%= f.asHumanMem(s.allocated.median) %}</span></td>
-<td><span class="stats-alloc-change" title="change over median allocated memory">{%= f.per(s.allocated.change_m) %}</span></td>{%
+{% for (const i of it.criteriaOrder) {
+    const cssClassForTotal = i === 'total' ? ' stats-total' : '';
+    let median;
+    if (i === 'total') {
+      median = f.r2(s[i].median);
+    } else {
+      switch (it.criteria[i].unit) {
+        case 'bytes':
+          median = f.asHumanMem(s[i].median);
+          break;
+        default:
+          median = f.r0(s[i].median);
+          break;
+      }
+    }
+
+    const change = f.per(s[i].change_m);
+%}
+<td><span class="stats-median" title="median">{%= median %}</span></td>
+<td><span class="stats-change{%= cssClassForTotal %}" title="diff %">{%= change %}</span></td>{%
 } %}

--- a/src/backend/compare/html/stats-row.html
+++ b/src/backend/compare/html/stats-row.html
@@ -51,7 +51,9 @@ if (!stats.missing || hasTotal) {
 {%   } else {
 %}{%-   include('stats-row-across-versions.html', {
         stats: stats.versionStats,
-        dataFormatters: it.dataFormatters}
+        dataFormatters: it.dataFormatters,
+        criteriaOrder: it.criteriaOrder,
+        criteria: it.criteria}
       ) %}
 {%   }
 %}<td>{%- include('stats-row-buttons-info.html', {

--- a/src/backend/compare/html/stats-row.html
+++ b/src/backend/compare/html/stats-row.html
@@ -46,7 +46,9 @@ if (!stats.missing || hasTotal) {
 %}{%-   include('stats-row-across-exes.html', {
           exes: stats.exeStats,
           dataFormatters: it.dataFormatters,
-          viewHelpers: it.viewHelpers}
+          viewHelpers: it.viewHelpers,
+          criteriaOrder: it.criteriaOrder,
+          criteria: it.criteria}
       ) %}
 {%   } else {
 %}{%-   include('stats-row-across-versions.html', {

--- a/src/backend/compare/html/stats-summary.html
+++ b/src/backend/compare/html/stats-summary.html
@@ -11,13 +11,13 @@
 %}
 </div>
 <dl class="row">
-  <dt class="col-sm-5" style="white-space: nowrap;">Number of Run Configurations</dt>
-  <dd class="col-sm-5">{%= it.numRunConfigs %}</dd>
+  <dt class="col-sm-3" style="white-space: nowrap;">Number of Run Configurations</dt>
+  <dd class="col-sm-7">{%= it.numRunConfigs %}</dd>
 
 {% for (let name in s) {
       const data = s[name];
       const label = name === 'total' ? 'Run time' : name;
-%}  <dt class="col-sm-5">Median {%= label %} in {%= data.unit %}</dt>
-  <dd class="col-sm-5">{%= d.r2(data.median) %} (min. {%= d.r2(data.min) %}, max. {%= d.r2(data.max) %})</dd>
+%}  <dt class="col-sm-3">Change of {%= label %}</dt>
+  <dd class="col-sm-7">median {%= d.per(data.median) %}% (min. {%= d.per(data.min) %}%, max. {%= d.per(data.max) %}%)</dd>
 {% }
 %}</dl>

--- a/src/backend/compare/html/stats-tbl-header.html
+++ b/src/backend/compare/html/stats-tbl-header.html
@@ -3,15 +3,13 @@
 <th scope="col"></th>
 {% if (it.isAcrossExes) { %}<th scope="col" title="Executor, without common prefix with baseline">Exe</th>{% } %}
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in {%= it.criteria.total.unit %}</th>
-<th scope="col">time diff %</th>
-{% if (it.criteria['GC time']) { %}
-<th scope="col">median GC<br>time in {%= it.criteria['GC time'].unit %}</th>
-<th scope="col">GC diff %</th>
-{% }
-   if (it.criteria.Allocated) { %}
-<th scope="col">median <br>allocated {%= it.criteria.Allocated.unit %}</th>
-<th scope="col">Alloc diff %</th>
+{% for (const i of it.criteriaOrder) {
+   const name = it.criteria[i].name;
+   const unit = it.criteria[i].unit;
+   const longLabel = it.dataFormatters.smartLower(name === 'total' ? 'time' : name);
+   const shortLabel = name === 'total' ? 'time' : it.dataFormatters.shortenCriteria(longLabel);
+%}<th scope="col" title="median {%= longLabel %}">median {%= shortLabel %}<br>in {%= unit %}</th>
+<th scope="col" title="difference in % of {%= longLabel %}">{%= shortLabel %} diff %</th>
 {% } %}
 <th scope="col"></th>
 </tr></thead>

--- a/src/backend/compare/html/stats-tbl.html
+++ b/src/backend/compare/html/stats-tbl.html
@@ -1,7 +1,11 @@
 <table class="table table-sm benchmark-details">
-{%- include('stats-tbl-header.html', {
+{% const criteria = Object.keys(it.criteria);
+    it.viewHelpers.sortTotalToFront(criteria);
+%}{%- include('stats-tbl-header.html', {
   criteria: it.criteria,
-  isAcrossExes: it.isAcrossExes
+  criteriaOrder: criteria,
+  isAcrossExes: it.isAcrossExes,
+  dataFormatters: it.dataFormatters,
 }) %}
 <tbody>
 {%  it.benchmarks.sort(it.viewHelpers.sortByNameAndArguments);
@@ -12,7 +16,9 @@
           environments: it.environments,
           dataFormatters: it.dataFormatters,
           viewHelpers: it.viewHelpers,
-          isAcrossExes: it.isAcrossExes
+          isAcrossExes: it.isAcrossExes,
+          criteriaOrder: criteria,
+          criteria: it.criteria,
         }) %}
 {%  }
 %}</tbody>

--- a/src/backend/compare/prep-data.ts
+++ b/src/backend/compare/prep-data.ts
@@ -1117,6 +1117,15 @@ export async function prepareCompareView(
   return data;
 }
 
+function filterOutZeroChange(criteria: Map<string, ComparisonStatsWithUnit>) {
+  for (const key of criteria.keys()) {
+    const stats = criteria.get(key);
+    if (stats?.data.every((s) => s.change_m === 0 && s.median === 0)) {
+      criteria.delete(key);
+    }
+  }
+}
+
 export async function calculateAllStatisticsAndRenderPlots(
   byExeSuiteBench: ResultsByExeSuiteBenchmark,
   suitesWithMultipleExecutors: string[],
@@ -1160,6 +1169,9 @@ export async function calculateAllStatisticsAndRenderPlots(
     reportOutputFolder,
     inlinePlotName + '-exe'
   );
+
+  filterOutZeroChange(criteriaAcrossVersions);
+  filterOutZeroChange(criteriaAcrossExes);
 
   const plotData = calculateDataForOverviewPlot(comparisonData, 'total');
 

--- a/src/backend/compare/prep-data.ts
+++ b/src/backend/compare/prep-data.ts
@@ -539,28 +539,26 @@ async function computeStatisticsAndInlinePlot(
 
     row.versionStats[change.criterion.name] = changeStats;
 
-    if (
-      outputFolder !== null &&
-      plotName != null &&
-      change.criterion.name === inlinePlotCriterion
-    ) {
-      lastPlotId += 1;
-      row.inlinePlot = await createInlinePlot(
-        base.commitId,
-        change.commitId,
-        sortedBase,
-        sortedChange,
-        outputFolder,
-        plotName,
-        lastPlotId
-      );
+    if (change.criterion.name === inlinePlotCriterion) {
+      numRunConfigs += 1;
+
+      if (outputFolder !== null && plotName != null) {
+        lastPlotId += 1;
+        row.inlinePlot = await createInlinePlot(
+          base.commitId,
+          change.commitId,
+          sortedBase,
+          sortedChange,
+          outputFolder,
+          plotName,
+          lastPlotId
+        );
+      }
     }
 
     if (perCriteria !== null) {
       recordPerCriteria(perCriteria, measurements, i, baseOffset, changeStats);
     }
-
-    numRunConfigs += 1;
   }
 
   return { lastPlotId, numRunConfigs };

--- a/src/frontend/compare.ts
+++ b/src/frontend/compare.ts
@@ -9,10 +9,11 @@ function determineAndDisplaySignificance() {
 
 function displaySignificance(sig) {
   $('#significance-val').val(`${sig}%`);
-  $('.stats-change').each((i, e) => {
+  $('.stats-change.stats-total').each((i, e) => {
     const change = parseFloat(<string>e.textContent);
     const parent = $(e).parent();
-    const target = parent.find('.stats-change').length > 1 ? $(e) : parent;
+    const target =
+      parent.find('.stats-change.stats-total').length > 1 ? $(e) : parent;
     if (change < -sig) {
       target.css('background-color', '#e4ffc7');
     } else if (change > sig) {

--- a/src/shared/data-format.ts
+++ b/src/shared/data-format.ts
@@ -130,3 +130,32 @@ export function dataSeriesIds(
     `${ids.change.commitId}/${changeTrialId}`
   );
 }
+
+/**
+ * Turn the text into lower case, but keep abbreviations in upper case.
+ */
+export function smartLower(text: string): string {
+  const words = text.split(' ');
+  const result: string[] = [];
+  for (const word of words) {
+    if (word.length > 1 && word === word.toUpperCase()) {
+      result.push(word);
+    } else {
+      result.push(word.toLowerCase());
+    }
+  }
+  return result.join(' ');
+}
+
+export function shortenCriteria(text: string): string {
+  const words = text.split(' ');
+  const result: string[] = [];
+  for (const word of words) {
+    // skip the word 'time'
+    if (word.toLowerCase() === 'time') {
+      continue;
+    }
+    result.push(word);
+  }
+  return result.join(' ');
+}

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -92,3 +92,12 @@ export function sortByNameAndArguments(
     numeric: true
   });
 }
+
+export function sortTotalToFront(criteria: string[]): string[] {
+  const i = criteria.indexOf('total');
+  if (i !== -1) {
+    criteria.splice(i, 1);
+    criteria.unshift('total');
+  }
+  return criteria;
+}

--- a/src/shared/view-types.ts
+++ b/src/shared/view-types.ts
@@ -34,6 +34,9 @@ export type CompareStatsTableHeader = Record<string, CriterionData>;
 
 export interface CompareStatsTableHeaderPartial {
   criteria: CompareStatsTableHeader;
+  criteriaOrder: string[];
+  dataFormatters: DataFormat;
+  isAcrossExes: boolean;
 }
 
 export interface CompareStatsRowAcrossExes {
@@ -55,6 +58,8 @@ export type CompareStatsRowAcrossVersions = Record<
 export interface CompareStatsRowAcrossVersionsPartial {
   stats: CompareStatsRowAcrossVersions;
   dataFormatters: DataFormat;
+  criteriaOrder: string[];
+  criteria: CompareStatsTableHeader;
 }
 
 /**
@@ -128,6 +133,8 @@ export interface CompareStatsRowPartial {
   dataFormatters: DataFormat;
   viewHelpers: ViewHelpers;
   config: ReportConfig;
+  criteriaOrder: string[];
+  criteria: CompareStatsTableHeader;
 }
 
 export interface ButtonsAdditionalInfoPartial {
@@ -149,6 +156,7 @@ export interface CompareStatsTablePartial extends CompareStatsTable {
   dataFormatters: DataFormat;
   viewHelpers: ViewHelpers;
   config: ReportConfig;
+  isAcrossExes: boolean;
 }
 
 export interface CompareNavPartial {

--- a/src/shared/view-types.ts
+++ b/src/shared/view-types.ts
@@ -48,6 +48,8 @@ export interface CompareStatsRowAcrossExesPartial {
   exes: CompareStatsRowAcrossExes[];
   dataFormatters: DataFormat;
   viewHelpers: ViewHelpers;
+  criteriaOrder: string[];
+  criteria: CompareStatsTableHeader;
 }
 
 export type CompareStatsRowAcrossVersions = Record<

--- a/tests/backend/compare/charts.test.ts
+++ b/tests/backend/compare/charts.test.ts
@@ -92,6 +92,11 @@ describe('renderOverviewPlots()', () => {
     expect(plotDataTSOM).toBeDefined();
   });
 
+  it('should have the correct number of run configurations', () => {
+    expect(jsSomStats.numRunConfigs).toEqual(26);
+    expect(tSomStats.numRunConfigs).toEqual(166);
+  });
+
   describe('with JsSOM data', () => {
     let result: { png: string; svg: string[] };
     it('should not error when rendering the plots', async () => {

--- a/tests/backend/compare/compare-view.test.ts
+++ b/tests/backend/compare/compare-view.test.ts
@@ -158,7 +158,9 @@ describe('Compare View Parts', () => {
       const data: CompareStatsRowAcrossExesPartial = {
         exes: exeStats,
         dataFormatters,
-        viewHelpers
+        viewHelpers,
+        criteria: criteria2,
+        criteriaOrder: criteriaOrder2
       };
       const result = tpl(data);
       expect(result).toEqualHtmlFragment('compare-view/stats-row-across-exes');

--- a/tests/backend/compare/compare-view.test.ts
+++ b/tests/backend/compare/compare-view.test.ts
@@ -47,6 +47,14 @@ const criteria = {
   'GC time': { name: 'GC time', unit: 'ms' },
   Allocated: { name: 'Allocated', unit: 'bytes' }
 };
+const criteriaOrder = ['total', 'GC time', 'Allocated'];
+
+const criteria2 = {
+  total: { name: 'total', unit: 'ms' },
+  gcTime: { name: 'gcTime', unit: 'ms' },
+  allocated: { name: 'allocated', unit: 'bytes' }
+};
+const criteriaOrder2 = ['total', 'gcTime', 'allocated'];
 
 const benchId = {
   b: 'my-benchmark',
@@ -129,7 +137,9 @@ describe('Compare View Parts', () => {
     it('should render <td> elements with the statistics', () => {
       const data: CompareStatsRowAcrossVersionsPartial = {
         stats: versionStats,
-        dataFormatters
+        dataFormatters,
+        criteriaOrder: criteriaOrder2,
+        criteria: criteria2
       };
       const result = tpl(data);
       expect(result).toEqualHtmlFragment(
@@ -207,7 +217,10 @@ describe('Compare View Parts', () => {
 
     it('should render the data as expected', () => {
       const data: CompareStatsTableHeaderPartial = {
-        criteria
+        criteria,
+        criteriaOrder,
+        dataFormatters,
+        isAcrossExes: false
       };
 
       const result = tpl(data);
@@ -233,7 +246,9 @@ describe('Compare View Parts', () => {
         environments,
         dataFormatters,
         viewHelpers,
-        config
+        config,
+        criteriaOrder: criteriaOrder2,
+        criteria: criteria2
       };
 
       const result = tpl(data);
@@ -252,7 +267,9 @@ describe('Compare View Parts', () => {
         environments,
         dataFormatters,
         viewHelpers,
-        config
+        config,
+        criteriaOrder: criteriaOrder2,
+        criteria: criteria2
       };
 
       const result = tpl(data);
@@ -273,7 +290,9 @@ describe('Compare View Parts', () => {
         environments,
         dataFormatters,
         viewHelpers,
-        config
+        config,
+        criteriaOrder: ['total'],
+        criteria: { total: { name: 'total', unit: 'ms' } }
       };
 
       const result = tpl(data);
@@ -300,7 +319,9 @@ describe('Compare View Parts', () => {
         environments,
         dataFormatters,
         viewHelpers,
-        config
+        config,
+        criteriaOrder: ['total'],
+        criteria: { total: { name: 'total', unit: 'ms' } }
       };
 
       const result = tpl(data);
@@ -318,7 +339,7 @@ describe('Compare View Parts', () => {
 
     it('should render the data as expected', () => {
       const data: CompareStatsTablePartial = {
-        criteria,
+        criteria: criteria2,
         benchmarks: [
           {
             benchId,
@@ -331,7 +352,8 @@ describe('Compare View Parts', () => {
         environments,
         dataFormatters,
         viewHelpers,
-        config
+        config,
+        isAcrossExes: false
       };
 
       const result = tpl(data);
@@ -428,7 +450,7 @@ describe('Compare View Parts', () => {
 
     it('should render the data as expected', () => {
       const benchmarks: CompareStatsTable = {
-        criteria,
+        criteria: criteria2,
         benchmarks: [
           {
             benchId,

--- a/tests/data/expected-results/compare-view/compare-versions.html
+++ b/tests/data/expected-results/compare-view/compare-versions.html
@@ -9,14 +9,12 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
-
-<th scope="col">median GC<br>time in ms</th>
-<th scope="col">GC diff %</th>
-
-<th scope="col">median <br>allocated bytes</th>
-<th scope="col">Alloc diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
+<th scope="col" title="median gctime">median gctime<br>in ms</th>
+<th scope="col" title="difference in % of gctime">gctime diff %</th>
+<th scope="col" title="median allocated">median allocated<br>in bytes</th>
+<th scope="col" title="difference in % of allocated">allocated diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -25,12 +23,13 @@
 <th scope="row">my-benchmark</th>
 <td class="inline-cmp"><img src="base-url/inline.png"></td>
 <td class="stats-samples">43</td>
+
 <td><span class="stats-median" title="median">0.33</span></td>
-<td><span class="stats-change" title="change over median run time">54600</span></td>
+<td><span class="stats-change stats-total" title="diff %">54600</span></td>
 <td><span class="stats-median" title="median">0</span></td>
-<td><span class="stats-gc-change" title="change over median GC time">14600</span></td>
+<td><span class="stats-change" title="diff %">14600</span></td>
 <td><span class="stats-median" title="median">222b</span></td>
-<td><span class="stats-alloc-change" title="change over median allocated memory">64600</span></td>
+<td><span class="stats-change" title="diff %">64600</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
 data-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"

--- a/tests/data/expected-results/compare-view/stats-row-across-exes.html
+++ b/tests/data/expected-results/compare-view/stats-row-across-exes.html
@@ -6,27 +6,28 @@ ast
 43
 <br>12
 </td>
+
 <td><span class="stats-median" title="median">
 0.33
 <br>0.45
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">54600</span>
-<br><span class="stats-change" title="change over median run time">3400</span>
+<span class="stats-change stats-total" title="diff %">54600</span>
+<br><span class="stats-change stats-total" title="diff %">3400</span>
 </td>
 <td><span class="stats-median" title="median">
 0
 <br>0
 </span></td>
 <td>
-<span class="stats-change" title="change over median GC time">14600</span>
-<br><span class="stats-change" title="change over median GC time">232300</span>
+<span class="stats-change" title="diff %">14600</span>
+<br><span class="stats-change" title="diff %">232300</span>
 </td>
 <td><span class="stats-median" title="median">
 222b
 <br>675b
 </span></td>
 <td>
-<span class="stats-change" title="change over median allocated">64600</span>
-<br><span class="stats-change" title="change over median allocated">604600</span>
+<span class="stats-change" title="diff %">64600</span>
+<br><span class="stats-change" title="diff %">604600</span>
 </td>

--- a/tests/data/expected-results/compare-view/stats-row-across-version.html
+++ b/tests/data/expected-results/compare-view/stats-row-across-version.html
@@ -1,7 +1,8 @@
 <td class="stats-samples">43</td>
+
 <td><span class="stats-median" title="median">0.33</span></td>
-<td><span class="stats-change" title="change over median run time">54600</span></td>
+<td><span class="stats-change stats-total" title="diff %">54600</span></td>
 <td><span class="stats-median" title="median">0</span></td>
-<td><span class="stats-gc-change" title="change over median GC time">14600</span></td>
+<td><span class="stats-change" title="diff %">14600</span></td>
 <td><span class="stats-median" title="median">222b</span></td>
-<td><span class="stats-alloc-change" title="change over median allocated memory">64600</span></td>
+<td><span class="stats-change" title="diff %">64600</span></td>

--- a/tests/data/expected-results/compare-view/stats-row-exe.html
+++ b/tests/data/expected-results/compare-view/stats-row-exe.html
@@ -9,29 +9,30 @@ ast
 43
 <br>12
 </td>
+
 <td><span class="stats-median" title="median">
 0.33
 <br>0.45
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">54600</span>
-<br><span class="stats-change" title="change over median run time">3400</span>
+<span class="stats-change stats-total" title="diff %">54600</span>
+<br><span class="stats-change stats-total" title="diff %">3400</span>
 </td>
 <td><span class="stats-median" title="median">
 0
 <br>0
 </span></td>
 <td>
-<span class="stats-change" title="change over median GC time">14600</span>
-<br><span class="stats-change" title="change over median GC time">232300</span>
+<span class="stats-change" title="diff %">14600</span>
+<br><span class="stats-change" title="diff %">232300</span>
 </td>
 <td><span class="stats-median" title="median">
 222b
 <br>675b
 </span></td>
 <td>
-<span class="stats-change" title="change over median allocated">64600</span>
-<br><span class="stats-change" title="change over median allocated">604600</span>
+<span class="stats-change" title="diff %">64600</span>
+<br><span class="stats-change" title="diff %">604600</span>
 </td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
 data-content="<code>som/some-command with args</code>"></button>

--- a/tests/data/expected-results/compare-view/stats-row-version-one-criteria-missing.html
+++ b/tests/data/expected-results/compare-view/stats-row-version-one-criteria-missing.html
@@ -7,12 +7,9 @@
 <th scope="row">my-benchmark</th>
 <td class="inline-cmp"><img src="base-url/inline.png"></td>
 <td class="stats-samples">43</td>
+
 <td><span class="stats-median" title="median">0.33</span></td>
-<td><span class="stats-change" title="change over median run time">54600</span></td>
-<td><span class="stats-median" title="median">0</span></td>
-<td><span class="stats-gc-change" title="change over median GC time">14600</span></td>
-<td><span class="stats-median" title="median">222b</span></td>
-<td><span class="stats-alloc-change" title="change over median allocated memory">64600</span></td>
+<td><span class="stats-change stats-total" title="diff %">54600</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
 data-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"

--- a/tests/data/expected-results/compare-view/stats-row-version.html
+++ b/tests/data/expected-results/compare-view/stats-row-version.html
@@ -2,12 +2,13 @@
 <th scope="row">my-benchmark</th>
 <td class="inline-cmp"><img src="base-url/inline.png"></td>
 <td class="stats-samples">43</td>
+
 <td><span class="stats-median" title="median">0.33</span></td>
-<td><span class="stats-change" title="change over median run time">54600</span></td>
+<td><span class="stats-change stats-total" title="diff %">54600</span></td>
 <td><span class="stats-median" title="median">0</span></td>
-<td><span class="stats-gc-change" title="change over median GC time">14600</span></td>
+<td><span class="stats-change" title="diff %">14600</span></td>
 <td><span class="stats-median" title="median">222b</span></td>
-<td><span class="stats-alloc-change" title="change over median allocated memory">64600</span></td>
+<td><span class="stats-change" title="diff %">64600</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
 data-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"

--- a/tests/data/expected-results/compare-view/stats-summary.html
+++ b/tests/data/expected-results/compare-view/stats-summary.html
@@ -3,12 +3,12 @@
 <img src="base-url/some-url1.svg" width="432"><img src="base-url/some-url2.svg" width="432">
 </div>
 <dl class="row">
-<dt class="col-sm-5" style="white-space: nowrap;">Number of Run Configurations</dt>
-<dd class="col-sm-5">232</dd>
-  <dt class="col-sm-5">Median Run time in ms</dt>
-<dd class="col-sm-5">0.50 (min. 0.10, max. 1.10)</dd>
-  <dt class="col-sm-5">Median gcTime in ms</dt>
-<dd class="col-sm-5">2.50 (min. 2.10, max. 3.10)</dd>
-  <dt class="col-sm-5">Median allocated in bytes</dt>
-<dd class="col-sm-5">4.50 (min. 4.10, max. 5.10)</dd>
+<dt class="col-sm-3" style="white-space: nowrap;">Number of Run Configurations</dt>
+<dd class="col-sm-7">232</dd>
+  <dt class="col-sm-3">Change of Run time</dt>
+<dd class="col-sm-7">median 50% (min. 10%, max. 110%)</dd>
+  <dt class="col-sm-3">Change of gcTime</dt>
+<dd class="col-sm-7">median 250% (min. 210%, max. 310%)</dd>
+  <dt class="col-sm-3">Change of allocated</dt>
+<dd class="col-sm-7">median 450% (min. 410%, max. 510%)</dd>
 </dl>

--- a/tests/data/expected-results/compare-view/stats-tbl-header.html
+++ b/tests/data/expected-results/compare-view/stats-tbl-header.html
@@ -3,14 +3,12 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
-
-<th scope="col">median GC<br>time in ms</th>
-<th scope="col">GC diff %</th>
-
-<th scope="col">median <br>allocated bytes</th>
-<th scope="col">Alloc diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
+<th scope="col" title="median GC time">median GC<br>in ms</th>
+<th scope="col" title="difference in % of GC time">GC diff %</th>
+<th scope="col" title="median allocated">median allocated<br>in bytes</th>
+<th scope="col" title="difference in % of allocated">allocated diff %</th>
 
 <th scope="col"></th>
 </tr></thead>

--- a/tests/data/expected-results/compare-view/stats-tbl.html
+++ b/tests/data/expected-results/compare-view/stats-tbl.html
@@ -4,14 +4,12 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
-
-<th scope="col">median GC<br>time in ms</th>
-<th scope="col">GC diff %</th>
-
-<th scope="col">median <br>allocated bytes</th>
-<th scope="col">Alloc diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
+<th scope="col" title="median gctime">median gctime<br>in ms</th>
+<th scope="col" title="difference in % of gctime">gctime diff %</th>
+<th scope="col" title="median allocated">median allocated<br>in bytes</th>
+<th scope="col" title="difference in % of allocated">allocated diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -20,12 +18,13 @@
 <th scope="row">my-benchmark</th>
 <td class="inline-cmp"><img src="base-url/inline.png"></td>
 <td class="stats-samples">43</td>
+
 <td><span class="stats-median" title="median">0.33</span></td>
-<td><span class="stats-change" title="change over median run time">54600</span></td>
+<td><span class="stats-change stats-total" title="diff %">54600</span></td>
 <td><span class="stats-median" title="median">0</span></td>
-<td><span class="stats-gc-change" title="change over median GC time">14600</span></td>
+<td><span class="stats-change" title="diff %">14600</span></td>
 <td><span class="stats-median" title="median">222b</span></td>
-<td><span class="stats-alloc-change" title="change over median allocated memory">64600</span></td>
+<td><span class="stats-change" title="diff %">64600</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
 data-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"

--- a/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
@@ -120,11 +120,11 @@
 <img src="/static/reports/jssom/overview-som.svg" width="432">
 </div>
 <dl class="row">
-  <dt class="col-sm-5" style="white-space: nowrap;">Number of Run Configurations</dt>
-  <dd class="col-sm-5">26</dd>
+  <dt class="col-sm-3" style="white-space: nowrap;">Number of Run Configurations</dt>
+  <dd class="col-sm-7">26</dd>
 
-  <dt class="col-sm-5">Median Run time in ms</dt>
-  <dd class="col-sm-5">0.01 (min. -0.13, max. 0.09)</dd>
+  <dt class="col-sm-3">Change of Run time</dt>
+  <dd class="col-sm-7">median 1% (min. -13%, max. 9%)</dd>
 </dl>
 
 

--- a/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
@@ -142,8 +142,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -153,10 +153,9 @@
 <th scope="row">DeltaBlue</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-1.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">90.54</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 10 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -169,10 +168,9 @@
 <th scope="row">GraphSearch</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-2.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">51.72</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 10 0  4</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -185,10 +183,9 @@
 <th scope="row">JsonSmall</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-3.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">126.04</span></td>
-<td><span class="stats-change" title="change over median run time">-7</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som JsonSmall 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -201,10 +198,9 @@
 <th scope="row">NBody</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-4.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">81.38</span></td>
-<td><span class="stats-change" title="change over median run time">-10</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-10</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 10 0  500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -217,10 +213,9 @@
 <th scope="row">PageRank</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-5.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">208.31</span></td>
-<td><span class="stats-change" title="change over median run time">4</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 10 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -233,10 +228,9 @@
 <th scope="row">Richards</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-6.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">2589.35</span></td>
-<td><span class="stats-change" title="change over median run time">7</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -261,8 +255,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -272,10 +266,9 @@
 <th scope="row">Bounce</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-7.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">80.36</span></td>
-<td><span class="stats-change" title="change over median run time">-2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -288,10 +281,9 @@
 <th scope="row">BubbleSort</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-8.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">127.88</span></td>
-<td><span class="stats-change" title="change over median run time">-4</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -304,10 +296,9 @@
 <th scope="row">Dispatch</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-9.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">70.81</span></td>
-<td><span class="stats-change" title="change over median run time">-13</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-13</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -320,10 +311,9 @@
 <th scope="row">Fannkuch</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-10.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">59.91</span></td>
-<td><span class="stats-change" title="change over median run time">5</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 10 0  6</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -336,10 +326,9 @@
 <th scope="row">Fibonacci</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-11.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">263.34</span></td>
-<td><span class="stats-change" title="change over median run time">-3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -352,10 +341,9 @@
 <th scope="row">FieldLoop</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-12.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">190.50</span></td>
-<td><span class="stats-change" title="change over median run time">4</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -368,10 +356,9 @@
 <th scope="row">IntegerLoop</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-13.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">149.09</span></td>
-<td><span class="stats-change" title="change over median run time">3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -384,10 +371,9 @@
 <th scope="row">List</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-14.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">124.80</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -400,10 +386,9 @@
 <th scope="row">Loop</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-15.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">164.68</span></td>
-<td><span class="stats-change" title="change over median run time">5</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 10 0  5</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -416,10 +401,9 @@
 <th scope="row">Mandelbrot</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-16.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">138.32</span></td>
-<td><span class="stats-change" title="change over median run time">-7</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 10 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -432,10 +416,9 @@
 <th scope="row">Permute</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-17.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">130.80</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -448,10 +431,9 @@
 <th scope="row">Queens</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-18.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">100.68</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -464,10 +446,9 @@
 <th scope="row">QuickSort</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-19.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">27.68</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -480,10 +461,9 @@
 <th scope="row">Recurse</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-20.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">147.77</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -496,10 +476,9 @@
 <th scope="row">Sieve</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-21.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">124.33</span></td>
-<td><span class="stats-change" title="change over median run time">-2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 10 0  4</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -512,10 +491,9 @@
 <th scope="row">Storage</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-22.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">34.65</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -528,10 +506,9 @@
 <th scope="row">Sum</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-23.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">64.02</span></td>
-<td><span class="stats-change" title="change over median run time">5</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -544,10 +521,9 @@
 <th scope="row">Towers</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-24.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">176.06</span></td>
-<td><span class="stats-change" title="change over median run time">-3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -560,10 +536,9 @@
 <th scope="row">TreeSort</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-25.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">80.91</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -576,10 +551,9 @@
 <th scope="row">WhileLoop</th>
   <td class="inline-cmp"><img src="/static/reports/jssom/inline-26.svg"></td>
 <td class="stats-samples">10</td>
+
 <td><span class="stats-median" title="median">92.95</span></td>
-<td><span class="stats-change" title="change over median run time">9</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">9</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 10 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"

--- a/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
@@ -182,8 +182,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -193,10 +193,9 @@
 <th scope="row">List</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-1.svg"></td>
 <td class="stats-samples">1</td>
+
 <td><span class="stats-median" title="median">21624.67</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -208,10 +207,9 @@
 <th scope="row">Loop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-2.svg"></td>
 <td class="stats-samples">1</td>
+
 <td><span class="stats-median" title="median">15196.07</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -223,10 +221,9 @@
 <th scope="row">Mandelbrot</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-3.svg"></td>
 <td class="stats-samples">1</td>
+
 <td><span class="stats-median" title="median">351.52</span></td>
-<td><span class="stats-change" title="change over median run time">-6</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-6</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -238,10 +235,9 @@
 <th scope="row">Queens</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-4.svg"></td>
 <td class="stats-samples">1</td>
+
 <td><span class="stats-median" title="median">14760.86</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -253,10 +249,9 @@
 <th scope="row">Recurse</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-5.svg"></td>
 <td class="stats-samples">1</td>
+
 <td><span class="stats-median" title="median">13668.42</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -280,8 +275,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -291,10 +286,9 @@
 <th scope="row">List</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-6.svg"></td>
 <td class="stats-samples">1</td>
+
 <td><span class="stats-median" title="median">28426.29</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -306,10 +300,9 @@
 <th scope="row">Loop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-7.svg"></td>
 <td class="stats-samples">1</td>
+
 <td><span class="stats-median" title="median">19723.08</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -321,10 +314,9 @@
 <th scope="row">Mandelbrot</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-8.svg"></td>
 <td class="stats-samples">1</td>
+
 <td><span class="stats-median" title="median">456.26</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -336,10 +328,9 @@
 <th scope="row">Queens</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-9.svg"></td>
 <td class="stats-samples">1</td>
+
 <td><span class="stats-median" title="median">18868.32</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -351,10 +342,9 @@
 <th scope="row">Recurse</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-10.svg"></td>
 <td class="stats-samples">1</td>
+
 <td><span class="stats-median" title="median">18004.65</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -378,8 +368,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -389,10 +379,9 @@
 <th scope="row">DeltaBlue</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-11.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">275.04</span></td>
-<td><span class="stats-change" title="change over median run time">9</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">9</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -404,10 +393,9 @@
 <th scope="row">GraphSearch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-12.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">182.46</span></td>
-<td><span class="stats-change" title="change over median run time">-8</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -419,10 +407,9 @@
 <th scope="row">Json</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-13.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">253.06</span></td>
-<td><span class="stats-change" title="change over median run time">4</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -434,10 +421,9 @@
 <th scope="row">NBody</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-14.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">132.49</span></td>
-<td><span class="stats-change" title="change over median run time">-14</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-14</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -449,10 +435,9 @@
 <th scope="row">PageRank</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-15.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">159.80</span></td>
-<td><span class="stats-change" title="change over median run time">-2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -476,8 +461,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -487,10 +472,9 @@
 <th scope="row">DeltaBlue</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-16.svg"></td>
 <td class="stats-samples">120</td>
+
 <td><span class="stats-median" title="median">49.53</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -503,10 +487,9 @@
 <th scope="row">GraphSearch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-17.svg"></td>
 <td class="stats-samples">250</td>
+
 <td><span class="stats-median" title="median">71.07</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -519,10 +502,9 @@
 <th scope="row">Json</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-18.svg"></td>
 <td class="stats-samples">120</td>
+
 <td><span class="stats-median" title="median">105.25</span></td>
-<td><span class="stats-change" title="change over median run time">-5</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -535,10 +517,9 @@
 <th scope="row">NBody</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-19.svg"></td>
 <td class="stats-samples">120</td>
+
 <td><span class="stats-median" title="median">70.04</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -551,10 +532,9 @@
 <th scope="row">PageRank</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-20.svg"></td>
 <td class="stats-samples">120</td>
+
 <td><span class="stats-median" title="median">114.29</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -567,10 +547,9 @@
 <th scope="row">Richards</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-21.svg"></td>
 <td class="stats-samples">130</td>
+
 <td><span class="stats-median" title="median">99.78</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -595,8 +574,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -606,10 +585,9 @@
 <th scope="row">Bounce</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-22.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">151.69</span></td>
-<td><span class="stats-change" title="change over median run time">4</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -621,10 +599,9 @@
 <th scope="row">BubbleSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-23.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">129.31</span></td>
-<td><span class="stats-change" title="change over median run time">-8</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -636,10 +613,9 @@
 <th scope="row">Dispatch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-24.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">100.84</span></td>
-<td><span class="stats-change" title="change over median run time">-2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -651,10 +627,9 @@
 <th scope="row">Fibonacci</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-25.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">134.85</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -666,10 +641,9 @@
 <th scope="row">FieldLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-26.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">47.32</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -681,10 +655,9 @@
 <th scope="row">IntegerLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-27.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">89.40</span></td>
-<td><span class="stats-change" title="change over median run time">-2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -696,10 +669,9 @@
 <th scope="row">List</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-28.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">80.21</span></td>
-<td><span class="stats-change" title="change over median run time">7</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -711,10 +683,9 @@
 <th scope="row">Loop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-29.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">88.65</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -726,10 +697,9 @@
 <th scope="row">Mandelbrot</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-30.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">123.19</span></td>
-<td><span class="stats-change" title="change over median run time">9</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">9</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -741,10 +711,9 @@
 <th scope="row">Permute</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-31.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">145.52</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -756,10 +725,9 @@
 <th scope="row">Queens</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-32.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">119.00</span></td>
-<td><span class="stats-change" title="change over median run time">-9</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-9</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -771,10 +739,9 @@
 <th scope="row">QuickSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-33.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">185.47</span></td>
-<td><span class="stats-change" title="change over median run time">8</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -786,10 +753,9 @@
 <th scope="row">Recurse</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-34.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">128.25</span></td>
-<td><span class="stats-change" title="change over median run time">11</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">11</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -801,10 +767,9 @@
 <th scope="row">Sieve</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-35.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">132.23</span></td>
-<td><span class="stats-change" title="change over median run time">4</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -816,10 +781,9 @@
 <th scope="row">Storage</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-36.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">158.52</span></td>
-<td><span class="stats-change" title="change over median run time">14</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">14</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -831,10 +795,9 @@
 <th scope="row">Sum</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-37.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">80.63</span></td>
-<td><span class="stats-change" title="change over median run time">-3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -846,10 +809,9 @@
 <th scope="row">Towers</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-38.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">140.07</span></td>
-<td><span class="stats-change" title="change over median run time">-2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -861,10 +823,9 @@
 <th scope="row">TreeSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-39.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">156.97</span></td>
-<td><span class="stats-change" title="change over median run time">4</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -876,10 +837,9 @@
 <th scope="row">WhileLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-40.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">67.42</span></td>
-<td><span class="stats-change" title="change over median run time">3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -903,8 +863,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -914,10 +874,9 @@
 <th scope="row">Bounce</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-41.svg"></td>
 <td class="stats-samples">60</td>
+
 <td><span class="stats-median" title="median">139.58</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -930,10 +889,9 @@
 <th scope="row">BubbleSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-42.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">83.49</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -946,10 +904,9 @@
 <th scope="row">Dispatch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-43.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">223.33</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -962,10 +919,9 @@
 <th scope="row">Fannkuch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-44.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">46.52</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -978,10 +934,9 @@
 <th scope="row">Fibonacci</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-45.svg"></td>
 <td class="stats-samples">60</td>
+
 <td><span class="stats-median" title="median">85.58</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -994,10 +949,9 @@
 <th scope="row">FieldLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-46.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">240.07</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1010,10 +964,9 @@
 <th scope="row">IntegerLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-47.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">155.00</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1026,10 +979,9 @@
 <th scope="row">List</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-48.svg"></td>
 <td class="stats-samples">65</td>
+
 <td><span class="stats-median" title="median">105.67</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1042,10 +994,9 @@
 <th scope="row">Loop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-49.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">2.41</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1058,10 +1009,9 @@
 <th scope="row">Mandelbrot</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-50.svg"></td>
 <td class="stats-samples">110</td>
+
 <td><span class="stats-median" title="median">358.87</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1074,10 +1024,9 @@
 <th scope="row">Permute</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-51.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">135.55</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1090,10 +1039,9 @@
 <th scope="row">Queens</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-52.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">119.42</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1106,10 +1054,9 @@
 <th scope="row">QuickSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-53.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">121.89</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1122,10 +1069,9 @@
 <th scope="row">Recurse</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-54.svg"></td>
 <td class="stats-samples">65</td>
+
 <td><span class="stats-median" title="median">122.70</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1138,10 +1084,9 @@
 <th scope="row">Sieve</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-55.svg"></td>
 <td class="stats-samples">60</td>
+
 <td><span class="stats-median" title="median">100.75</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1154,10 +1099,9 @@
 <th scope="row">Storage</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-56.svg"></td>
 <td class="stats-samples">60</td>
+
 <td><span class="stats-median" title="median">97.29</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1170,10 +1114,9 @@
 <th scope="row">Sum</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-57.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">250.33</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1186,10 +1129,9 @@
 <th scope="row">Towers</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-58.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">343.36</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1202,10 +1144,9 @@
 <th scope="row">TreeSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-59.svg"></td>
 <td class="stats-samples">60</td>
+
 <td><span class="stats-median" title="median">154.65</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1218,10 +1159,9 @@
 <th scope="row">WhileLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-60.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">181.69</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1246,8 +1186,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -1257,10 +1197,9 @@
 <th scope="row">DeltaBlue</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-61.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">292.45</span></td>
-<td><span class="stats-change" title="change over median run time">15</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">15</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1272,10 +1211,9 @@
 <th scope="row">GraphSearch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-62.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">212.70</span></td>
-<td><span class="stats-change" title="change over median run time">6</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">6</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1287,10 +1225,9 @@
 <th scope="row">Json</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-63.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">254.33</span></td>
-<td><span class="stats-change" title="change over median run time">-10</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-10</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1302,10 +1239,9 @@
 <th scope="row">NBody</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-64.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">172.67</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1317,10 +1253,9 @@
 <th scope="row">PageRank</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-65.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">287.66</span></td>
-<td><span class="stats-change" title="change over median run time">3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1332,10 +1267,9 @@
 <th scope="row">Richards</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-66.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">689.30</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1359,8 +1293,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -1370,10 +1304,9 @@
 <th scope="row">DeltaBlue</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-67.svg"></td>
 <td class="stats-samples">120</td>
+
 <td><span class="stats-median" title="median">160.50</span></td>
-<td><span class="stats-change" title="change over median run time">5</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1386,10 +1319,9 @@
 <th scope="row">GraphSearch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-68.svg"></td>
 <td class="stats-samples">250</td>
+
 <td><span class="stats-median" title="median">72.17</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1402,10 +1334,9 @@
 <th scope="row">Json</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-69.svg"></td>
 <td class="stats-samples">120</td>
+
 <td><span class="stats-median" title="median">111.11</span></td>
-<td><span class="stats-change" title="change over median run time">-6</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-6</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1418,10 +1349,9 @@
 <th scope="row">NBody</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-70.svg"></td>
 <td class="stats-samples">120</td>
+
 <td><span class="stats-median" title="median">61.05</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1434,10 +1364,9 @@
 <th scope="row">PageRank</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-71.svg"></td>
 <td class="stats-samples">120</td>
+
 <td><span class="stats-median" title="median">107.50</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1450,10 +1379,9 @@
 <th scope="row">Richards</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-72.svg"></td>
 <td class="stats-samples">130</td>
+
 <td><span class="stats-median" title="median">97.56</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1478,8 +1406,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -1489,10 +1417,9 @@
 <th scope="row">Bounce</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-73.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">163.67</span></td>
-<td><span class="stats-change" title="change over median run time">-3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1504,10 +1431,9 @@
 <th scope="row">BubbleSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-74.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">141.15</span></td>
-<td><span class="stats-change" title="change over median run time">4</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1519,10 +1445,9 @@
 <th scope="row">Dispatch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-75.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">115.17</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1534,10 +1459,9 @@
 <th scope="row">Fannkuch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-76.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">194.92</span></td>
-<td><span class="stats-change" title="change over median run time">-3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1549,10 +1473,9 @@
 <th scope="row">Fibonacci</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-77.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">231.00</span></td>
-<td><span class="stats-change" title="change over median run time">4</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1564,10 +1487,9 @@
 <th scope="row">FieldLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-78.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">65.15</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1579,10 +1501,9 @@
 <th scope="row">IntegerLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-79.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">228.15</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1594,10 +1515,9 @@
 <th scope="row">List</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-80.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">76.16</span></td>
-<td><span class="stats-change" title="change over median run time">17</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">17</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1609,10 +1529,9 @@
 <th scope="row">Loop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-81.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">118.13</span></td>
-<td><span class="stats-change" title="change over median run time">-3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1624,10 +1543,9 @@
 <th scope="row">Mandelbrot</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-82.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">244.78</span></td>
-<td><span class="stats-change" title="change over median run time">-3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1639,10 +1557,9 @@
 <th scope="row">Permute</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-83.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">189.32</span></td>
-<td><span class="stats-change" title="change over median run time">-29</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-29</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1654,10 +1571,9 @@
 <th scope="row">Queens</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-84.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">186.72</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1669,10 +1585,9 @@
 <th scope="row">QuickSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-85.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">239.84</span></td>
-<td><span class="stats-change" title="change over median run time">-3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1684,10 +1599,9 @@
 <th scope="row">Recurse</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-86.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">144.41</span></td>
-<td><span class="stats-change" title="change over median run time">9</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">9</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1699,10 +1613,9 @@
 <th scope="row">Sieve</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-87.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">172.03</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1714,10 +1627,9 @@
 <th scope="row">Storage</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-88.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">179.38</span></td>
-<td><span class="stats-change" title="change over median run time">4</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1729,10 +1641,9 @@
 <th scope="row">Sum</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-89.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">110.34</span></td>
-<td><span class="stats-change" title="change over median run time">3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1744,10 +1655,9 @@
 <th scope="row">Towers</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-90.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">178.94</span></td>
-<td><span class="stats-change" title="change over median run time">3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1759,10 +1669,9 @@
 <th scope="row">TreeSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-91.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">217.42</span></td>
-<td><span class="stats-change" title="change over median run time">14</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">14</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1774,10 +1683,9 @@
 <th scope="row">WhileLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-92.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">225.86</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1801,8 +1709,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -1812,10 +1720,9 @@
 <th scope="row">Bounce</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-93.svg"></td>
 <td class="stats-samples">60</td>
+
 <td><span class="stats-median" title="median">216.01</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1828,10 +1735,9 @@
 <th scope="row">BubbleSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-94.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">78.22</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1844,10 +1750,9 @@
 <th scope="row">Dispatch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-95.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">196.97</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1860,10 +1765,9 @@
 <th scope="row">Fannkuch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-96.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">195.80</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1876,10 +1780,9 @@
 <th scope="row">Fibonacci</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-97.svg"></td>
 <td class="stats-samples">60</td>
+
 <td><span class="stats-median" title="median">116.58</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1892,10 +1795,9 @@
 <th scope="row">FieldLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-98.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">239.91</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1908,10 +1810,9 @@
 <th scope="row">IntegerLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-99.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">268.56</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1924,10 +1825,9 @@
 <th scope="row">List</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-100.svg"></td>
 <td class="stats-samples">65</td>
+
 <td><span class="stats-median" title="median">101.37</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1940,10 +1840,9 @@
 <th scope="row">Loop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-101.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">175.47</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1956,10 +1855,9 @@
 <th scope="row">Mandelbrot</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-102.svg"></td>
 <td class="stats-samples">110</td>
+
 <td><span class="stats-median" title="median">394.93</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1972,10 +1870,9 @@
 <th scope="row">Permute</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-103.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">424.57</span></td>
-<td><span class="stats-change" title="change over median run time">-2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -1988,10 +1885,9 @@
 <th scope="row">Queens</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-104.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">106.88</span></td>
-<td><span class="stats-change" title="change over median run time">-2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2004,10 +1900,9 @@
 <th scope="row">QuickSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-105.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">246.59</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2020,10 +1915,9 @@
 <th scope="row">Recurse</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-106.svg"></td>
 <td class="stats-samples">65</td>
+
 <td><span class="stats-median" title="median">138.64</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2036,10 +1930,9 @@
 <th scope="row">Sieve</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-107.svg"></td>
 <td class="stats-samples">60</td>
+
 <td><span class="stats-median" title="median">102.64</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2052,10 +1945,9 @@
 <th scope="row">Storage</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-108.svg"></td>
 <td class="stats-samples">60</td>
+
 <td><span class="stats-median" title="median">197.72</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2068,10 +1960,9 @@
 <th scope="row">Sum</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-109.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">190.78</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2084,10 +1975,9 @@
 <th scope="row">Towers</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-110.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">335.06</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2100,10 +1990,9 @@
 <th scope="row">TreeSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-111.svg"></td>
 <td class="stats-samples">60</td>
+
 <td><span class="stats-median" title="median">159.52</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2116,10 +2005,9 @@
 <th scope="row">WhileLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-112.svg"></td>
 <td class="stats-samples">55</td>
+
 <td><span class="stats-median" title="median">787.93</span></td>
-<td><span class="stats-change" title="change over median run time">-3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2144,8 +2032,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -2155,10 +2043,9 @@
 <th scope="row">Richards</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-113.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">357.33</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2182,8 +2069,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -2193,10 +2080,9 @@
 <th scope="row">Fannkuch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-114.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">123.53</span></td>
-<td><span class="stats-change" title="change over median run time">-7</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2220,8 +2106,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -2231,10 +2117,9 @@
 <th scope="row">DeltaBlue</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-115.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">71.54</span></td>
-<td><span class="stats-change" title="change over median run time">8</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2246,10 +2131,9 @@
 <th scope="row">GraphSearch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-116.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">59.00</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2261,10 +2145,9 @@
 <th scope="row">Json</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-117.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">158.93</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2276,10 +2159,9 @@
 <th scope="row">NBody</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-118.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">69.55</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2291,10 +2173,9 @@
 <th scope="row">PageRank</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-119.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">64.81</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2306,10 +2187,9 @@
 <th scope="row">Richards</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-120.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">412.86</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2333,8 +2213,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -2344,10 +2224,9 @@
 <th scope="row">Bounce</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-121.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">87.33</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2359,10 +2238,9 @@
 <th scope="row">BubbleSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-122.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">70.28</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2374,10 +2252,9 @@
 <th scope="row">Dispatch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-123.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">64.68</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2389,10 +2266,9 @@
 <th scope="row">Fannkuch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-124.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">44.35</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2404,10 +2280,9 @@
 <th scope="row">Fibonacci</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-125.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">60.74</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2419,10 +2294,9 @@
 <th scope="row">FieldLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-126.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">34.76</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2434,10 +2308,9 @@
 <th scope="row">IntegerLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-127.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">55.56</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2449,10 +2322,9 @@
 <th scope="row">List</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-128.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">19.29</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2464,10 +2336,9 @@
 <th scope="row">Loop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-129.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">122.04</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2479,10 +2350,9 @@
 <th scope="row">Mandelbrot</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-130.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">105.75</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2494,10 +2364,9 @@
 <th scope="row">Permute</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-131.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">107.63</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2509,10 +2378,9 @@
 <th scope="row">Queens</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-132.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">67.01</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2524,10 +2392,9 @@
 <th scope="row">QuickSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-133.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">92.15</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2539,10 +2406,9 @@
 <th scope="row">Recurse</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-134.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">61.08</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2554,10 +2420,9 @@
 <th scope="row">Sieve</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-135.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">91.75</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2569,10 +2434,9 @@
 <th scope="row">Storage</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-136.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">68.34</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2584,10 +2448,9 @@
 <th scope="row">Sum</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-137.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">142.33</span></td>
-<td><span class="stats-change" title="change over median run time">8</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2599,10 +2462,9 @@
 <th scope="row">Towers</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-138.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">45.54</span></td>
-<td><span class="stats-change" title="change over median run time">-8</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2614,10 +2476,9 @@
 <th scope="row">TreeSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-139.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">57.86</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2629,10 +2490,9 @@
 <th scope="row">WhileLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-140.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">84.46</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2656,8 +2516,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -2667,10 +2527,9 @@
 <th scope="row">DeltaBlue</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-141.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">76.58</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2682,10 +2541,9 @@
 <th scope="row">GraphSearch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-142.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">69.81</span></td>
-<td><span class="stats-change" title="change over median run time">3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2697,10 +2555,9 @@
 <th scope="row">Json</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-143.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">153.97</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2712,10 +2569,9 @@
 <th scope="row">NBody</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-144.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">81.59</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2727,10 +2583,9 @@
 <th scope="row">PageRank</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-145.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">105.03</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2742,10 +2597,9 @@
 <th scope="row">Richards</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-146.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">624.07</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2769,8 +2623,8 @@
 <th scope="col"></th>
 
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -2780,10 +2634,9 @@
 <th scope="row">Bounce</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-147.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">89.81</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2795,10 +2648,9 @@
 <th scope="row">BubbleSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-148.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">95.55</span></td>
-<td><span class="stats-change" title="change over median run time">-7</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2810,10 +2662,9 @@
 <th scope="row">Dispatch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-149.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">123.38</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2825,10 +2676,9 @@
 <th scope="row">Fannkuch</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-150.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">71.65</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2840,10 +2690,9 @@
 <th scope="row">Fibonacci</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-151.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">139.68</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2855,10 +2704,9 @@
 <th scope="row">FieldLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-152.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">22.88</span></td>
-<td><span class="stats-change" title="change over median run time">12</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">12</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2870,10 +2718,9 @@
 <th scope="row">IntegerLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-153.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">150.75</span></td>
-<td><span class="stats-change" title="change over median run time">6</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">6</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2885,10 +2732,9 @@
 <th scope="row">List</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-154.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">22.22</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2900,10 +2746,9 @@
 <th scope="row">Loop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-155.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">528.11</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2915,10 +2760,9 @@
 <th scope="row">Mandelbrot</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-156.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">124.67</span></td>
-<td><span class="stats-change" title="change over median run time">-2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2930,10 +2774,9 @@
 <th scope="row">Permute</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-157.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">129.47</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2945,10 +2788,9 @@
 <th scope="row">Queens</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-158.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">118.02</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2960,10 +2802,9 @@
 <th scope="row">QuickSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-159.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">89.83</span></td>
-<td><span class="stats-change" title="change over median run time">-3</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2975,10 +2816,9 @@
 <th scope="row">Recurse</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-160.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">76.64</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -2990,10 +2830,9 @@
 <th scope="row">Sieve</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-161.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">115.01</span></td>
-<td><span class="stats-change" title="change over median run time">-1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -3005,10 +2844,9 @@
 <th scope="row">Storage</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-162.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">77.53</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -3020,10 +2858,9 @@
 <th scope="row">Sum</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-163.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">254.49</span></td>
-<td><span class="stats-change" title="change over median run time">1</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -3035,10 +2872,9 @@
 <th scope="row">Towers</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-164.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">69.94</span></td>
-<td><span class="stats-change" title="change over median run time">2</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -3050,10 +2886,9 @@
 <th scope="row">TreeSort</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-165.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">79.03</span></td>
-<td><span class="stats-change" title="change over median run time">0</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -3065,10 +2900,9 @@
 <th scope="row">WhileLoop</th>
   <td class="inline-cmp"><img src="/static/reports/tsom/inline-166.svg"></td>
 <td class="stats-samples">5</td>
+
 <td><span class="stats-median" title="median">92.71</span></td>
-<td><span class="stats-change" title="change over median run time">-5</span></td>
-
-
+<td><span class="stats-change stats-total" title="diff %">-5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
@@ -3095,8 +2929,8 @@
 <th scope="col"></th>
 <th scope="col" title="Executor, without common prefix with baseline">Exe</th>
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -3261,8 +3095,8 @@ ast
 <th scope="col"></th>
 <th scope="col" title="Executor, without common prefix with baseline">Exe</th>
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -3504,8 +3338,8 @@ graal-bc
 <th scope="col"></th>
 <th scope="col" title="Executor, without common prefix with baseline">Exe</th>
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -3699,8 +3533,8 @@ graal-bc
 <th scope="col"></th>
 <th scope="col" title="Executor, without common prefix with baseline">Exe</th>
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>
@@ -4460,8 +4294,8 @@ graal
 <th scope="col"></th>
 <th scope="col" title="Executor, without common prefix with baseline">Exe</th>
 <th scope="col" title="Number of Samples">#M</th>
-<th scope="col">median time<br>in ms</th>
-<th scope="col">time diff %</th>
+<th scope="col" title="median time">median time<br>in ms</th>
+<th scope="col" title="difference in % of time">time diff %</th>
 
 <th scope="col"></th>
 </tr></thead>

--- a/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
@@ -160,11 +160,11 @@
 <img src="/static/reports/tsom/overview-micro-somsom.svg" width="432"><img src="/static/reports/tsom/overview-macro-startup.svg" width="432"><img src="/static/reports/tsom/overview-macro-steady.svg" width="432"><img src="/static/reports/tsom/overview-micro-startup.svg" width="432"><img src="/static/reports/tsom/overview-micro-steady.svg" width="432">
 </div>
 <dl class="row">
-  <dt class="col-sm-5" style="white-space: nowrap;">Number of Run Configurations</dt>
-  <dd class="col-sm-5">166</dd>
+  <dt class="col-sm-3" style="white-space: nowrap;">Number of Run Configurations</dt>
+  <dd class="col-sm-7">166</dd>
 
-  <dt class="col-sm-5">Median Run time in ms</dt>
-  <dd class="col-sm-5">0.00 (min. -0.29, max. 0.17)</dd>
+  <dt class="col-sm-3">Change of Run time</dt>
+  <dd class="col-sm-7">median 0% (min. -29%, max. 17%)</dd>
 </dl>
 
 

--- a/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
@@ -2947,16 +2947,15 @@ ast
 1
 <br>1
 </td>
+
 <td><span class="stats-median" title="median">
 21624.67
 <br>28426.29
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">31</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">31</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  1</code>"></button>
@@ -2976,16 +2975,15 @@ ast
 1
 <br>1
 </td>
+
 <td><span class="stats-median" title="median">
 15196.07
 <br>19723.08
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">30</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">30</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  1</code>"></button>
@@ -3005,16 +3003,15 @@ ast
 1
 <br>1
 </td>
+
 <td><span class="stats-median" title="median">
 351.52
 <br>456.26
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">30</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">30</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  3</code>"></button>
@@ -3034,16 +3031,15 @@ ast
 1
 <br>1
 </td>
+
 <td><span class="stats-median" title="median">
 14760.86
 <br>18868.32
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">28</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">28</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  1</code>"></button>
@@ -3063,16 +3059,15 @@ ast
 1
 <br>1
 </td>
+
 <td><span class="stats-median" title="median">
 13668.42
 <br>18004.65
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">32</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">32</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  1</code>"></button>
@@ -3117,6 +3112,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 275.04
 <br>292.45
@@ -3124,13 +3120,11 @@ graal
 <br>76.58
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">6</span>
-<br><span class="stats-change" title="change over median run time">-74</span>
-<br><span class="stats-change" title="change over median run time">-72</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">6</span>
+<br><span class="stats-change stats-total" title="diff %">-74</span>
+<br><span class="stats-change stats-total" title="diff %">-72</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
@@ -3154,6 +3148,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 182.46
 <br>212.70
@@ -3161,13 +3156,11 @@ graal
 <br>69.81
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">17</span>
-<br><span class="stats-change" title="change over median run time">-68</span>
-<br><span class="stats-change" title="change over median run time">-62</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">17</span>
+<br><span class="stats-change stats-total" title="diff %">-68</span>
+<br><span class="stats-change stats-total" title="diff %">-62</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
@@ -3191,6 +3184,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 253.06
 <br>254.33
@@ -3198,13 +3192,11 @@ graal
 <br>153.97
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">1</span>
-<br><span class="stats-change" title="change over median run time">-37</span>
-<br><span class="stats-change" title="change over median run time">-39</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">1</span>
+<br><span class="stats-change stats-total" title="diff %">-37</span>
+<br><span class="stats-change stats-total" title="diff %">-39</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
@@ -3228,6 +3220,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 132.49
 <br>172.67
@@ -3235,13 +3228,11 @@ graal
 <br>81.59
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">30</span>
-<br><span class="stats-change" title="change over median run time">-48</span>
-<br><span class="stats-change" title="change over median run time">-38</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">30</span>
+<br><span class="stats-change stats-total" title="diff %">-48</span>
+<br><span class="stats-change stats-total" title="diff %">-38</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
@@ -3265,6 +3256,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 159.80
 <br>287.66
@@ -3272,13 +3264,11 @@ graal
 <br>105.03
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">80</span>
-<br><span class="stats-change" title="change over median run time">-59</span>
-<br><span class="stats-change" title="change over median run time">-34</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">80</span>
+<br><span class="stats-change stats-total" title="diff %">-59</span>
+<br><span class="stats-change stats-total" title="diff %">-34</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
@@ -3302,6 +3292,7 @@ graal-bc
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 689.30
 <br>357.33
@@ -3309,13 +3300,11 @@ graal-bc
 <br>624.07
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-48</span>
-<br><span class="stats-change" title="change over median run time">-40</span>
-<br><span class="stats-change" title="change over median run time">-9</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-48</span>
+<br><span class="stats-change stats-total" title="diff %">-40</span>
+<br><span class="stats-change stats-total" title="diff %">-9</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
@@ -3356,16 +3345,15 @@ graal-bc
 120
 <br>120
 </td>
+
 <td><span class="stats-median" title="median">
 49.53
 <br>160.50
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">224</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">224</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
@@ -3385,16 +3373,15 @@ graal-bc
 250
 <br>250
 </td>
+
 <td><span class="stats-median" title="median">
 71.07
 <br>72.17
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">2</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">2</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
@@ -3414,16 +3401,15 @@ graal-bc
 120
 <br>120
 </td>
+
 <td><span class="stats-median" title="median">
 105.25
 <br>111.11
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">6</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">6</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
@@ -3443,16 +3429,15 @@ graal-bc
 120
 <br>120
 </td>
+
 <td><span class="stats-median" title="median">
 70.04
 <br>61.05
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-13</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-13</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
@@ -3472,16 +3457,15 @@ graal-bc
 120
 <br>120
 </td>
+
 <td><span class="stats-median" title="median">
 114.29
 <br>107.50
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-6</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-6</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
@@ -3501,16 +3485,15 @@ graal-bc
 130
 <br>130
 </td>
+
 <td><span class="stats-median" title="median">
 99.78
 <br>97.56
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-2</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-2</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
@@ -3555,6 +3538,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 151.69
 <br>163.67
@@ -3562,13 +3546,11 @@ graal
 <br>89.81
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">8</span>
-<br><span class="stats-change" title="change over median run time">-42</span>
-<br><span class="stats-change" title="change over median run time">-41</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">8</span>
+<br><span class="stats-change stats-total" title="diff %">-42</span>
+<br><span class="stats-change stats-total" title="diff %">-41</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
@@ -3592,6 +3574,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 129.31
 <br>141.15
@@ -3599,13 +3582,11 @@ graal
 <br>95.55
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">9</span>
-<br><span class="stats-change" title="change over median run time">-46</span>
-<br><span class="stats-change" title="change over median run time">-26</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">9</span>
+<br><span class="stats-change stats-total" title="diff %">-46</span>
+<br><span class="stats-change stats-total" title="diff %">-26</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
@@ -3629,6 +3610,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 100.84
 <br>115.17
@@ -3636,13 +3618,11 @@ graal
 <br>123.38
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">14</span>
-<br><span class="stats-change" title="change over median run time">-36</span>
-<br><span class="stats-change" title="change over median run time">22</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">14</span>
+<br><span class="stats-change stats-total" title="diff %">-36</span>
+<br><span class="stats-change stats-total" title="diff %">22</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
@@ -3666,6 +3646,7 @@ graal-bc
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 194.92
 <br>123.53
@@ -3673,13 +3654,11 @@ graal-bc
 <br>71.65
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-37</span>
-<br><span class="stats-change" title="change over median run time">-77</span>
-<br><span class="stats-change" title="change over median run time">-63</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-37</span>
+<br><span class="stats-change stats-total" title="diff %">-77</span>
+<br><span class="stats-change stats-total" title="diff %">-63</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
@@ -3703,6 +3682,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 134.85
 <br>231.00
@@ -3710,13 +3690,11 @@ graal
 <br>139.68
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">71</span>
-<br><span class="stats-change" title="change over median run time">-55</span>
-<br><span class="stats-change" title="change over median run time">4</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">71</span>
+<br><span class="stats-change stats-total" title="diff %">-55</span>
+<br><span class="stats-change stats-total" title="diff %">4</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
@@ -3740,6 +3718,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 47.32
 <br>65.15
@@ -3747,13 +3726,11 @@ graal
 <br>22.88
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">38</span>
-<br><span class="stats-change" title="change over median run time">-27</span>
-<br><span class="stats-change" title="change over median run time">-52</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">38</span>
+<br><span class="stats-change stats-total" title="diff %">-27</span>
+<br><span class="stats-change stats-total" title="diff %">-52</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
@@ -3777,6 +3754,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 89.40
 <br>228.15
@@ -3784,13 +3762,11 @@ graal
 <br>150.75
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">155</span>
-<br><span class="stats-change" title="change over median run time">-38</span>
-<br><span class="stats-change" title="change over median run time">69</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">155</span>
+<br><span class="stats-change stats-total" title="diff %">-38</span>
+<br><span class="stats-change stats-total" title="diff %">69</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
@@ -3814,6 +3790,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 80.21
 <br>76.16
@@ -3821,13 +3798,11 @@ graal
 <br>22.22
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-5</span>
-<br><span class="stats-change" title="change over median run time">-76</span>
-<br><span class="stats-change" title="change over median run time">-72</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-5</span>
+<br><span class="stats-change stats-total" title="diff %">-76</span>
+<br><span class="stats-change stats-total" title="diff %">-72</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
@@ -3851,6 +3826,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 88.65
 <br>118.13
@@ -3858,13 +3834,11 @@ graal
 <br>528.11
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">33</span>
-<br><span class="stats-change" title="change over median run time">38</span>
-<br><span class="stats-change" title="change over median run time">496</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">33</span>
+<br><span class="stats-change stats-total" title="diff %">38</span>
+<br><span class="stats-change stats-total" title="diff %">496</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
@@ -3888,6 +3862,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 123.19
 <br>244.78
@@ -3895,13 +3870,11 @@ graal
 <br>124.67
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">99</span>
-<br><span class="stats-change" title="change over median run time">-14</span>
-<br><span class="stats-change" title="change over median run time">1</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">99</span>
+<br><span class="stats-change stats-total" title="diff %">-14</span>
+<br><span class="stats-change stats-total" title="diff %">1</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
@@ -3925,6 +3898,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 145.52
 <br>189.32
@@ -3932,13 +3906,11 @@ graal
 <br>129.47
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">30</span>
-<br><span class="stats-change" title="change over median run time">-26</span>
-<br><span class="stats-change" title="change over median run time">-11</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">30</span>
+<br><span class="stats-change stats-total" title="diff %">-26</span>
+<br><span class="stats-change stats-total" title="diff %">-11</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
@@ -3962,6 +3934,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 119.00
 <br>186.72
@@ -3969,13 +3942,11 @@ graal
 <br>118.02
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">57</span>
-<br><span class="stats-change" title="change over median run time">-44</span>
-<br><span class="stats-change" title="change over median run time">-1</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">57</span>
+<br><span class="stats-change stats-total" title="diff %">-44</span>
+<br><span class="stats-change stats-total" title="diff %">-1</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
@@ -3999,6 +3970,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 185.47
 <br>239.84
@@ -4006,13 +3978,11 @@ graal
 <br>89.83
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">29</span>
-<br><span class="stats-change" title="change over median run time">-50</span>
-<br><span class="stats-change" title="change over median run time">-52</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">29</span>
+<br><span class="stats-change stats-total" title="diff %">-50</span>
+<br><span class="stats-change stats-total" title="diff %">-52</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
@@ -4036,6 +4006,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 128.25
 <br>144.41
@@ -4043,13 +4014,11 @@ graal
 <br>76.64
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">13</span>
-<br><span class="stats-change" title="change over median run time">-52</span>
-<br><span class="stats-change" title="change over median run time">-40</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">13</span>
+<br><span class="stats-change stats-total" title="diff %">-52</span>
+<br><span class="stats-change stats-total" title="diff %">-40</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
@@ -4073,6 +4042,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 132.23
 <br>172.03
@@ -4080,13 +4050,11 @@ graal
 <br>115.01
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">30</span>
-<br><span class="stats-change" title="change over median run time">-31</span>
-<br><span class="stats-change" title="change over median run time">-13</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">30</span>
+<br><span class="stats-change stats-total" title="diff %">-31</span>
+<br><span class="stats-change stats-total" title="diff %">-13</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
@@ -4110,6 +4078,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 158.52
 <br>179.38
@@ -4117,13 +4086,11 @@ graal
 <br>77.53
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">13</span>
-<br><span class="stats-change" title="change over median run time">-57</span>
-<br><span class="stats-change" title="change over median run time">-51</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">13</span>
+<br><span class="stats-change stats-total" title="diff %">-57</span>
+<br><span class="stats-change stats-total" title="diff %">-51</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
@@ -4147,6 +4114,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 80.63
 <br>110.34
@@ -4154,13 +4122,11 @@ graal
 <br>254.49
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">37</span>
-<br><span class="stats-change" title="change over median run time">77</span>
-<br><span class="stats-change" title="change over median run time">216</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">37</span>
+<br><span class="stats-change stats-total" title="diff %">77</span>
+<br><span class="stats-change stats-total" title="diff %">216</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
@@ -4184,6 +4150,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 140.07
 <br>178.94
@@ -4191,13 +4158,11 @@ graal
 <br>69.94
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">28</span>
-<br><span class="stats-change" title="change over median run time">-67</span>
-<br><span class="stats-change" title="change over median run time">-50</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">28</span>
+<br><span class="stats-change stats-total" title="diff %">-67</span>
+<br><span class="stats-change stats-total" title="diff %">-50</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
@@ -4221,6 +4186,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 156.97
 <br>217.42
@@ -4228,13 +4194,11 @@ graal
 <br>79.03
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">39</span>
-<br><span class="stats-change" title="change over median run time">-63</span>
-<br><span class="stats-change" title="change over median run time">-50</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">39</span>
+<br><span class="stats-change stats-total" title="diff %">-63</span>
+<br><span class="stats-change stats-total" title="diff %">-50</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
@@ -4258,6 +4222,7 @@ graal
 <br>5
 <br>5
 </td>
+
 <td><span class="stats-median" title="median">
 67.42
 <br>225.86
@@ -4265,13 +4230,11 @@ graal
 <br>92.71
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">235</span>
-<br><span class="stats-change" title="change over median run time">25</span>
-<br><span class="stats-change" title="change over median run time">37</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">235</span>
+<br><span class="stats-change stats-total" title="diff %">25</span>
+<br><span class="stats-change stats-total" title="diff %">37</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
@@ -4312,16 +4275,15 @@ graal
 60
 <br>60
 </td>
+
 <td><span class="stats-median" title="median">
 139.58
 <br>216.01
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">55</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">55</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
@@ -4341,16 +4303,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 83.49
 <br>78.22
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-6</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-6</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
@@ -4370,16 +4331,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 223.33
 <br>196.97
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-12</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-12</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
@@ -4399,16 +4359,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 46.52
 <br>195.80
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">321</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">321</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
@@ -4428,16 +4387,15 @@ graal
 60
 <br>60
 </td>
+
 <td><span class="stats-median" title="median">
 85.58
 <br>116.58
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">36</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">36</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
@@ -4457,16 +4415,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 240.07
 <br>239.91
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">0</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">0</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
@@ -4486,16 +4443,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 155.00
 <br>268.56
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">73</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">73</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
@@ -4515,16 +4471,15 @@ graal
 65
 <br>65
 </td>
+
 <td><span class="stats-median" title="median">
 105.67
 <br>101.37
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-4</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-4</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
@@ -4544,16 +4499,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 2.41
 <br>175.47
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">7172</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">7172</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
@@ -4573,16 +4527,15 @@ graal
 110
 <br>110
 </td>
+
 <td><span class="stats-median" title="median">
 358.87
 <br>394.93
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">10</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">10</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
@@ -4602,16 +4555,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 135.55
 <br>424.57
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">213</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">213</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
@@ -4631,16 +4583,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 119.42
 <br>106.88
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-11</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-11</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
@@ -4660,16 +4611,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 121.89
 <br>246.59
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">102</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">102</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
@@ -4689,16 +4639,15 @@ graal
 65
 <br>65
 </td>
+
 <td><span class="stats-median" title="median">
 122.70
 <br>138.64
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">13</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">13</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
@@ -4718,16 +4667,15 @@ graal
 60
 <br>60
 </td>
+
 <td><span class="stats-median" title="median">
 100.75
 <br>102.64
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">2</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">2</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
@@ -4747,16 +4695,15 @@ graal
 60
 <br>60
 </td>
+
 <td><span class="stats-median" title="median">
 97.29
 <br>197.72
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">103</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">103</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
@@ -4776,16 +4723,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 250.33
 <br>190.78
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-24</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-24</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
@@ -4805,16 +4751,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 343.36
 <br>335.06
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">-2</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">-2</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
@@ -4834,16 +4779,15 @@ graal
 60
 <br>60
 </td>
+
 <td><span class="stats-median" title="median">
 154.65
 <br>159.52
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">3</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">3</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
@@ -4863,16 +4807,15 @@ graal
 55
 <br>55
 </td>
+
 <td><span class="stats-median" title="median">
 181.69
 <br>787.93
 </span></td>
 <td>
-<span class="stats-change" title="change over median run time">0</span>
-<br><span class="stats-change" title="change over median run time">334</span>
+<span class="stats-change stats-total" title="diff %">0</span>
+<br><span class="stats-change stats-total" title="diff %">334</span>
 </td>
-
-
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>

--- a/tests/views/helpers.test.ts
+++ b/tests/views/helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import {
   commonStringStart,
   PerIterationOutput,
+  sortTotalToFront,
   withoutStart
 } from '../../src/shared/helpers';
 
@@ -110,6 +111,34 @@ describe('Helper functions for the views', () => {
       output.next();
       output.next();
       expect(output.next()).toBe('second');
+    });
+  });
+
+  describe('sortTotalToFront()', () => {
+    it('should sort the list of strings with total to the front', () => {
+      expect(sortTotalToFront(['foo', 'bar', 'total', 'baz'])).toEqual([
+        'total',
+        'foo',
+        'bar',
+        'baz'
+      ]);
+    });
+
+    it('should not change array if total is already at the front', () => {
+      expect(sortTotalToFront(['total', 'foo', 'bar', 'baz'])).toEqual([
+        'total',
+        'foo',
+        'bar',
+        'baz'
+      ]);
+    });
+
+    it('should not change array if total is not present', () => {
+      expect(sortTotalToFront(['foo', 'bar', 'baz'])).toEqual([
+        'foo',
+        'bar',
+        'baz'
+      ]);
     });
   });
 });


### PR DESCRIPTION
This filters the criteria that are displayed in the overview and in the tables for the comparison view based on the criteria for which we have non-zero data.
So, we filter out data that is always zero to avoid clutter.
And we show the columns for all criteria.

The overview statistics are percentage of change, and now labeled as such.

This PR resolves the following issues:
 - #143
 - #149
 - #153

It also fixes the counting of run configurations, which previously multiplied the result by the number of found criteria.