### PR TITLE
Make data set render

### DIFF
--- a/src/backend/compare/html/stats-row-across-exes.html
+++ b/src/backend/compare/html/stats-row-across-exes.html
@@ -41,7 +41,7 @@ const commonStart = h.commonStringStart(it.exes.map((e) => e.exeName));
   itOut = new h.PerIterationOutput('', '<br>');
   for (const e of it.exes) {
   %}{%- itOut.next()
-  %}{%= medianFmtFn(e.criteria[i].median) %}
+  %}{%= (!e.criteria[i]) ? '' : medianFmtFn(e.criteria[i].median) %}
 {% }
 %}</span></td>
 <td>
@@ -49,7 +49,7 @@ const commonStart = h.commonStringStart(it.exes.map((e) => e.exeName));
   itOut = new h.PerIterationOutput('', '<br>');
   for (const e of it.exes) {
   %}{%- itOut.next()
-  %}<span class="stats-change{%= cssClassForTotal %}" title="diff %">{%= changeFmtFn(e.criteria[i].change_m) %}</span>
+  %}<span class="stats-change{%= cssClassForTotal %}" title="diff %">{%= (!e.criteria[i]) ? '' : changeFmtFn(e.criteria[i].change_m) %}</span>
 {% }
 %}</td>{%
   } %}

--- a/src/backend/compare/html/stats-row-across-versions.html
+++ b/src/backend/compare/html/stats-row-across-versions.html
@@ -6,7 +6,9 @@ const s = it.stats;
 {% for (const i of it.criteriaOrder) {
     const cssClassForTotal = i === 'total' ? ' stats-total' : '';
     let median;
-    if (i === 'total') {
+    if (!s[i]) {
+      median = '';
+    } else if (i === 'total') {
       median = f.r2(s[i].median);
     } else {
       switch (it.criteria[i].unit) {
@@ -19,7 +21,7 @@ const s = it.stats;
       }
     }
 
-    const change = f.per(s[i].change_m);
+    const change = (!s[i]) ? '' : f.per(s[i].change_m);
 %}
 <td><span class="stats-median" title="median">{%= median %}</span></td>
 <td><span class="stats-change{%= cssClassForTotal %}" title="diff %">{%= change %}</span></td>{%

--- a/src/backend/compare/prep-data.ts
+++ b/src/backend/compare/prep-data.ts
@@ -796,14 +796,8 @@ export async function calculateAcrossExesStatsForBenchmark(
   const exes = new Set<string>();
   for (const result of results) {
     exes.add(result.exe);
-
     // make sure we have the expected structure
     assertBasicPropertiesOfSortedMeasurements(result, 0, 1);
-    assert(
-      result.measurements.length === results[0].measurements.length,
-      'For the rest of this code to work, ' +
-        'we assume that all results have the same shape, i.e., set of criteria.'
-    );
   }
 
   const exesArr = [...exes];
@@ -822,13 +816,17 @@ export async function calculateAcrossExesStatsForBenchmark(
     const values: number[][] = [];
 
     for (const result of results) {
-      assert(
-        result.measurements[i + changeOffset].criterion.name === criterion,
-        'We expect the same criteria to be at the same index'
-      );
-      const sorted = result.measurements[i + changeOffset].values.flat();
-      sorted.sort((a, b) => a - b);
-      values.push(sorted);
+      if (
+        result.measurements &&
+        result.measurements[i + changeOffset] &&
+        result.measurements[i + changeOffset].criterion.name === criterion
+      ) {
+        const sorted = result.measurements[i + changeOffset].values.flat();
+        sorted.sort((a, b) => a - b);
+        values.push(sorted);
+      } else {
+        values.push([0]);
+      }
     }
 
     const stats = calculateChangeStatisticsForFirstAsBaseline(values);

--- a/src/shared/stats.ts
+++ b/src/shared/stats.ts
@@ -408,12 +408,6 @@ export function calculateChangeStatisticsForFirstAsBaseline(
   sorted: number[][]
 ): ComparisonStatistics[] {
   for (const series of sorted) {
-    if (series.length !== sorted[0].length) {
-      throw new Error(
-        `All arrays must have the same length, but ` +
-          `base has ${sorted[0].length}, while another has ${series.length}.`
-      );
-    }
     if (!isSorted(series)) {
       throw new Error('Input arrays must be sorted.');
     }

--- a/tests/shared/stats.test.ts
+++ b/tests/shared/stats.test.ts
@@ -355,16 +355,19 @@ describe('calculateChangeStatisticsForFirstAsBaseline()', () => {
     expect(stats[1].change_m).toEqual(0);
   });
 
-  it('should given an error when base and change have different length', () => {
-    expect(() => {
-      calculateChangeStatisticsForFirstAsBaseline([
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-      ]);
-    }).toThrow(
-      `All arrays must have the same length, ` +
-        `but base has 10, while another has 11.`
-    );
+  it('should give results when base and change have different length', () => {
+    const stats = calculateChangeStatisticsForFirstAsBaseline([
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    ]);
+
+    expect(stats[0].samples).toEqual(10);
+    expect(stats[0].median).toEqual(4.5);
+    expect(stats[0].change_m).toEqual(0);
+
+    expect(stats[1].samples).toEqual(11);
+    expect(stats[1].median).toEqual(5);
+    expect(stats[1].change_m).toEqual(0.11111111111111116);
   });
 
   it('should error on unordered data', () => {


### PR DESCRIPTION
This makes the new comparison view a bit more robust to odd data sets.

Specifically, it enables to render:
http://localhost:33333/CSOM/compare-new/19976d337bfa93eb337d9e039c2bc0dac206b76e..e85807751395941ae09f659a4580fe9599cc0029

The displayed results are not ideal, but given the odd data set, it’s better to render at least something instead of just fail with some assertion and an internal server error.