### PR TITLE
Remove unused Unit table

### DIFF
--- a/src/backend/db/db.sql
+++ b/src/backend/db/db.sql
@@ -22,13 +22,6 @@ CREATE TABLE Environment (
   note text
 );
 
--- The unit of a measure.
-CREATE TABLE Unit (
-  name varchar primary key,
-  description text,
-  lessIsBetter boolean
-);
-
 -- A specific criterion that is measured for a benchmark.
 -- This can be anything, from total time over memory consumption
 -- to other things or parts worth measuring.
@@ -37,8 +30,7 @@ CREATE TABLE Criterion (
   name varchar,
   unit varchar,
 
-  unique (name, unit),
-  foreign key (unit) references Unit (name)
+  unique (name, unit)
 );
 
 -- Groups all the data that belongs together.

--- a/src/backend/db/db.ts
+++ b/src/backend/db/db.ts
@@ -828,21 +828,6 @@ export abstract class Database {
     return exp;
   }
 
-  private async recordUnit(unitName: string) {
-    const result = await this.query({
-      name: 'fetchUnitByName',
-      text: 'SELECT * from Unit WHERE name = $1',
-      values: [unitName]
-    });
-    if (result.rowCount === 0) {
-      await this.query({
-        name: 'insertUnit',
-        text: 'INSERT INTO Unit (name) VALUES ($1)',
-        values: [unitName]
-      });
-    }
-  }
-
   public async recordCriterion(c: ApiCriterion): Promise<Criterion> {
     const cacheKey = `${c.c}::${c.u}`;
 
@@ -850,7 +835,6 @@ export abstract class Database {
       return <Criterion>this.criteria.get(cacheKey);
     }
 
-    await this.recordUnit(c.u);
     return this.recordCached(
       this.criteria,
       cacheKey,


### PR DESCRIPTION
In a similar spirit as #178, this PR removes the `Unit` table.
It was intended to store some metadata for units, like sorting direction, but this hasn't been used so far, and might belong better into the `Criterion` if we ever need it.

So, this PR removes it for now.