### PR TITLE
Use JOIN ... USING instead of JOIN ... ON

### DIFF
--- a/src/backend/compare/compare.ts
+++ b/src/backend/compare/compare.ts
@@ -45,7 +45,7 @@ async function getProfile(
             invocation, numIterations, warmup, value as profile
           FROM ProfileData
             JOIN Trial ON trialId = Trial.id
-            JOIN Source ON source.id = trial.sourceId
+            JOIN Source USING (sourceId)
             JOIN Run ON runId = run.id
           WHERE runId = $1 AND source.commitId = $2`,
     values: [runId, commitId]
@@ -99,7 +99,7 @@ async function getMeasurements(
             FROM
               Measurement
               JOIN Trial ON trialId = Trial.id
-              JOIN Source ON source.id = trial.sourceId
+              JOIN Source USING (sourceId)
               JOIN Experiment ON Trial.expId = Experiment.id
               JOIN Criterion ON criterion = criterion.id
               JOIN Run ON runId = run.id

--- a/src/backend/compare/compare.ts
+++ b/src/backend/compare/compare.ts
@@ -100,7 +100,7 @@ async function getMeasurements(
               Measurement
               JOIN Trial ON trialId = Trial.id
               JOIN Source USING (sourceId)
-              JOIN Experiment ON Trial.expId = Experiment.id
+              JOIN Experiment USING (expId)
               JOIN Criterion ON criterion = criterion.id
               JOIN Run ON runId = run.id
               JOIN Project ON Project.id = Experiment.projectId

--- a/src/backend/db/db.sql
+++ b/src/backend/db/db.sql
@@ -36,7 +36,7 @@ CREATE TABLE Criterion (
 -- Groups all the data that belongs together.
 -- ReBenchDB is meant to keep data for multiple experiments.
 CREATE TABLE Project (
-  id serial primary key,
+  projectId serial primary key,
   name varchar unique,
   slug varchar unique,
   description text,
@@ -80,7 +80,7 @@ CREATE TABLE Experiment (
 
   unique (projectId, name),
 
-  foreign key (projectId) references Project (id)
+  foreign key (projectId) references Project (projectId)
 );
 
 -- Is part of an experiment, and consists of measurements.

--- a/src/backend/db/db.sql
+++ b/src/backend/db/db.sql
@@ -55,7 +55,7 @@ CREATE TABLE Project (
 -- Identifies the specific state of the source, the code, on which
 -- an experiment and its measurements are based.
 CREATE TABLE Source (
-  id serial primary key,
+  sourceId serial primary key,
   repoURL varchar,
   branchOrTag varchar,
   commitId varchar unique,
@@ -113,7 +113,7 @@ CREATE TABLE Trial (
 
   foreign key (expId) references Experiment (id),
   foreign key (envId) references Environment (envId),
-  foreign key (sourceId) references Source (id)
+  foreign key (sourceId) references Source (sourceId)
 );
 
 -- Documents the software versions used by a specific environment.

--- a/src/backend/db/db.sql
+++ b/src/backend/db/db.sql
@@ -71,7 +71,7 @@ CREATE TABLE Source (
 -- To identify experiments, we use a name.
 -- Optionally, a more elaborated description can be provided for documentation.
 CREATE TABLE Experiment (
-  id serial primary key,
+  expId serial primary key,
 
   name varchar NOT NULL,
   projectId smallint,
@@ -111,7 +111,7 @@ CREATE TABLE Trial (
   -- functionally dependent on startTime in the intended scenarios.
   unique (username, envId, expId, startTime),
 
-  foreign key (expId) references Experiment (id),
+  foreign key (expId) references Experiment (expId),
   foreign key (envId) references Environment (envId),
   foreign key (sourceId) references Source (sourceId)
 );

--- a/src/backend/db/db.sql
+++ b/src/backend/db/db.sql
@@ -1,7 +1,7 @@
 -- A specific software version, possibly used by multiple environments
 -- or versions of environments.
 CREATE TABLE SoftwareVersionInfo (
-  id serial primary key,
+  softId serial primary key,
   name varchar,
   version varchar,
   unique (name, version)
@@ -10,7 +10,7 @@ CREATE TABLE SoftwareVersionInfo (
 -- Identifies the specific state of an environment, including
 -- the relevant software versions.
 CREATE TABLE Environment (
-  id serial primary key,
+  envId serial primary key,
   hostname varchar unique,
   osType varchar,
   -- total number of bytes of memory provided by the system
@@ -26,7 +26,7 @@ CREATE TABLE Environment (
 -- This can be anything, from total time over memory consumption
 -- to other things or parts worth measuring.
 CREATE TABLE Criterion (
-  id serial primary key,
+  critId serial primary key,
   name varchar,
   unit varchar,
 
@@ -112,7 +112,7 @@ CREATE TABLE Trial (
   unique (username, envId, expId, startTime),
 
   foreign key (expId) references Experiment (id),
-  foreign key (envId) references Environment (id),
+  foreign key (envId) references Environment (envId),
   foreign key (sourceId) references Source (id)
 );
 
@@ -122,8 +122,8 @@ CREATE TABLE SoftwareUse (
   softId smallint,
   primary key (envId, softId),
 
-  foreign key (envId) references Environment (id),
-  foreign key (softId) references SoftwareVersionInfo (id)
+  foreign key (envId) references Environment (envId),
+  foreign key (softId) references SoftwareVersionInfo (softId)
 );
 
 -- A concrete execution of a benchmark by a specific executor.
@@ -152,16 +152,16 @@ CREATE TABLE Run (
 CREATE TABLE Measurement (
   runId smallint,
   trialId smallint,
-  criterion smallint,
+  critId smallint,
   invocation smallint,
   iteration smallint,
 
   value float4 NOT NULL,
 
-  primary key (iteration, invocation, runId, trialId, criterion),
+  primary key (iteration, invocation, runId, trialId, critId),
   foreign key (trialId) references Trial (id),
   foreign key (runId) references Run (id),
-  foreign key (criterion) references Criterion (id)
+  foreign key (critId) references Criterion (critId)
 );
 
 CREATE TABLE ProfileData (
@@ -181,7 +181,7 @@ CREATE TABLE ProfileData (
 CREATE TABLE Timeline (
   runId smallint,
   trialId smallint,
-  criterion smallint,
+  critId smallint,
 
   numSamples int,
 
@@ -195,8 +195,8 @@ CREATE TABLE Timeline (
   bci95low float4,
   bci95up  float4,
 
-  primary key (runId, trialId, criterion),
+  primary key (runId, trialId, critId),
   foreign key (trialId) references Trial (id),
   foreign key (runId) references Run (id),
-  foreign key (criterion) references Criterion (id)
+  foreign key (critId) references Criterion (critId)
 );

--- a/src/backend/db/db.ts
+++ b/src/backend/db/db.ts
@@ -763,7 +763,7 @@ export abstract class Database {
     const result = await this.query({
       name: 'fetchEnvForComparison',
       text: `SELECT
-                env.id as id, env.hostname, env.ostype, env.memory,
+                env.envid, env.hostname, env.ostype, env.memory,
                 env.cpu, env.clockspeed, note
              FROM Source src
                 JOIN Trial t         ON t.sourceId = src.id

--- a/src/backend/db/types.ts
+++ b/src/backend/db/types.ts
@@ -56,7 +56,7 @@ export interface Criterion {
 }
 
 export interface Project {
-  id: number;
+  projectid: number;
   name: string;
   slug: string;
   description: string;

--- a/src/backend/db/types.ts
+++ b/src/backend/db/types.ts
@@ -68,7 +68,7 @@ export interface Project {
 }
 
 export interface Source {
-  id: number;
+  sourceid: number;
   repourl: string;
   branchortag: string;
   commitid: string;

--- a/src/backend/db/types.ts
+++ b/src/backend/db/types.ts
@@ -28,13 +28,13 @@ export interface Benchmark {
 }
 
 export interface SoftwareVersionInfo {
-  id: number;
+  softId: number;
   name: string;
   version: string;
 }
 
 export interface Environment {
-  id: number;
+  envid: number;
   hostname: string;
   ostype: string;
   memory: number;
@@ -50,7 +50,7 @@ export interface Unit {
 }
 
 export interface Criterion {
-  id: number;
+  critid: number;
   name: string;
   unit: string;
 }

--- a/src/backend/db/types.ts
+++ b/src/backend/db/types.ts
@@ -80,7 +80,7 @@ export interface Source {
 }
 
 export interface Experiment {
-  id: number;
+  expid: number;
 
   name: string;
   projectid: number;

--- a/src/backend/main/index.html
+++ b/src/backend/main/index.html
@@ -25,7 +25,7 @@
 
   <div id="projects">
     {% for (const p of it.projects) { %}
-    <div class="card project-data" data-id="{%= p.id %}" data-showchanges="{%= p.showchanges %}" data-allresults="{%= p.allresults %}">
+    <div class="card project-data" data-id="{%= p.projectid %}" data-showchanges="{%= p.showchanges %}" data-allresults="{%= p.allresults %}">
       <h5 class="card-header" id="{%= p.slug %}"><a
         href="/{%= p.slug %}/data">{%= p.name %}</a></h5>
       <div class="card-body">
@@ -33,18 +33,18 @@
         <h5>Changes</h5>
         <div class="container min-padding"><div class="row">
           <div class="col-sm min-padding scroll-list">
-            <div class="list-group baseline" id="p{%= p.id %}-baseline"
+            <div class="list-group baseline" id="p{%= p.projectid %}-baseline"
               data-project-slug="{%= p.slug %}"></div>
           </div>
           <div class="col-sm min-padding scroll-list">
-            <div class="list-group change" id="p{%= p.id %}-change"></div>
+            <div class="list-group change" id="p{%= p.projectid %}-change"></div>
           </div>
         </div></div>
 
-        <a class="btn btn-primary" id="p{%= p.id %}-compare">Compare</a>
+        <a class="btn btn-primary" id="p{%= p.projectid %}-compare">Compare</a>
         {% }
            if (p.allresults) { %}
-        <div id="p{%= p.id %}-results" class="timeline-single"></div>
+        <div id="p{%= p.projectid %}-results" class="timeline-single"></div>
         {% } %}
         <a href="/{%= p.slug %}/timeline">Timeline</a>
       </div>

--- a/src/backend/main/main.ts
+++ b/src/backend/main/main.ts
@@ -160,14 +160,14 @@ export async function getChanges(
 ): Promise<{ changes: any[] }> {
   const result = await db.query({
     name: 'fetchAllChangesByProjectId',
-    text: ` SELECT commitId, branchOrTag, projectId, repoURL, commitMessage,
+    text: ` SELECT commitId, branchOrTag, p.projectId, repoURL, commitMessage,
                 max(startTime) as experimentTime
             FROM experiment
             JOIN Trial ON expId = experiment.id
             JOIN Source ON sourceId = source.id
-            JOIN Project ON projectId = project.id
-            WHERE project.id = $1
-            GROUP BY commitId, branchOrTag, projectId, repoURL, commitMessage
+            JOIN Project p USING (projectId)
+            WHERE p.projectId = $1
+            GROUP BY commitId, branchOrTag, p.projectId, repoURL, commitMessage
             ORDER BY max(startTime) DESC`,
     values: [projectId]
   });

--- a/src/backend/main/main.ts
+++ b/src/backend/main/main.ts
@@ -75,7 +75,7 @@ export async function getLast100Measurements(
                       JOIN Trial t ON  m.trialId = t.id
                       JOIN Experiment e ON t.expId = e.id
                       JOIN Run r ON m.runId = r.id
-                      JOIN Criterion c ON m.criterion = c.id
+                      JOIN Criterion c USING (critId)
                     WHERE projectId = $1 AND
                       c.name = '${TotalCriterion}'
                     ORDER BY t.startTime, m.invocation, m.iteration

--- a/src/backend/main/main.ts
+++ b/src/backend/main/main.ts
@@ -164,7 +164,7 @@ export async function getChanges(
                 max(startTime) as experimentTime
             FROM experiment
             JOIN Trial ON expId = experiment.id
-            JOIN Source ON sourceId = source.id
+            JOIN Source USING (sourceId)
             JOIN Project p USING (projectId)
             WHERE p.projectId = $1
             GROUP BY commitId, branchOrTag, p.projectId, repoURL, commitMessage

--- a/src/backend/main/main.ts
+++ b/src/backend/main/main.ts
@@ -73,7 +73,7 @@ export async function getLast100Measurements(
                     )
                     FROM Measurement m
                       JOIN Trial t ON  m.trialId = t.id
-                      JOIN Experiment e ON t.expId = e.id
+                      JOIN Experiment e USING (expId)
                       JOIN Run r ON m.runId = r.id
                       JOIN Criterion c USING (critId)
                     WHERE projectId = $1 AND
@@ -163,8 +163,8 @@ export async function getChanges(
     text: ` SELECT commitId, branchOrTag, p.projectId, repoURL, commitMessage,
                 max(startTime) as experimentTime
             FROM experiment
-            JOIN Trial ON expId = experiment.id
-            JOIN Source USING (sourceId)
+            JOIN Trial     USING (expId)
+            JOIN Source    USING (sourceId)
             JOIN Project p USING (projectId)
             WHERE p.projectId = $1
             GROUP BY commitId, branchOrTag, p.projectId, repoURL, commitMessage

--- a/src/backend/project/data-export.ts
+++ b/src/backend/project/data-export.ts
@@ -92,7 +92,7 @@ export async function getDataOverview(
     name: 'fetchDataOverview',
     text: `
         SELECT
-          exp.id as expId, exp.name, exp.description,
+          exp.expId, exp.name, exp.description,
           min(t.startTime) as minStartTime,
           max(t.endTime) as maxEndTime,
           ARRAY_TO_STRING(ARRAY_AGG(DISTINCT t.username), ', ') as users,
@@ -108,7 +108,7 @@ export async function getDataOverview(
           SUM(tl.numSamples) as measurements,
           count(DISTINCT tl.runId) as runs
         FROM experiment exp
-        JOIN Trial t         ON exp.id = t.expId
+        JOIN Trial t         USING (expId)
         JOIN Source src      USING (sourceId)
         JOIN Environment env USING (envId)
 
@@ -117,7 +117,7 @@ export async function getDataOverview(
 
         WHERE exp.projectId = $1
 
-        GROUP BY exp.name, exp.description, exp.id
+        GROUP BY exp.name, exp.description, exp.expId
         ORDER BY minStartTime DESC;`,
     values: [projectId]
   });

--- a/src/backend/project/data-export.ts
+++ b/src/backend/project/data-export.ts
@@ -110,7 +110,7 @@ export async function getDataOverview(
         FROM experiment exp
         JOIN Trial t         ON exp.id = t.expId
         JOIN Source src      ON t.sourceId = src.id
-        JOIN Environment env ON env.id = t.envId
+        JOIN Environment env USING (envId)
 
         --JOIN Measurement m   ON m.trialId = t.id
         JOIN Timeline tl     ON tl.trialId = t.id

--- a/src/backend/project/data-export.ts
+++ b/src/backend/project/data-export.ts
@@ -109,7 +109,7 @@ export async function getDataOverview(
           count(DISTINCT tl.runId) as runs
         FROM experiment exp
         JOIN Trial t         ON exp.id = t.expId
-        JOIN Source src      ON t.sourceId = src.id
+        JOIN Source src      USING (sourceId)
         JOIN Environment env USING (envId)
 
         --JOIN Measurement m   ON m.trialId = t.id

--- a/src/backend/project/project-data.html
+++ b/src/backend/project/project-data.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta id="project-id" value="{%= it.project.id %}">
+  <meta id="project-id" value="{%= it.project.projectid %}">
   <meta id="project-slug" value="{%= it.project.slug %}">
   <title>ReBench: {%= it.project.name %}</title>
   {%- include('header.html') %}

--- a/src/backend/project/project.html
+++ b/src/backend/project/project.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <title>ReBench: {%= it.name %}</title>
-  <meta id="project-id" value="{%= it.id %}">
+  <meta id="project-id" value="{%= it.projectid %}">
   <meta id="project-showchanges" value="{%= it.showchanges%}">
   <meta id="project-allresults" value="{%= it.allresults%}">
   {%- include('header.html') %}
@@ -26,18 +26,18 @@
         <h5>Changes</h5>
         <div class="container min-padding"><div class="row">
           <div class="col-sm min-padding scroll-list">
-            <div class="list-group baseline" id="p{%= it.id %}-baseline"
+            <div class="list-group baseline" id="p{%= it.projectid %}-baseline"
               data-project-slug="{%= it.slug %}"></div>
           </div>
           <div class="col-sm min-padding scroll-list">
-            <div class="list-group change" id="p{%= it.id %}-change"></div>
+            <div class="list-group change" id="p{%= it.projectid %}-change"></div>
           </div>
         </div></div>
 
-        <a class="btn btn-primary" id="p{%= it.id %}-compare">Compare</a>
+        <a class="btn btn-primary" id="p{%= it.projectid %}-compare">Compare</a>
         {% } %}
         {% if (it.allresults) { %}
-        <div id="p{%= it.id %}-results" class="timeline-single"></div>
+        <div id="p{%= it.projectid %}-results" class="timeline-single"></div>
         {% } %}
         <div class="project-card-content"></div>
         <a href="/{%= it.slug %}/timeline">Timeline</a>

--- a/src/backend/timeline/timeline.html
+++ b/src/backend/timeline/timeline.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta id="project-id" value="{%= it.project.id %}">
+  <meta id="project-id" value="{%= it.project.projectid %}">
   <meta id="project-slug" value="{%= it.project.slug %}">
   <title>ReBench: Timeline {%= it.project.name %}</title>
   {%- include('header.html') %}

--- a/src/backend/timeline/timeline.ts
+++ b/src/backend/timeline/timeline.ts
@@ -51,7 +51,10 @@ export async function renderTimeline(
   if (project) {
     ctx.body = timelineTpl({
       project,
-      benchmarks: await getLatestBenchmarksForTimelineView(project.id, db)
+      benchmarks: await getLatestBenchmarksForTimelineView(
+        project.projectid,
+        db
+      )
     });
     ctx.type = 'html';
   } else {

--- a/src/shared/data-format.ts
+++ b/src/shared/data-format.ts
@@ -75,7 +75,7 @@ export function formatEnvironment(
   envId: number,
   environments: Environment[]
 ): string | undefined {
-  const env = environments.find((e) => e.id === envId);
+  const env = environments.find((e) => e.envid === envId);
   if (env === undefined) {
     return undefined;
   }

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -22,3 +22,12 @@ export function reportConnectionRefused(e: any): void {
     );
   }
 }
+
+export function reportDatabaseInUse(e: any): void {
+  log.error(e.message);
+  log.error(e.detail);
+}
+
+export function reportOtherErrors(e: any): void {
+  log.error('benchmark failed unexpectedly', e);
+}

--- a/tests/backend/compare/compare-view.test.ts
+++ b/tests/backend/compare/compare-view.test.ts
@@ -64,7 +64,7 @@ const benchId = {
 
 const environments: Environment[] = [
   {
-    id: 1,
+    envid: 1,
     hostname: 'MyHost',
     ostype: 'Linux',
     memory: 123456,

--- a/tests/backend/db/db-setup.test.ts
+++ b/tests/backend/db/db-setup.test.ts
@@ -121,7 +121,7 @@ describe('Recording a ReBench execution data fragments', () => {
     const result = await db.recordTrial(basicTestData, env, exp);
     expect(e.userName).toEqual(result.username);
     expect(e.manualRun).toEqual(result.manualrun);
-    expect(env.id).toEqual(result.envid);
+    expect(env.envid).toEqual(result.envid);
   });
 
   it('should accept trial denoise info', async () => {
@@ -146,7 +146,7 @@ describe('Recording a ReBench execution data fragments', () => {
     const result = await db.recordTrial(testData, env, exp);
     expect(e.userName).toEqual(result.username);
     expect(e.manualRun).toEqual(result.manualrun);
-    expect(env.id).toEqual(result.envid);
+    expect(env.envid).toEqual(result.envid);
     expect(e.denoise.scaling_governor).toEqual('performance');
     expect(e.denoise).toEqual(result.denoise);
   });
@@ -165,8 +165,8 @@ describe('Recording a ReBench execution data fragments', () => {
     const criterion = await db.recordCriterion(c);
     expect(c.c).toEqual(criterion.name);
     expect(c.u).toEqual(criterion.unit);
-    expect(typeof criterion.id).toEqual('number');
-    expect(criterion.id).toBeGreaterThanOrEqual(0);
+    expect(typeof criterion.critid).toEqual('number');
+    expect(criterion.critid).toBeGreaterThanOrEqual(0);
   });
 });
 

--- a/tests/backend/db/db.test.ts
+++ b/tests/backend/db/db.test.ts
@@ -60,15 +60,15 @@ describe('Record Trial', () => {
   it('but, recording the same for another experiment, should', async () => {
     basicTestData.experimentName += ' 2';
     const exp2 = await db.recordExperiment(basicTestData);
-    expect(exp2.id).not.toEqual(exp.id);
+    expect(exp2.expid).not.toEqual(exp.expid);
 
     const result = await db.recordTrial(basicTestData, env, exp2);
-    expect(result.expid).toEqual(exp2.id);
+    expect(result.expid).toEqual(exp2.expid);
 
     const tResult = await db.query({ text: 'SELECT * FROM Trial' });
     expect(tResult.rowCount).toEqual(2);
-    expect(tResult.rows[0].expid).toEqual(exp.id);
-    expect(tResult.rows[1].expid).toEqual(exp2.id);
+    expect(tResult.rows[0].expid).toEqual(exp.expid);
+    expect(tResult.rows[1].expid).toEqual(exp2.expid);
   });
 });
 

--- a/tests/backend/main/with-data.test.ts
+++ b/tests/backend/main/with-data.test.ts
@@ -81,7 +81,7 @@ describe('Test with basic test data loaded', () => {
     const projects = await db.getAllProjects();
     expect(projects).toHaveLength(1);
     expect(projects[0].name).toEqual('Small Example Project');
-    expect(projects[0].id).toEqual(1);
+    expect(projects[0].projectid).toEqual(1);
   });
 
   it('Should get results', async () => {

--- a/tests/backend/project/project.test.ts
+++ b/tests/backend/project/project.test.ts
@@ -9,7 +9,7 @@ initJestMatchers();
 describe('renderProjectDataPage', () => {
   it('should render the page', () => {
     const project: Project = {
-      id: 1,
+      projectid: 1,
       name: 'Test Project',
       slug: 'test-project',
       description: 'desc',

--- a/tests/shared/data-format.test.ts
+++ b/tests/shared/data-format.test.ts
@@ -133,7 +133,7 @@ describe('Format Functions for Numerical Values', () => {
   describe('formatEnvironment - for display to user', () => {
     const envs: Environment[] = [
       {
-        id: 1,
+        envid: 1,
         hostname: 'host',
         ostype: 'Linux',
         memory: 453454333,


### PR DESCRIPTION
This is the start of a PR to move from using JOIN ... ON to the JOIN ... USING, which only requires to name the columns on which to join.

Though, while I do like the idea of getting rid of columns just named `id`, I don't like that the JOIN clauses don't make it explicit which tables are actually joined. While this makes things somewhat redundant, it also allows one to read an SQL query in isolation and see which tables are linked together.

So, this PR is mostly for archival.
I'll close it without merging. (It's also still incomplete).