### PR TITLE
Attempt to reduce unnecessary accesses to data files

### DIFF
--- a/src/frontend/render.ts
+++ b/src/frontend/render.ts
@@ -73,9 +73,8 @@ export function renderProjectDataOverview(
         )}</p></td>
         <td>${row.hostnames}</td>
         <td class="num-col">${row.runs}</td>
-        <td class="num-col"><a href="/${projectSlug}/data/${row.expid}">${
-          row.measurements
-        }</a></td>
+        <td class="num-col"><a rel="nofollow"
+          href="/${projectSlug}/data/${row.expid}">${row.measurements}</a></td>
       </tr>`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,9 +93,18 @@ router.get('/:projectSlug/source/:sourceId', async (ctx) =>
 );
 router.get('/:projectSlug/timeline', async (ctx) => renderTimeline(ctx, db));
 router.get('/:projectSlug/data', async (ctx) => renderProjectDataPage(ctx, db));
-router.get('/:projectSlug/data/:expId', async (ctx) =>
-  renderDataExport(ctx, db)
-);
+router.get('/:projectSlug/data/:expId', async (ctx) => {
+  if (
+    ctx.header['X-Purpose'] === 'preview' ||
+    ctx.header['Purpose'] === 'prefetch' ||
+    ctx.header['X-Moz'] === 'prefetch'
+  ) {
+    ctx.set('Cache-Control', 'must-revalidate');
+    ctx.status = 425; // HTTP Code for 'Too Early'
+    return;
+  }
+  return renderDataExport(ctx, db);
+});
 router.get('/:projectSlug/compare/:baseline..:change', async (ctx) =>
   renderComparePage(ctx, db)
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,16 @@ router.get('/status', async (ctx) => {
   ctx.type = 'text';
 });
 
+router.get('/robots.txt', async (ctx) => {
+  ctx.body = `User-agent: *
+
+Disallow: /status
+Disallow: /*/data*
+Disallow: /rebenchdb*
+`;
+  ctx.type = 'text';
+});
+
 router.get('/:projectSlug', async (ctx) => renderProjectPage(ctx, db));
 router.get('/:projectSlug/source/:sourceId', async (ctx) =>
   getSourceAsJson(ctx, db)


### PR DESCRIPTION
Looks like rebench.dev is caching a lot of raw data files.
Though, they should only ever be generated when someone actually requested them.
So, it's not clear to me why this happens.

This PR adds three things to hopefully minimize this unnecessary load on the server:
 - mark links to data files as `nofollow`
 - add the `data` URLs to the disallowed URLs in robots.txt
 - ignore browser requests that indicate they are prefetch attempts