### PR TITLE
Add overview table for missing data

### DIFF
--- a/src/backend/compare/html/index.html
+++ b/src/backend/compare/html/index.html
@@ -61,14 +61,6 @@
 </div>
 {% } %}
 
-{% if (it.noData) { %}
-<div class="compare">
-  <h3>Issue with Unexpected Data</h3>
-  <p>The data provided for baseline and change does not seem to have a common benchmarks/executors.</p>
-  <p>This is known to happen for instance, when benchmarks or parameters are changed, or executors renamed.</p>
-</div>
-{% } %}
-
 {% if (it.revisionFound) { %}
 <div id="version-details" class="compare">
   <h2>Version Details</h2>

--- a/src/backend/compare/html/index.html
+++ b/src/backend/compare/html/index.html
@@ -112,10 +112,34 @@
 
 {% if (it.notInBoth) { %}
 <h3>Changes in Benchmark Set</h3>
- TODO
- show table with
-  commitid, exe, suite, bench, varvalue, cores, inputsize, extraargs
-
+<table class="table table-sm">
+<thead>
+<tr>
+  <th scope="col">Commit</th>
+  <th scope="col">Executor</th>
+  <th scope="col">Suite</th>
+  <th scope="col">Benchmark</th>
+  <th scope="col">Variable Values</th>
+  <th scope="col">Cores</th>
+  <th scope="col">Input Size</th>
+  <th scope="col">Extra Arguments</th>
+</tr>
+</thead>
+<tbody>
+{% for (const m of it.stats.acrossVersions.missing) { %}
+  <tr>
+    <td>{%= m.commitId.substring(0, 6) %}</td>
+    <td>{%= m.e %}</td>
+    <td>{%= m.s %}</td>
+    <td>{%= m.b %}</td>
+    <td>{%= m.v %}</td>
+    <td>{%= m.c %}</td>
+    <td>{%= m.i %}</td>
+    <td>{%= m.ea %}</td>
+  </tr>
+{% } %}
+</tbody>
+</table>
 {% } %}
 
 {%- include('compare-versions.html', {...it.stats, config: it.config}) %}

--- a/src/backend/compare/prep-data.ts
+++ b/src/backend/compare/prep-data.ts
@@ -1089,7 +1089,6 @@ export async function prepareCompareView(
     navigation,
     hasExeComparison: navigation.navExeComparison.suites.length > 0,
 
-    noData: false, // TODO: need to derive this from one of the stats details
     notInBoth: allStats.acrossVersions.missing.length > 0,
 
     stats: { ...allStats, environments },

--- a/src/backend/compare/prep-data.ts
+++ b/src/backend/compare/prep-data.ts
@@ -26,7 +26,8 @@ import {
   CompareNavPartial,
   CompareStatsRow,
   CompareStatsTable,
-  CompareViewWithData
+  CompareViewWithData,
+  MissingBenchmark
 } from '../../shared/view-types.js';
 import {
   calculateInlinePlotHeight,
@@ -632,8 +633,14 @@ export async function calculateAllChangeStatisticsAndInlinePlots(
   criteria: Map<string, ComparisonStatsWithUnit> | null = null,
   outputFolder: string | null = null,
   plotName: string | null = null
-): Promise<{ numRunConfigs: number; comparisonData: ByExeSuiteComparison }> {
+): Promise<{
+  numRunConfigs: number;
+  comparisonData: ByExeSuiteComparison;
+  missing: MissingBenchmark[];
+}> {
   const comparisonData = new Map<string, Map<string, CompareStatsTable>>();
+  const missing: MissingBenchmark[] = [];
+
   // those two counts are likely always the same,
   // but for the moment, I'll keep them separate
   let lastPlotId = 0;
@@ -663,6 +670,16 @@ export async function calculateAllChangeStatisticsAndInlinePlots(
           plotName
         );
 
+        for (const row of result.stats) {
+          if (row.missing) {
+            for (const m of row.missing) {
+              if (m.criterion.name === 'total') {
+                missing.push({ ...row.benchId, ...m });
+              }
+            }
+          }
+        }
+
         lastPlotId = result.lastPlotId;
         numRunConfigs += result.numRunConfigs;
 
@@ -672,7 +689,7 @@ export async function calculateAllChangeStatisticsAndInlinePlots(
       bySuiteCompare.set(suite, byBenchmark);
     }
   }
-  return { numRunConfigs, comparisonData };
+  return { numRunConfigs, comparisonData, missing };
 }
 
 /**
@@ -1073,7 +1090,7 @@ export async function prepareCompareView(
     hasExeComparison: navigation.navExeComparison.suites.length > 0,
 
     noData: false, // TODO: need to derive this from one of the stats details
-    notInBoth: null, // TODO: need to get this out of the stats calculations
+    notInBoth: allStats.acrossVersions.missing.length > 0,
 
     stats: { ...allStats, environments },
     config: {
@@ -1140,7 +1157,7 @@ export async function calculateAllStatisticsAndRenderPlots(
   const criteriaAcrossVersions = new Map<string, ComparisonStatsWithUnit>();
   const criteriaAcrossExes = new Map<string, ComparisonStatsWithUnit>();
 
-  const { numRunConfigs, comparisonData } =
+  const { numRunConfigs, comparisonData, missing } =
     await calculateAllChangeStatisticsAndInlinePlots(
       byExeSuiteBench,
       hasProfiles,
@@ -1184,7 +1201,8 @@ export async function calculateAllStatisticsAndRenderPlots(
         overviewPngUrl: files.png,
         overviewSvgUrls: files.svg
       },
-      allMeasurements: comparisonData
+      allMeasurements: comparisonData,
+      missing
     },
     acrossExes
   };

--- a/src/shared/view-types.ts
+++ b/src/shared/view-types.ts
@@ -210,7 +210,6 @@ export interface CompareViewWithoutData extends CompareViewBasics {
 export interface CompareViewWithData extends CompareViewBasics {
   revisionFound: true;
 
-  noData: boolean;
   notInBoth: boolean;
 
   base: RevisionData;

--- a/src/shared/view-types.ts
+++ b/src/shared/view-types.ts
@@ -104,6 +104,8 @@ export interface MissingData {
   criterion: CriterionData;
 }
 
+export type MissingBenchmark = BenchmarkId & MissingData;
+
 export interface CompareStatsRow {
   benchId: BenchmarkId;
   details: RunDetails;
@@ -164,6 +166,7 @@ export interface AllStats {
   acrossVersions: {
     summary: StatsSummary;
     allMeasurements: ByExeSuiteComparison;
+    missing: MissingBenchmark[];
   };
   acrossExes: BySuiteComparison;
 }
@@ -208,7 +211,7 @@ export interface CompareViewWithData extends CompareViewBasics {
   revisionFound: true;
 
   noData: boolean;
-  notInBoth: any; // TODO
+  notInBoth: boolean;
 
   base: RevisionData;
   change: RevisionData;

--- a/tests/backend/compare/compare-view.test.ts
+++ b/tests/backend/compare/compare-view.test.ts
@@ -456,7 +456,8 @@ describe('Compare View Parts', () => {
       const data: CompareVersionsPartial = {
         acrossVersions: {
           allMeasurements: new Map(),
-          summary: <any>{}
+          summary: <any>{},
+          missing: []
         },
         acrossExes: new Map(),
         environments,

--- a/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
@@ -77,8 +77,6 @@
 
 
 
-
-
 <div id="version-details" class="compare">
   <h2>Version Details</h2>
   <dl class="row">

--- a/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
@@ -77,8 +77,6 @@
 
 
 
-
-
 <div id="version-details" class="compare">
   <h2>Version Details</h2>
   <dl class="row">


### PR DESCRIPTION
This adds the overview table for missing data, which we had in the old comparison view.

The PR also removes the case from the template that a message was shown that there's no comparable data. The tables seem more informative, so, I'll stick with that for the moment.

This resolves #147.