### PR TITLE
Fix startup after Denormalizing Run table in #178, and make shared libraries available to frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "compile-uplot": "terser --module --ecma 2018 --compress --mangle -o ./resources/uPlot.esm.min.js -- node_modules/uplot/dist/uPlot.esm.js",
     "compile": "tsc",
     "postcompile": "npm run prep-static && npm run download-font",
-    "prep-static": "cp dist/src/frontend/*.js ./resources/",
+    "prep-static": "cp dist/src/frontend/*.js dist/src/shared/*.js ./resources/",
     "download-font": "node dist/src/download.js https://github.com/googlefonts/roboto/releases/download/v2.136/roboto-hinted.zip tmp/roboto-hinted.zip && unzip -o -d dist tmp/roboto-hinted.zip",
     "start": "node --enable-source-maps --experimental-json-modules ./dist/src/index.js",
     "nodemon": "DEV=true nodemon --enable-source-maps --experimental-json-modules ./dist/src/index.js --watch ./dist/src --watch ./package.json --watch ./src --ext js,json,html",

--- a/src/backend/db/db.ts
+++ b/src/backend/db/db.ts
@@ -166,7 +166,7 @@ export abstract class Database {
       name: 'doTableExist',
       text: `SELECT *
                 FROM   information_schema.tables
-                WHERE  table_name = 'executor'`
+                WHERE  table_name = 'run'`
     });
     return result.rowCount === null || result.rowCount <= 0;
   }


### PR DESCRIPTION
The `needsTables()` was overlooked, and tried to see whether the `Executor` table is there, which is gone since #178, so, it's better to check for the `Run` table instead.

In production, I also had a fix that was not yet in the code base, to copy the shared libraries to the resources folder so that they are available to the browser/user.