### PR TITLE
Use Docker Compose and add test that the server comes up

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**/node_modules
+/dist
+/resources
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,15 @@ name: CI
 on: [push, pull_request]
 
 env:
-  RDB_DB:   postgres
+  RDB_DB: postgres
   RDB_USER: postgres
   RDB_PASS: postgres
-  DEBUG:    true
-  DB_HOST:  localhost
-  DB_PORT:  5432  # defined below in the services.postgres.ports (the first one)
-  LANG:     en_US.UTF-8
+  DEBUG: true
+  DB_HOST: localhost
+  DB_PORT: 5432 # defined below in the services.postgres.ports (the first one)
+  LANG: en_US.UTF-8
   LANGUAGE: en_US.UTF-8
-  LC_ALL:   en_US.UTF-8
+  LC_ALL: en_US.UTF-8
 
 jobs:
   build-and-test:
@@ -36,24 +36,24 @@ jobs:
 
     steps:
       - name: Checkout ReBench
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '19'
 
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
-         cache-name: node-modules
+          cache-name: node-modules
         with:
-         # npm cache files are stored in `~/.npm` on Linux/macOS
-         path: ~/.npm
-         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('package.json', 'package-lock.json') }}
-         restore-keys: |
-           ${{ runner.os }}-${{ env.cache-name }}-
-           ${{ runner.os }}-
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('package.json', 'package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
 
       - name: NPM CI
         run: |
@@ -62,7 +62,7 @@ jobs:
       - name: Run Tests
         run: |
           npm test
-      
+
       - name: Upload image difference, if there are any
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -12,13 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+      - name: Checkout ReBench
+        uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build
-        uses: docker/build-push-action@v3
-        with:
-          push: false
+      - name: Build and Test Docker Image and Composition
+        run: |
+          docker compose -f ./docker-compose.yml up --detach
+          curl --retry 5 --retry-delay 5 --retry-all-errors http://localhost:33333/status
+          docker compose -f ./docker-compose.yml down

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      - docker**
+      - compose**
 
 jobs:
   docker:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,13 @@ build-and-benchmark:
   stage: build-and-benchmark
   tags: [yuria2]
   script:
-    - podman build . -f Dockerfile -t rebenchdb
+    - podman build . -f Dockerfile -t rebenchdb-app
     - podman build . -f Dockerfile.rebench -t bench-rdb
-    - podman run --hostname yuria2-podman bench-rdb:latest -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf
+    - podman run --hostname postgres -e POSTGRES_USER=docker -e POSTGRES_PASSWORD=docker -e POSTGRES_DB=rebenchdb --cidfile=postgres.pid --publish=5432:5432 --detach postgres:16-alpine
+    - sleep 5
+    - podman run --network=host bench-rdb:latest -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf
+  after_script:
+    - POSTGRES_PID=$(cat postgres.pid)
+    - podman stop $POSTGRES_PID
+    - podman rm $POSTGRES_PID
+    - rm postgres.pid

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
-FROM postgres:16-bookworm
+FROM node:21-bookworm
 # this allows the setup to ignore all of the ubuntu OS setup
 # thats not needed for this docker image (Time Zone for example)
 ARG DEBIAN_FRONTEND=noninteractive
 
 # tools needed for docker setup
-RUN apt-get update && apt-get install -y apt-utils curl bash sudo
+RUN apt-get update && apt-get install -y apt-utils bash sudo
 
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-# Add Node.js repo
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-
 # Node.js, PostgreSQL, headers for R packages
 RUN apt-get update && apt-get install -y \
-    build-essential nodejs unzip \
+    build-essential unzip \
     libfontconfig1-dev \
     libpq-dev
 
@@ -26,26 +23,7 @@ WORKDIR /project/
 
 RUN SKIP_COMPILE=true npm ci --ignore-scripts=false --foreground-scripts
 
-ENV POSTGRES_PASSWORD=docker
-ENV POSTGRES_USER=docker
-
-# Basic Configuration
-ENV RDB_USER=docker
-ENV RDB_PASS=docker
-ENV RDB_DB=docker
-ENV REFRESH_SECRET=refresh
-
-# open TCP/Project port
-EXPOSE 33333
-
-# Generate Script to start the image
-RUN echo 'echo Starting ReBenchDB\n\
-docker-entrypoint.sh postgres &\n\
-DEV=true npm run start' > ./start-server.sh
-
 # all of the project files will be copyed to a new dir called project
 COPY . /project
 
 RUN npm run compile
-
-CMD ["bash", "./start-server.sh" ]

--- a/Dockerfile.rebench
+++ b/Dockerfile.rebench
@@ -1,14 +1,10 @@
 # Used for benchmarking
-FROM rebenchdb:latest
+FROM rebenchdb-app:latest
 
 RUN apt-get install -y git python3-pip
 RUN pip install --break-system-packages git+https://github.com/smarr/ReBench.git
 
-RUN echo 'echo Starting PostgreSQL Server\n\
-docker-entrypoint.sh postgres &\n\
-rebench "$@"' > ./start-server-and-rebench.sh
-
 RUN npm run pretest
 
-ENTRYPOINT ["bash", "./start-server-and-rebench.sh"]
+ENTRYPOINT ["rebench"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ ReBenchDB isn't
 - a statistics library:
   We currently use R for our statistic needs, but anything outputting HTML would be suitable.
 
+## Docker/Podman Setup
+
+The repository contains a `Dockerfile` and a `docker-compose.yml`, which will
+install all dependencies and setup the required PostgreSQL database.
+
+With Docker, this should be usable with:
+
+```bash
+docker compose -f ./docker-compose.yml up
+```
+
+For Podman users, podman-compose is needed:
+
+```bash
+pip3 install podman-compose  # if not already available
+podman-compose up
+```
+
 ## Installation and Usage
 
 <a id="install"></a>

--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ ReBenchDB is designed to
 
 ### Features
 
- - compare performance between specific commits
-   - show aggregated results on an overview plot
-   - give summary statistics
-   - show per-benchmark details
-     - a plot that allows to judge noise
-     - a plot with per-iteration data
-     - a plot of previous results
-     - various metrics and the command line
-     - profiling information
-   - compare performance across different executors
- - per-project timeline view
- - per-project data inventory and data export
+- compare performance between specific commits
+  - show aggregated results on an overview plot
+  - give summary statistics
+  - show per-benchmark details
+    - a plot that allows to judge noise
+    - a plot with per-iteration data
+    - a plot of previous results
+    - various metrics and the command line
+    - profiling information
+  - compare performance across different executors
+- per-project timeline view
+- per-project data inventory and data export
 
 ## Non-Goals
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       RDB_USER: docker
       RDB_PASS: docker
       RDB_DB: rebenchdb
+      RDB_PORT: 5432
       REFRESH_SECRET: refresh
     depends_on:
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+services:
+  rebenchdb-app:
+    build: .
+    image: rebenchdb-app
+    command: npm run start
+    expose:
+      - 33333
+    environment:
+      RDB_HOST: postgres
+      RDB_USER: docker
+      RDB_PASS: docker
+      RDB_DB: rebenchdb
+      REFRESH_SECRET: refresh
+    depends_on:
+      - postgres
+    ports:
+      - '33333:33333'
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: docker
+      POSTGRES_PASSWORD: docker
+      POSTGRES_DB: rebenchdb
+      DEV: true
+    ports:
+      - '5432:5432'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       RDB_DB: rebenchdb
       RDB_PORT: 5432
       REFRESH_SECRET: refresh
+      DEV: true
     depends_on:
       - postgres
     ports:
@@ -25,6 +26,5 @@ services:
       POSTGRES_USER: docker
       POSTGRES_PASSWORD: docker
       POSTGRES_DB: rebenchdb
-      DEV: true
     ports:
       - '5432:5432'

--- a/rebench.conf
+++ b/rebench.conf
@@ -47,12 +47,12 @@ benchmark_suites:
 
 executors:
     benchmarks:
-        executable: /usr/bin/node
+        executable: /usr/local/bin/node
         env:
             RDB_USER: docker
             RDB_PASS: docker
             RDB_HOST: localhost
-            RDB_DB:   docker
+            RDB_DB:   rebenchdb
 
 # define the benchmarks to be executed for a re-executable benchmark run
 experiments:

--- a/src/backend/util.ts
+++ b/src/backend/util.ts
@@ -45,12 +45,16 @@ export const robustSrcPath = __dirname.includes('dist/')
       return `${__dirname}/../../dist/src/${path}`;
     };
 
+const port: number = process.env.RDB_PORT
+  ? parseInt(process.env.RDB_PORT)
+  : 5432;
+
 export const dbConfig = {
   user: process.env.RDB_USER || '',
   password: process.env.RDB_PASS || '',
   host: process.env.RDB_HOST || 'localhost',
   database: process.env.RDB_DB || 'rdb_smde2',
-  port: 5432
+  port
 };
 
 export const refreshSecret =

--- a/src/benchmarks/harness.ts
+++ b/src/benchmarks/harness.ts
@@ -19,7 +19,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import type { Benchmark } from './benchmark';
+import { reportConnectionRefused } from '../shared/errors.js';
+import type { Benchmark } from './benchmark.js';
 
 class IncorrectResultError extends Error {
   constructor() {
@@ -102,6 +103,10 @@ class Run {
     try {
       await benchmark.oneTimeSetup(this.problemSize);
       await this.doRuns(benchmark);
+    } catch (e: any) {
+      if (e.code == 'ECONNREFUSED') {
+        reportConnectionRefused(e);
+      }
     } finally {
       await benchmark.oneTimeTeardown();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,15 @@ export const db = new DatabaseWithPool(
 router.get('/', async (ctx) => {
   return renderMainPage(ctx, db);
 });
+
+router.get('/status', async (ctx) => {
+  ctx.body = `# ReBenchDB Status
+
+- version ${rebenchVersion}
+`;
+  ctx.type = 'text';
+});
+
 router.get('/:projectSlug', async (ctx) => renderProjectPage(ctx, db));
 router.get('/:projectSlug/source/:sourceId', async (ctx) =>
   getSourceAsJson(ctx, db)
@@ -138,14 +147,6 @@ if (DEV) {
     serveReport
   );
 }
-
-router.get('/status', async (ctx) => {
-  ctx.body = `# ReBenchDB Status
-
-- version ${rebenchVersion}
-`;
-  ctx.type = 'text';
-});
 
 // curl -X PUT -H "Content-Type: application/json" -d '{"foo":"bar","baz":3}'
 //  http://localhost:33333/rebenchdb/results

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import { getAvailableDataAsJson } from './backend/project/data-export.js';
 import { submitTimelineUpdateJobs } from './backend/admin/operations.js';
 import { acceptResultData } from './backend/rebench/results.js';
 import { setTimeout } from 'node:timers/promises';
+import { reportConnectionRefused } from './shared/errors.js';
 
 log.info('Starting ReBenchDB Version ' + rebenchVersion);
 
@@ -195,26 +196,3 @@ async function tryToConnect(n: number): Promise<boolean> {
   log.info(`Starting server on http://localhost:${siteConfig.port}`);
   app.listen(siteConfig.port);
 })();
-
-function reportConnectionRefused(e: any) {
-  if (e.errors && e.errors.length > 0) {
-    for (const currentE of e.errors) {
-      if (currentE.code == 'ECONNREFUSED' && currentE.port) {
-        log.error(
-          `Unable to connect to database on port ` +
-            `${currentE.address}:${currentE.port}.\n`
-        );
-      }
-    }
-    log.error(
-      'Connection refused.\n' +
-        'ReBenchDB requires a Postgres database to work.'
-    );
-  } else {
-    log.error(
-      `Unable to connect to database on port ${e.address}:${e.port}.\n` +
-        'Connection refused.\n' +
-        'ReBenchDB requires a Postgres database to work.'
-    );
-  }
-}

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -1,0 +1,24 @@
+import { log } from '../backend/logging.js';
+
+export function reportConnectionRefused(e: any): void {
+  if (e.errors && e.errors.length > 0) {
+    for (const currentE of e.errors) {
+      if (currentE.code == 'ECONNREFUSED' && currentE.port) {
+        log.error(
+          `Unable to connect to database on port ` +
+            `${currentE.address}:${currentE.port}.\n`
+        );
+      }
+    }
+    log.error(
+      'Connection refused.\n' +
+        'ReBenchDB requires a Postgres database to work.'
+    );
+  } else {
+    log.error(
+      `Unable to connect to database on port ${e.address}:${e.port}.\n` +
+        'Connection refused.\n' +
+        'ReBenchDB requires a Postgres database to work.'
+    );
+  }
+}


### PR DESCRIPTION
This PR changes how the docker-based setup works.

Instead of starting the PostgreSQL server and the Node.js server in the same container, docker-compose.yml defines both as separate containers.

This should improve the ability to use standard docker tooling and container management, and hopefully also avoid issues with the system not starting up properly.

The PR also adds code to wait for Postgres to come up properly, and retry connecting to it.


With Docker, this should be usable with:

```bash
docker compose -f ./docker-compose.yml up
```

For Podman users, podman-compose is needed:

```bash
pip3 install podman-compose  # if not already available
podman-compose up
```

The GitLab CI setup for benchmarking is not using podman-compose, and instead manually starts both containers. Unfortunately, podman-compose is not as full feature as needed. It doesn't fully support its `--abort-on-container-exit`/`--exit-code-from`, and dealing with environment variables is problematic, too. 