### PR TITLE
Combine measurements from multiple trials and experiments for the same code revision

### DIFF
--- a/src/backend/compare/compare.ts
+++ b/src/backend/compare/compare.ts
@@ -92,7 +92,7 @@ async function getMeasurements(
   db: Database
 ): Promise<WarmupData | null> {
   const q = {
-    name: 'fetchMeasurementsByProjectIdRunIdTrialId',
+    name: 'fetchMeasurementsByProjectIdRunIdExpId',
     text: `SELECT
               trialId,
               invocation, iteration, warmup,

--- a/src/backend/compare/compare.ts
+++ b/src/backend/compare/compare.ts
@@ -3,7 +3,7 @@ import { ParameterizedContext } from 'koa';
 import { Database } from '../db/db.js';
 import { completeRequest, startRequest } from '../perf-tracker.js';
 import type {
-  WarmupData,
+  ProfileRow,
   WarmupDataForTrial,
   WarmupDataPerCriterion
 } from '../../shared/view-types.js';
@@ -23,7 +23,7 @@ export async function getProfileAsJson(
 
   ctx.body = await getProfile(
     Number(ctx.params.runId),
-    Number(ctx.params.expId),
+    ctx.params.commitId,
     db
   );
   if (ctx.body === undefined) {
@@ -36,32 +36,35 @@ export async function getProfileAsJson(
 
 async function getProfile(
   runId: number,
-  expId: number,
+  commitId: number,
   db: Database
-): Promise<any> {
+): Promise<ProfileRow[]> {
   const result = await db.query({
-    name: 'fetchProfileDataByRunIdExpId',
+    name: 'fetchProfileDataByRunIdCommitId',
     text: `
-          SELECT substring(commitId, 1, 6) as commitid,
+          SELECT commitid,
             benchmark.name as bench, executor.name as exe, suite.name as suite,
             cmdline, varValue, cores, inputSize, extraArgs,
             invocation, numIterations, warmup, value as profile
           FROM ProfileData
             JOIN Trial ON trialId = Trial.id
-            JOIN Source ON source.id = sourceId
+            JOIN Source ON source.id = trial.sourceId
             JOIN Run ON runId = run.id
             JOIN Suite ON suiteId = suite.id
             JOIN Benchmark ON benchmarkId = benchmark.id
             JOIN Executor ON execId = executor.id
-          WHERE runId = $1 AND trial.expId = $2`,
-    values: [runId, expId]
+          WHERE runId = $1 AND source.commitId = $2`,
+    values: [runId, commitId]
   });
 
-  const data = result.rows[0];
-  try {
-    data.profile = JSON.parse(data.profile);
-  } catch (e) {
-    /* let's just leave it as a string */
+  const data: ProfileRow[] = [];
+  for (const row of result.rows) {
+    try {
+      row.profile = JSON.parse(row.profile);
+    } catch (e) {
+      /* let's just leave it as a string */
+    }
+    data.push(row);
   }
   return data;
 }
@@ -75,8 +78,8 @@ export async function getMeasurementsAsJson(
   ctx.body = await getMeasurements(
     ctx.params.projectSlug,
     Number(ctx.params.runId),
-    Number(ctx.params.expId1),
-    Number(ctx.params.expId2),
+    ctx.params.baseId,
+    ctx.params.changeId,
     db
   );
 
@@ -87,14 +90,14 @@ export async function getMeasurementsAsJson(
 async function getMeasurements(
   projectSlug: string,
   runId: number,
-  expId1: number,
-  expId2: number,
+  baseCommitId: string,
+  changeCommitId: string,
   db: Database
-): Promise<WarmupData | null> {
+): Promise<WarmupDataForTrial[] | null> {
   const q = {
-    name: 'fetchMeasurementsByProjectIdRunIdExpId',
+    name: 'fetchMeasurementsByProjectIdRunIdCommitId',
     text: `SELECT
-              trialId,
+              trialId, source.commitId as commitId,
               invocation, iteration, warmup,
               criterion.name as criterion,
               criterion.unit as unit,
@@ -102,52 +105,37 @@ async function getMeasurements(
             FROM
               Measurement
               JOIN Trial ON trialId = Trial.id
+              JOIN Source ON source.id = trial.sourceId
               JOIN Experiment ON Trial.expId = Experiment.id
               JOIN Criterion ON criterion = criterion.id
               JOIN Run ON runId = run.id
               JOIN Project ON Project.id = Experiment.projectId
             WHERE Project.slug = $1
               AND runId = $2
-              AND (Trial.expId = $3 OR Trial.expId = $4)
+              AND (source.commitId = $3 OR source.commitId = $4)
             ORDER BY trialId, criterion, invocation, iteration;`,
-    values: [projectSlug, runId, expId1, expId2]
+    values: [projectSlug, runId, baseCommitId, changeCommitId]
   };
   const result = await db.query(q);
   if (result.rows.length === 0) {
     return null;
   }
 
-  const trial1: WarmupDataForTrial = {
-    trialId: result.rows[0].trialid,
-    warmup: result.rows[0].warmup,
-    data: []
-  };
-  const trial2: WarmupDataForTrial = {
-    trialId: result.rows[result.rows.length - 1].trialid,
-    warmup: result.rows[result.rows.length - 1].warmup,
-    data: []
-  };
-  // preprocess rows, but should already have it like this in the database...
-
-  let trialId = 0;
+  const dataPerTrial: WarmupDataForTrial[] = [];
   let currentTrial: WarmupDataForTrial | null = null;
   let lastCriterion = null;
   let critObject: WarmupDataPerCriterion | null = null;
 
   for (const r of result.rows) {
-    if (trialId === 0) {
-      trialId = r.trialid;
-      currentTrial = trial1;
+    if (currentTrial === null || currentTrial.trialId !== r.trialid) {
+      currentTrial = {
+        trialId: r.trialid,
+        warmup: r.warmup,
+        commitId: r.commitid,
+        data: []
+      };
       lastCriterion = null;
-    } else if (trialId !== r.trialid) {
-      if (currentTrial === trial2) {
-        throw Error(
-          'Unexpected trialId change. We only expect two different ones.'
-        );
-      }
-      trialId = r.trialid;
-      currentTrial = trial2;
-      lastCriterion = null;
+      dataPerTrial.push(currentTrial);
     }
 
     if (lastCriterion === null || lastCriterion !== r.criterion) {
@@ -161,6 +149,7 @@ async function getMeasurements(
     }
 
     if (critObject) {
+      // this is fine, because we separate the data by trialId
       if (critObject.values[r.invocation - 1] === undefined) {
         critObject.values[r.invocation - 1] = [];
       }
@@ -169,7 +158,7 @@ async function getMeasurements(
     }
   }
 
-  return { trial1, trial2 };
+  return dataPerTrial;
 }
 
 export async function getTimelineDataAsJson(

--- a/src/backend/compare/db-data.ts
+++ b/src/backend/compare/db-data.ts
@@ -181,8 +181,7 @@ function findOrConstructMeasurements(
     envId: row.envid,
     commitId: row.commitid,
     runSettings: runSetting,
-    runId: row.runid,
-    expId: row.expid
+    runId: row.runid
   };
   benchResult.measurements.push(m);
   forSuiteByBench.criteria[criterion.name] = criterion;
@@ -210,7 +209,6 @@ function isSameMeasurements(row: MeasurementData, m: Measurements) {
     m.envId == row.envid &&
     m.commitId == row.commitid &&
     m.runId == row.runid &&
-    m.expId == row.expid &&
     m.criterion.name == row.criterion
   );
 }

--- a/src/backend/compare/db-data.ts
+++ b/src/backend/compare/db-data.ts
@@ -178,7 +178,6 @@ function findMeasurements(
   benchResult: ProcessedResult,
   row: MeasurementData
 ): Measurements | null {
-  let m: Measurements | null = null;
   for (const mm of benchResult.measurements) {
     if (
       mm.envId == row.envid &&
@@ -187,9 +186,8 @@ function findMeasurements(
       mm.expId == row.expid &&
       mm.criterion.name == row.criterion
     ) {
-      m = mm;
-      break;
+      return mm;
     }
   }
-  return m;
+  return null;
 }

--- a/src/backend/compare/db-data.ts
+++ b/src/backend/compare/db-data.ts
@@ -163,7 +163,6 @@ function findOrConstructMeasurements(
     commitId: row.commitid,
     runSettings: runSetting,
     runId: row.runid,
-    trialId: row.trialid,
     expId: row.expid
   };
   benchResult.measurements.push(m);
@@ -185,7 +184,7 @@ function findMeasurements(
       mm.envId == row.envid &&
       mm.commitId == row.commitid &&
       mm.runId == row.runid &&
-      mm.trialId == row.trialid &&
+      mm.expId == row.expid &&
       mm.criterion.name == row.criterion
     ) {
       m = mm;

--- a/src/backend/compare/db-data.ts
+++ b/src/backend/compare/db-data.ts
@@ -31,6 +31,11 @@ export function collateMeasurements(
   const runSettings = new Map<string, RunSettings>();
   const criteria = new Map<string, CriterionData>();
 
+  let lastInvocation = 0;
+  let lastTrialId = -1;
+  let lastMeasurements: Measurements | null = null;
+  let lastValues: number[] = [];
+
   for (const row of data) {
     const c = `${row.criterion}|${row.unit}`;
 
@@ -72,21 +77,35 @@ export function collateMeasurements(
       forExeBySuiteBench.set(row.suite, forSuiteByBench);
     }
 
-    const benchResult = findOrConstructProcessedResult(forSuiteByBench, row);
+    if (
+      lastMeasurements === null ||
+      !isSameInvocation(row, lastMeasurements, lastInvocation, lastTrialId)
+    ) {
+      const benchResult = findOrConstructProcessedResult(forSuiteByBench, row);
 
-    const m: Measurements = findOrConstructMeasurements(
-      benchResult,
-      row,
-      criterion,
-      runSetting,
-      forSuiteByBench
-    );
+      const m: Measurements = findOrConstructMeasurements(
+        benchResult,
+        row,
+        criterion,
+        runSetting,
+        forSuiteByBench
+      );
 
-    // adjust invocation and iteration to be zero-based
-    if (!m.values[row.invocation - 1]) {
-      m.values[row.invocation - 1] = [];
+      // We don't store the invocation number anymore
+      // I think this is fine, we don't really need it.
+      // We just need to distinguish iterations, but their ordering
+      // doesn't have any particular meaning.
+      // If we should need it for statistical analysis of inter-invocation
+      // effects, we may need to re-introduce it.
+      lastValues = [];
+      m.values.push(lastValues);
+      lastInvocation = row.invocation;
+      lastMeasurements = m;
+      lastTrialId = row.trialid;
     }
-    m.values[row.invocation - 1][row.iteration - 1] = row.value;
+
+    // adjusted to be zero-based
+    lastValues[row.iteration - 1] = row.value;
   }
 
   return sortResultsAlphabetically(byExeSuiteBench);
@@ -179,15 +198,32 @@ function findMeasurements(
   row: MeasurementData
 ): Measurements | null {
   for (const mm of benchResult.measurements) {
-    if (
-      mm.envId == row.envid &&
-      mm.commitId == row.commitid &&
-      mm.runId == row.runid &&
-      mm.expId == row.expid &&
-      mm.criterion.name == row.criterion
-    ) {
+    if (isSameMeasurements(row, mm)) {
       return mm;
     }
   }
   return null;
+}
+
+function isSameMeasurements(row: MeasurementData, m: Measurements) {
+  return (
+    m.envId == row.envid &&
+    m.commitId == row.commitid &&
+    m.runId == row.runid &&
+    m.expId == row.expid &&
+    m.criterion.name == row.criterion
+  );
+}
+
+function isSameInvocation(
+  row: MeasurementData,
+  m: Measurements,
+  invocation: number,
+  trialId: number
+) {
+  return (
+    invocation == row.invocation &&
+    trialId == row.trialid &&
+    isSameMeasurements(row, m)
+  );
 }

--- a/src/backend/compare/html/stats-row-buttons-info.html
+++ b/src/backend/compare/html/stats-row-buttons-info.html
@@ -11,14 +11,12 @@ const f = it.dataFormatters;
 {% }
 
    if (d.hasWarmup) {
-%}<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="{%= f.dataSeriesIds(d.dataSeries, d.dataSeries.runId, d.dataSeries.base.expId, d.dataSeries.change.expId) %}"></button>
+%}<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="{%= d.runId %}"></button>
 {%
    } 
 
-   if (d.profileBase) {
-      const baseExpId = d.profileBase.expid;
-      const changeExpId = d.profileChange.expid;
-%}<button type="button" class="btn btn-sm btn-profile" data-content="{%= f.dataSeriesIds(d.dataSeries, d.profileBase.runid, baseExpId, changeExpId) %}"></button>
+   if (d.profiles) {
+%}<button type="button" class="btn btn-sm btn-profile" data-content="{%= d.runId %}"></button>
 {%
    }
 %}<button type="button" class="btn btn-sm btn-timeline" data-content='{%- JSON.stringify(

--- a/src/backend/db/db.ts
+++ b/src/backend/db/db.ts
@@ -806,7 +806,7 @@ export abstract class Database {
             FROM
               ${measurementDataTableJoins}
             WHERE (commitId = $1 OR commitid = $2) AND Experiment.projectId = $3
-              ORDER BY expId, runId, invocation, iteration, criterion`,
+              ORDER BY expId, runId, trialId, invocation, iteration, criterion`,
       values: [commitHash1, commitHash2, projectId]
     });
     return result.rows;

--- a/src/backend/db/db.ts
+++ b/src/backend/db/db.ts
@@ -1344,7 +1344,7 @@ export abstract class Database {
   ): Promise<HasProfile> {
     const q = {
       name: 'fetchProfileAvailability',
-      text: `SELECT
+      text: `SELECT DISTINCT
                 benchmark.name as b,
                 executor.name as e,
                 suite.name as s,
@@ -1352,7 +1352,7 @@ export abstract class Database {
                 cores as c,
                 inputSize as i,
                 extraArgs as ea,
-                expId, runId
+                commitId, runId
               FROM ProfileData pd
                 JOIN Trial ON pd.trialId = Trial.id
                 JOIN Experiment e ON trial.expId = e.id
@@ -1365,7 +1365,7 @@ export abstract class Database {
                 (commitId = $1 OR commitId = $2)
                 AND e.projectId = $3
               ORDER BY
-                b, e, s, v, c, i, ea, expId, runId, trialId`,
+                b, e, s, v, c, i, ea, runId, commitId`,
       values: [commitId1, commitId2, projectId]
     };
 

--- a/src/backend/db/has-profile.ts
+++ b/src/backend/db/has-profile.ts
@@ -17,8 +17,9 @@ function sameBenchId(a: BenchmarkId, b: BenchmarkId): boolean {
 
 export class HasProfile {
   /**
-   * This is expected to be sorted by expid, runid, trialid
+   * This is expected to be sorted by runid, commitid
    * as coming from the database.
+   * This ensures that base and change profile availability is paired up.
    */
   private readonly availableProfiles: AvailableProfile[];
 
@@ -26,22 +27,10 @@ export class HasProfile {
     this.availableProfiles = availableProfiles;
   }
 
-  public get(
-    benchId: BenchmarkId
-  ): [AvailableProfile, AvailableProfile?] | false {
+  public has(benchId: BenchmarkId): boolean {
     const idx = this.availableProfiles.findIndex((id) =>
       sameBenchId(id, benchId)
     );
-    if (idx >= 0) {
-      if (
-        idx === this.availableProfiles.length - 1 ||
-        !sameBenchId(this.availableProfiles[idx + 1], benchId)
-      ) {
-        return [this.availableProfiles[idx]];
-      }
-
-      return [this.availableProfiles[idx], this.availableProfiles[idx + 1]];
-    }
-    return false;
+    return idx >= 0;
   }
 }

--- a/src/backend/db/types.ts
+++ b/src/backend/db/types.ts
@@ -145,7 +145,6 @@ export interface Baseline extends Source {
 export interface MeasurementData {
   expid: number;
   runid: number;
-  trialid: number;
   commitid: string;
   bench: string;
   exe: string;
@@ -197,7 +196,6 @@ export interface Measurements {
 
   envId: number;
   runId: number;
-  trialId: number;
   expId: number;
   runSettings: RunSettings;
   commitId: string;

--- a/src/backend/db/types.ts
+++ b/src/backend/db/types.ts
@@ -145,6 +145,7 @@ export interface Baseline extends Source {
 export interface MeasurementData {
   expid: number;
   runid: number;
+  trialid: number;
   commitid: string;
   bench: string;
   exe: string;

--- a/src/backend/db/types.ts
+++ b/src/backend/db/types.ts
@@ -165,7 +165,7 @@ export interface MeasurementData {
 }
 
 export interface AvailableProfile extends BenchmarkId {
-  expid: number;
+  commitid: string;
   runid: number;
 }
 
@@ -197,7 +197,6 @@ export interface Measurements {
 
   envId: number;
   runId: number;
-  expId: number;
   runSettings: RunSettings;
   commitId: string;
   stats?: SummaryStatistics;

--- a/src/backend/perf-tracker.ts
+++ b/src/backend/perf-tracker.ts
@@ -29,7 +29,7 @@ const descriptions = {
   'get-exp-data': 'Starting to prepare experiment data',
   'project-benchmarks': 'Time of GET /rebenchdb/dash/:projectId/benchmarks',
   'get-profiles':
-    // this url was changed to use the expId instead of the trialId
+    // this url was changed to use the commitId instead of the trialId
     // I'll leave this unchanged here to avoid issues
     // with the performance tracking
     'Time of GET /rebenchdb/dash/:projectId/profiles/:runId/:trialId',

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,11 +105,12 @@ router.get('/rebenchdb/dash/:projectId/results', async (ctx) =>
 router.get('/rebenchdb/dash/:projectId/timeline/:runId', async (ctx) =>
   getTimelineAsJson(ctx, db)
 );
-router.get('/rebenchdb/dash/:projectSlug/profiles/:runId/:expId', async (ctx) =>
-  getProfileAsJson(ctx, db)
+router.get(
+  '/rebenchdb/dash/:projectSlug/profiles/:runId/:commitId',
+  async (ctx) => getProfileAsJson(ctx, db)
 );
 router.get(
-  '/rebenchdb/dash/:projectSlug/measurements/:runId/:expId1/:expId2',
+  '/rebenchdb/dash/:projectSlug/measurements/:runId/:baseId/:changeId',
   async (ctx) => getMeasurementsAsJson(ctx, db)
 );
 router.get('/rebenchdb/stats', async (ctx) => getSiteStatsAsJson(ctx, db));

--- a/src/shared/data-format.ts
+++ b/src/shared/data-format.ts
@@ -1,6 +1,5 @@
 import type { BenchmarkId } from '../shared/api.js';
 import type { Environment } from '../backend/db/types.js';
-import type { DataSeriesVersionComparison } from './view-types.js';
 
 /**
  * Round to 0 decimal places.
@@ -116,19 +115,6 @@ export function benchmarkId(
     obj.ea = extraArgs;
   }
   return obj;
-}
-
-export function dataSeriesIds(
-  ids: DataSeriesVersionComparison,
-  runId: number,
-  baseExpId: number,
-  changeExpId: number
-): string {
-  // format is parsed in compare.ts:insertProfiles()
-  return (
-    `${runId},${ids.base.commitId}/${baseExpId},` +
-    `${ids.change.commitId}/${changeExpId}`
-  );
 }
 
 /**

--- a/src/shared/view-types.ts
+++ b/src/shared/view-types.ts
@@ -1,6 +1,5 @@
-import type { BenchmarkId } from './api.js';
+import type { BenchmarkId, ProfileElement } from './api.js';
 import type {
-  AvailableProfile,
   CriterionData,
   Environment,
   RevisionData
@@ -64,19 +63,10 @@ export interface CompareStatsRowAcrossVersionsPartial {
   criteria: CompareStatsTableHeader;
 }
 
-/**
- * Identifies the set of measurements of a specific run, i.e., a concrete
- * benchmark execution, and a experiment.
- */
-export interface DataSeriesId {
-  commitId: string; // this one is a bit redundant, it's implied by the trialId
-  expId: number;
-}
-
 export interface DataSeriesVersionComparison {
   runId: number;
-  base: DataSeriesId;
-  change: DataSeriesId;
+  baseCommitId: string;
+  changeCommitId: string;
 }
 
 export interface RunDetails {
@@ -86,10 +76,9 @@ export interface RunDetails {
 
   hasWarmup: boolean;
 
-  profileBase: AvailableProfile | false;
-  profileChange: AvailableProfile | false;
+  profiles: boolean;
 
-  dataSeries?: DataSeriesVersionComparison;
+  runId: number;
 
   /** Number of VarValues */
   numV: number;
@@ -246,11 +235,23 @@ export interface WarmupDataPerCriterion {
 
 export interface WarmupDataForTrial {
   trialId: number;
+  commitId: string;
   warmup: number;
   data: WarmupDataPerCriterion[];
 }
 
-export interface WarmupData {
-  trial1: WarmupDataForTrial;
-  trial2: WarmupDataForTrial;
+export interface ProfileRow {
+  commitid: string;
+  bench: string;
+  exe: string;
+  suite: string;
+  cmdline: string;
+  varvalue: string;
+  cores: string;
+  inputsize: string;
+  extraargs: string;
+  invocation: number;
+  numiterations: number;
+  warmup: number;
+  profile: string | ProfileElement[];
 }

--- a/tests/backend/compare/compare-view.test.ts
+++ b/tests/backend/compare/compare-view.test.ts
@@ -24,10 +24,7 @@ import {
   calculateAllStatisticsAndRenderPlots,
   getNavigation
 } from '../../../src/backend/compare/prep-data.js';
-import type {
-  AvailableProfile,
-  Environment
-} from '../../../src/backend/db/types.js';
+import type { Environment } from '../../../src/backend/db/types.js';
 import { collateMeasurements } from '../../../src/backend/compare/db-data.js';
 import { initJestMatchers } from '../../helpers.js';
 
@@ -80,20 +77,9 @@ const environments: Environment[] = [
 const details: RunDetails = {
   cmdline: 'som/some-command with args',
   envId: 1,
-  profileBase: <AvailableProfile>{ expid: 11, runid: 1 },
-  profileChange: <AvailableProfile>{ expid: 12, runid: 1 },
+  profiles: true,
   hasWarmup: true,
-  dataSeries: {
-    runId: 1,
-    base: {
-      commitId: '123456',
-      expId: 2
-    },
-    change: {
-      commitId: '123457',
-      expId: 4
-    }
-  },
+  runId: 1,
   numV: 0,
   numC: 0,
   numI: 0,

--- a/tests/backend/compare/db-data.test.ts
+++ b/tests/backend/compare/db-data.test.ts
@@ -177,6 +177,65 @@ describe('collateMeasurements()', () => {
       expect(m1.values[0]).toHaveLength(120);
       expect(m2.values[0]).toHaveLength(120);
     });
+
+    it('should have the expected measurements for all benchmarks', () => {
+      const numValuesSteady: string[][] = [];
+      numValuesSteady[55] = [
+        'BubbleSort',
+        'Dispatch',
+        'Fannkuch',
+        'QuickSort',
+        'Queens',
+        'Permute',
+        'Loop',
+        'FieldLoop',
+        'IntegerLoop',
+        'WhileLoop',
+        'Sum',
+        'Towers'
+      ];
+      numValuesSteady[60] = [
+        'Bounce',
+        'Fibonacci',
+        'Sieve',
+        'Storage',
+        'TreeSort'
+      ];
+      numValuesSteady[65] = ['List', 'Recurse'];
+      numValuesSteady[110] = ['Mandelbrot'];
+      numValuesSteady[120] = ['DeltaBlue', 'Json', 'NBody', 'PageRank'];
+      numValuesSteady[130] = ['Richards'];
+      numValuesSteady[250] = ['GraphSearch'];
+
+      for (const [exe, suites] of result) {
+        for (const [suite, benchmarks] of suites) {
+          for (const [bench, processed] of benchmarks.benchmarks) {
+            expect(processed.measurements).toHaveLength(2);
+            for (const m of processed.measurements) {
+              if (exe.includes('SomSom')) {
+                expect(m.values).toHaveLength(1);
+                expect(m.values[0]).toHaveLength(1);
+              } else if (suite.includes('startup')) {
+                expect(m.values).toHaveLength(5);
+                for (const v of m.values) {
+                  expect(v).toHaveLength(1);
+                }
+              } else if (suite.includes('steady')) {
+                expect(m.values).toHaveLength(1);
+                expect(numValuesSteady[m.values[0].length]).toContain(bench);
+              } else {
+                expect(false).toBe({
+                  exe,
+                  suite,
+                  bench,
+                  values: m.values
+                });
+              }
+            }
+          }
+        }
+      }
+    });
   });
 
   describe('needs to distinguish different run ids', () => {

--- a/tests/backend/compare/db-data.test.ts
+++ b/tests/backend/compare/db-data.test.ts
@@ -248,6 +248,7 @@ describe('collateMeasurements()', () => {
         expid: 1,
         runid,
         commitid,
+        trialid: 1,
 
         bench: 'b',
         exe: 'e',
@@ -306,5 +307,77 @@ describe('collateMeasurements()', () => {
 
       expect(b.measurements).toHaveLength(4);
     });
+  });
+
+  describe('Needs to combine data from different trials but same runId', () => {
+    function createMeasure(
+      runid: number,
+      trialid: number,
+      inputsize: string,
+      commitid: string
+    ): MeasurementData {
+      return {
+        expid: 1,
+        runid,
+        commitid,
+        trialid,
+
+        bench: 'b',
+        exe: 'e',
+        suite: 's',
+
+        cmdline: 'b e s ' + inputsize,
+        varvalue: null,
+        cores: null,
+        inputsize,
+        extraargs: null,
+
+        iteration: 1,
+        invocation: 1,
+        warmup: null,
+
+        criterion: 'total',
+        unit: 'ms',
+        value: 1,
+
+        envid: 1
+      };
+    }
+
+    const data: MeasurementData[] = [
+      createMeasure(1, 1, '1', 'a'),
+      createMeasure(1, 2, '1', 'a'),
+      createMeasure(1, 3, '1', 'a'),
+      createMeasure(1, 4, '1', 'b'),
+      createMeasure(1, 5, '1', 'b'),
+      createMeasure(1, 6, '1', 'b'),
+      createMeasure(2, 7, '2', 'a'),
+      createMeasure(2, 8, '2', 'b')
+    ];
+
+    const result: ResultsByExeSuiteBenchmark = collateMeasurements(data);
+
+    it('should have 4 measurements', () => {
+      const suites = <ResultsBySuiteBenchmark>result.get('e');
+      const bs = <ResultsByBenchmark>suites.get('s');
+      const b = <ProcessedResult>bs.benchmarks.get('b');
+
+      expect(b.measurements).toHaveLength(4);
+    });
+
+    it(
+      'should have 3 invocations for the 1st and 2nd measurement,' +
+        ' and 1 for the rest',
+      () => {
+        const suites = <ResultsBySuiteBenchmark>result.get('e');
+        const bs = <ResultsByBenchmark>suites.get('s');
+        const b = <ProcessedResult>bs.benchmarks.get('b');
+
+        expect(b.measurements[0].values).toHaveLength(3);
+        expect(b.measurements[1].values).toHaveLength(3);
+        expect(b.measurements[2].values).toHaveLength(1);
+        expect(b.measurements[3].values).toHaveLength(1);
+      }
+    );
   });
 });

--- a/tests/backend/compare/db-data.test.ts
+++ b/tests/backend/compare/db-data.test.ts
@@ -188,7 +188,6 @@ describe('collateMeasurements()', () => {
       return {
         expid: 1,
         runid,
-        trialid: 1,
         commitid,
 
         bench: 'b',

--- a/tests/data/expected-results/compare-view/compare-versions.html
+++ b/tests/data/expected-results/compare-view/compare-versions.html
@@ -34,8 +34,8 @@
 data-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
 data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1,123456/2,123457/4"></button>
-<button type="button" class="btn btn-sm btn-profile" data-content="1,123456/11,123457/12"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
+<button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button></td>
 </tr>
 </tbody>

--- a/tests/data/expected-results/compare-view/stats-row-button-info.html
+++ b/tests/data/expected-results/compare-view/stats-row-button-info.html
@@ -2,6 +2,6 @@
 data-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
 data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1,123456/2,123457/4"></button>
-<button type="button" class="btn btn-sm btn-profile" data-content="1,123456/11,123457/12"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
+<button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button>

--- a/tests/data/expected-results/compare-view/stats-row-exe.html
+++ b/tests/data/expected-results/compare-view/stats-row-exe.html
@@ -38,7 +38,7 @@ ast
 data-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
 data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1,123456/2,123457/4"></button>
-<button type="button" class="btn btn-sm btn-profile" data-content="1,123456/11,123457/12"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
+<button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button></td>
 </tr>

--- a/tests/data/expected-results/compare-view/stats-row-version-one-criteria-missing.html
+++ b/tests/data/expected-results/compare-view/stats-row-version-one-criteria-missing.html
@@ -14,7 +14,7 @@
 data-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
 data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1,123456/2,123457/4"></button>
-<button type="button" class="btn btn-sm btn-profile" data-content="1,123456/11,123457/12"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
+<button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button></td>
 </tr>

--- a/tests/data/expected-results/compare-view/stats-row-version.html
+++ b/tests/data/expected-results/compare-view/stats-row-version.html
@@ -13,7 +13,7 @@
 data-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
 data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1,123456/2,123457/4"></button>
-<button type="button" class="btn btn-sm btn-profile" data-content="1,123456/11,123457/12"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
+<button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button></td>
 </tr>

--- a/tests/data/expected-results/compare-view/stats-tbl.html
+++ b/tests/data/expected-results/compare-view/stats-tbl.html
@@ -29,8 +29,8 @@
 data-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
 data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1,123456/2,123457/4"></button>
-<button type="button" class="btn btn-sm btn-profile" data-content="1,123456/11,123457/12"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
+<button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button></td>
 </tr>
 </tbody>

--- a/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
@@ -160,7 +160,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 10 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1979,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1979"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"som","s":"macro"}'></button>
 </td>
 </tr>
@@ -175,7 +175,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 10 0  4</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1993,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1993"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"som","s":"macro"}'></button>
 </td>
 </tr>
@@ -190,7 +190,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som JsonSmall 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1986,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1986"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"JsonSmall","e":"som","s":"macro"}'></button>
 </td>
 </tr>
@@ -205,7 +205,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 10 0  500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1969,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1969"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"som","s":"macro"}'></button>
 </td>
 </tr>
@@ -220,7 +220,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 10 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1992,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1992"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"som","s":"macro"}'></button>
 </td>
 </tr>
@@ -235,7 +235,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1994,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1994"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"som","s":"macro"}'></button>
 </td>
 </tr>
@@ -273,7 +273,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1976,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1976"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -288,7 +288,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1980,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1980"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -303,7 +303,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1981,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1981"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -318,7 +318,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 10 0  6</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1970,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1970"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -333,7 +333,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1971,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1971"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -348,7 +348,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1991,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1991"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -363,7 +363,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1983,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1983"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -378,7 +378,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1973,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1973"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -393,7 +393,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 10 0  5</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1985,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1985"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -408,7 +408,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 10 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1988,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1988"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -423,7 +423,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1978,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1978"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -438,7 +438,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1982,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1982"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -453,7 +453,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1974,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1974"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -468,7 +468,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1989,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1989"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -483,7 +483,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 10 0  4</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1975,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1975"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -498,7 +498,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1990,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1990"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -513,7 +513,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1987,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1987"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -528,7 +528,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1984,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1984"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -543,7 +543,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1972,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1972"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"som","s":"micro"}'></button>
 </td>
 </tr>
@@ -558,7 +558,7 @@
   data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 10 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1977,4dff7e/320,bc1105/321"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1977"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"som","s":"micro"}'></button>
 </td>
 </tr>

--- a/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
@@ -479,7 +479,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1076,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1076"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -494,7 +494,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1087,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1087"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -509,7 +509,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="553,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="553"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Json","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -524,7 +524,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1070,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1070"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -539,7 +539,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1089,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1089"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -554,7 +554,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1068,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1068"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -881,7 +881,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="606,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="606"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -896,7 +896,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="615,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="615"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -911,7 +911,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="579,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="579"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -926,7 +926,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="582,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="582"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -941,7 +941,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="604,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="604"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -956,7 +956,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="595,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="595"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -971,7 +971,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="577,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="577"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -986,7 +986,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="576,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="576"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1001,7 +1001,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="589,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="589"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1016,7 +1016,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="596,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="596"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1031,7 +1031,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="586,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="586"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1046,7 +1046,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="597,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="597"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1061,7 +1061,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="599,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="599"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1076,7 +1076,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="610,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="610"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1091,7 +1091,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="614,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="614"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1106,7 +1106,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="612,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="612"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1121,7 +1121,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="594,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="594"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1136,7 +1136,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="605,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="605"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1151,7 +1151,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="611,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="611"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1166,7 +1166,7 @@
   data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="584,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="584"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1311,7 +1311,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2214,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2214"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -1326,7 +1326,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2208,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2208"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -1341,7 +1341,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2205,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2205"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Json","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -1356,7 +1356,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2212,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2212"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -1371,7 +1371,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2202,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2202"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -1386,7 +1386,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2207,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2207"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -1727,7 +1727,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2204,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2204"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1742,7 +1742,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2211,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2211"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1757,7 +1757,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2219,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2219"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1772,7 +1772,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2209,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2209"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1787,7 +1787,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2222,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2222"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1802,7 +1802,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2206,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2206"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1817,7 +1817,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2217,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2217"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1832,7 +1832,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2201,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2201"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1847,7 +1847,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2210,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2210"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1862,7 +1862,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2220,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2220"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1877,7 +1877,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2225,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2225"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1892,7 +1892,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2221,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2221"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1907,7 +1907,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2213,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2213"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1922,7 +1922,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2203,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2203"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1937,7 +1937,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2224,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2224"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1952,7 +1952,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2218,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2218"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1967,7 +1967,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2215,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2215"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1982,7 +1982,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2226,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2226"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -1997,7 +1997,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2223,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2223"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -2012,7 +2012,7 @@
   data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
     data-content=""></button>
-<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2216,5820ec/493,5fa4bd/499"></button>
+<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2216"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
 </tr>

--- a/tests/shared/data-format.test.ts
+++ b/tests/shared/data-format.test.ts
@@ -4,13 +4,11 @@ import {
   asHumanHz,
   asHumanMem,
   benchmarkId,
-  dataSeriesIds,
   formatEnvironment,
   per,
   r0,
   r2
 } from '../../src/shared/data-format.js';
-import { DataSeriesVersionComparison } from '../../src/shared/view-types.js';
 
 describe('Format Functions for Numerical Values', () => {
   describe('r0 - round to 0 decimal places', () => {
@@ -204,23 +202,5 @@ describe('Format Functions for Numerical Values', () => {
         )
       ).toBe('{"b":"bench","e":"exe","s":"suite"}');
     });
-  });
-});
-
-describe('dataSeriesIds()', () => {
-  it('should return the expected string', () => {
-    const ids: DataSeriesVersionComparison = {
-      runId: 1,
-      base: {
-        commitId: '123456',
-        expId: 2
-      },
-      change: {
-        commitId: '123457',
-        expId: 4
-      }
-    };
-
-    expect(dataSeriesIds(ids, 1, 2, 4)).toBe('1,123456/2,123457/4');
   });
 });


### PR DESCRIPTION
In this PR, we combine data in the comparison view for multiple experiment ids and trial ids.
We essentially stop using expId and trialId to distinguish data sets from now on.
Instead, we rely solely on commit ids.
The user interface of ReBenchDB is all around commit ids, so, it makes sense to combine multiple experiments that provide data for a specific revision, and the assumption is that there's no change in the setup, environment, benchmarks, or executors between different experiments on the same source revision.

As a consequence, the plots to visualize warmup data may need to show data from multiple trials/experiments.
The profiling info now can be a list of profiles, which are all shown under the corresponding revision.

We do not track invocation numbers anymore in the data for computing comparisons.
The reason is that we assume invocations to be independent, and it doesn't matter in which order they appeared.
This makes it simple to combine invocations from different experiments and trials, which are for the same experiments.

This fixes #158 and #159.