### PR TITLE
Add CSV data export directly from Postgres, and add integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,10 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          -v ${{ github.workspace }}:/postgres-export:rw
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
-        # Make sure the postgres container is has a exp-data directory
-        volumes:
-          - ${{ github.workspace }}:/postgres-export
 
     steps:
       - name: Checkout ReBench
@@ -92,15 +90,18 @@ jobs:
 
       - name: Run ReBench Integration Tests
         run: |
+          # make workspace writable for postgres container
+          chmod a+wx ${{ github.workspace }}
+
+          # start ReBenchDB server
           NODE_DATA_EXPORT_PATH=${{ github.workspace }} RDB_DATA_EXPORT_PATH=/postgres-export DEV=true npm run start &
           sleep 5
 
+          # run integration tests
           pushd tests/rebench-integration
           rebench --experiment IntegrationTest rebench.conf
 
-          ls -lah /home/runner/work/ReBenchDB/ReBenchDB/dist/src/backend/../../../src/../resources/exp-data/
           sleep 1
-
           PROJID=$(curl -s http://localhost:33333/ReBenchDB-integration-test/data | grep project-id | grep -o -E '[0-9]+')
           EXPID=$(curl -s http://localhost:33333/rebenchdb/dash/$PROJID/data-overview | jq '.data[0].expid')
 
@@ -109,6 +110,10 @@ jobs:
           curl -s http://localhost:33333/ReBenchDB-integration-test/data/$EXPID.csv.gz > /dev/null
 
           sleep 10 # give the server some time to generate the files
+          # reposses the files to be able to read them
+          sudo chown $(whoami):$(id -g -n) ${{ github.workspace }}/*.gz
+
+          # fetch the generated files via node and check them
           curl -sL http://localhost:33333/ReBenchDB-integration-test/data/$EXPID.json.gz -o actual.json.gz
           curl -sL http://localhost:33333/ReBenchDB-integration-test/data/$EXPID.csv.gz -o actual.csv.gz
           gzip -k -d actual.json.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
+        # Make sure the postgres container is has a exp-data directory
+        volumes:
+          - ${{ github.workspace }}:/home/runner/work/ReBenchDB/ReBenchDB/resources/exp-data/
 
     steps:
       - name: Checkout ReBench
@@ -94,12 +97,20 @@ jobs:
 
           pushd tests/rebench-integration
           rebench --experiment IntegrationTest rebench.conf
+
+          ls -lah /home/runner/work/ReBenchDB/ReBenchDB/dist/src/backend/../../../src/../resources/exp-data/
+          sleep 1
+
           PROJID=$(curl -s http://localhost:33333/ReBenchDB-integration-test/data | grep project-id | grep -o -E '[0-9]+')
           EXPID=$(curl -s http://localhost:33333/rebenchdb/dash/$PROJID/data-overview | jq '.data[0].expid')
 
           # Trigger data generation
-          curl -s http://localhost:33333/ReBenchDB-integration-test/data/$EXPID > /dev/null
-          sleep 10 # give the server some time to generate the json.gz file
-          curl -sL http://localhost:33333/ReBenchDB-integration-test/data/$EXPID -o actual.json.gz
+          curl -s http://localhost:33333/ReBenchDB-integration-test/data/$EXPID.json.gz > /dev/null
+          curl -s http://localhost:33333/ReBenchDB-integration-test/data/$EXPID.csv.gz > /dev/null
+
+          sleep 10 # give the server some time to generate the files
+          curl -sL http://localhost:33333/ReBenchDB-integration-test/data/$EXPID.json.gz -o actual.json.gz
+          curl -sL http://localhost:33333/ReBenchDB-integration-test/data/$EXPID.csv.gz -o actual.csv.gz
           gzip -k -d actual.json.gz
+          gzip -k -d actual.csv.gz
           node check-data.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,26 @@ jobs:
       - name: Lint and Formatting
         run: |
           npm run verify
+
+      - name: Install ReBench
+        run: |
+          git clone --depth 1 --branch rebenchdb https://github.com/smarr/rebench.git
+          pushd rebench
+          pip install .
+          popd
+
+      - name: Run ReBench Integration Tests
+        run: |
+          DEV=true npm run start &
+          sleep 5
+
+          pushd tests/rebench-integration
+          rebench --experiment IntegrationTest rebench.conf
+          EXPID=$(curl -s http://localhost:33333/rebenchdb/dash/2/data-overview | jq '.data[0].expid')
+
+          # Trigger data generation
+          curl -s http://localhost:33333/ReBenchDB-integration-test/data/$EXPID > /dev/null
+          sleep 10 # give the server some time to generate the json.gz file
+          curl -sL http://localhost:33333/ReBenchDB-integration-test/data/$EXPID -o actual.json.gz
+          gzip -k -d actual.json.gz
+          node check-data.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           - 5432:5432
         # Make sure the postgres container is has a exp-data directory
         volumes:
-          - ${{ github.workspace }}:/home/runner/work/ReBenchDB/ReBenchDB/resources/exp-data/
+          - ${{ github.workspace }}:/postgres-export
 
     steps:
       - name: Checkout ReBench
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run ReBench Integration Tests
         run: |
-          DEV=true npm run start &
+          NODE_DATA_EXPORT_PATH=${{ github.workspace }} RDB_DATA_EXPORT_PATH=/postgres-export DEV=true npm run start &
           sleep 5
 
           pushd tests/rebench-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,8 @@ jobs:
 
           pushd tests/rebench-integration
           rebench --experiment IntegrationTest rebench.conf
-          EXPID=$(curl -s http://localhost:33333/rebenchdb/dash/2/data-overview | jq '.data[0].expid')
+          PROJID=$(curl -s http://localhost:33333/ReBenchDB-integration-test/data | grep project-id | grep -o -E '[0-9]+')
+          EXPID=$(curl -s http://localhost:33333/rebenchdb/dash/$PROJID/data-overview | jq '.data[0].expid')
 
           # Trigger data generation
           curl -s http://localhost:33333/ReBenchDB-integration-test/data/$EXPID > /dev/null

--- a/src/backend/db/db.ts
+++ b/src/backend/db/db.ts
@@ -793,6 +793,29 @@ export abstract class Database {
     return result.rows;
   }
 
+  public async storeExperimentMeasurements(
+    expId: number,
+    outputFile: string
+  ): Promise<any[]> {
+    // Postgres doesn't support parameters for COPY
+    // so, just doing string substitution here
+    const query = `COPY (
+      SELECT
+        ${measurementDataColumns.replace('$1', '6')}
+      FROM
+        ${measurementDataTableJoins}
+      WHERE
+        Experiment.id = ${expId}
+      ORDER BY
+        runId, trialId, cmdline, invocation, iteration, criterion
+    ) TO PROGRAM 'gzip -9 > ${outputFile}'
+      WITH (FORMAT csv, HEADER true)`;
+    const result = await this.query({
+      text: query
+    });
+    return result.rows;
+  }
+
   public async recordExperimentCompletion(
     expId: number,
     endTime: string

--- a/src/backend/dev-server/server.ts
+++ b/src/backend/dev-server/server.ts
@@ -32,6 +32,10 @@ export async function serveStaticResource(
     ctx.type = 'application/json';
     ctx.set('Content-Encoding', 'gzip');
     path = robustPath(`../resources/${filename}`);
+  } else if (filename.endsWith('.csv.gz')) {
+    ctx.type = 'text/csv';
+    ctx.set('Content-Encoding', 'gzip');
+    path = robustPath(`../resources/${filename}`);
   } else {
     throw new Error(`Unsupported file type. Filename: ${filename}`);
   }

--- a/src/backend/dev-server/server.ts
+++ b/src/backend/dev-server/server.ts
@@ -2,7 +2,7 @@ import { ParameterizedContext } from 'koa';
 import { readFileSync } from 'node:fs';
 
 import { log } from '../logging.js';
-import { robustPath, robustSrcPath } from '../util.js';
+import { robustPath, robustSrcPath, siteConfig } from '../util.js';
 
 export async function serveStaticResource(
   ctx: ParameterizedContext
@@ -31,11 +31,11 @@ export async function serveStaticResource(
   } else if (filename.endsWith('.json.gz')) {
     ctx.type = 'application/json';
     ctx.set('Content-Encoding', 'gzip');
-    path = robustPath(`../resources/${filename}`);
+    path = `${siteConfig.dataExportPath}/${filename}`;
   } else if (filename.endsWith('.csv.gz')) {
     ctx.type = 'text/csv';
     ctx.set('Content-Encoding', 'gzip');
-    path = robustPath(`../resources/${filename}`);
+    path = `${siteConfig.dataExportPath}/${filename}`;
   } else {
     throw new Error(`Unsupported file type. Filename: ${filename}`);
   }

--- a/src/backend/project/project.ts
+++ b/src/backend/project/project.ts
@@ -106,11 +106,16 @@ export async function renderDataExport(
   db: Database
 ): Promise<void> {
   const start = startRequest();
+  const format = ctx.params.expIdAndExtension.endsWith('.json.gz')
+    ? 'json'
+    : 'csv';
+  const expId = ctx.params.expIdAndExtension.replace(`.${format}.gz`, '');
 
   const data = await getExpData(
     ctx.params.projectSlug,
-    Number(ctx.params.expId),
-    db
+    Number(expId),
+    db,
+    format
   );
 
   if (data.preparingData) {

--- a/src/backend/rebench/results.ts
+++ b/src/backend/rebench/results.ts
@@ -50,7 +50,7 @@ export async function acceptResultData(
       .then(([recMs, recPs]) =>
         log.info(
           // eslint-disable-next-line max-len
-          `/rebenchdb/results: stored ${recMs} measurements, ${recPs} profiles`
+          `/rebenchdb/results: stored ${recMs} sets of measurements, ${recPs} profiles`
         )
       )
       .catch((e) => {

--- a/src/backend/util.ts
+++ b/src/backend/util.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'path';
+import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 import { promisify } from 'node:util';
@@ -28,10 +28,10 @@ const __dirname = getDirname(import.meta.url);
  */
 export const robustPath = __dirname.includes('dist/')
   ? function (path) {
-      return `${__dirname}/../../../src/${path}`;
+      return resolve(`${__dirname}/../../../src/${path}`);
     }
   : function (path) {
-      return `${__dirname}/../${path}`;
+      return resolve(`${__dirname}/../${path}`);
     };
 
 /**

--- a/src/backend/util.ts
+++ b/src/backend/util.ts
@@ -49,11 +49,31 @@ const port: number = process.env.RDB_PORT
   ? parseInt(process.env.RDB_PORT)
   : 5432;
 
+const _rebench_dev = 'https://rebench.dev';
+const reportsUrl = process.env.REPORTS_URL || '/static/reports';
+const staticUrl = process.env.STATIC_URL || '/static';
+const publicUrl = process.env.PUBLIC_URL || _rebench_dev;
+
+// configuration for data export is a little more involved,
+// because the database might run elsewhere, but may produce
+// data files, which we need to be able to serve, at least in the dev mode.
+const dbDataExportPath =
+  process.env.RDB_DATA_EXPORT_PATH || robustPath('../resources/exp-data');
+
+// I assume that Node has access to files produced by itself and PostgreSQL.
+const nodeDataExportPath =
+  process.env.NODE_DATA_EXPORT_PATH || dbDataExportPath;
+
+const dataExportUrlBase = process.env.DATA_URL_BASE || `${staticUrl}/exp-data`;
+
 export const dbConfig = {
   user: process.env.RDB_USER || '',
   password: process.env.RDB_PASS || '',
   host: process.env.RDB_HOST || 'localhost',
   database: process.env.RDB_DB || 'rdb_smde2',
+
+  /** The path where PostgreSQL writes data files to. */
+  dataExportPath: dbDataExportPath,
   port
 };
 
@@ -62,8 +82,6 @@ export const refreshSecret =
 
 /** How long to still hold on to the cache after it became invalid. In ms. */
 export const cacheInvalidationDelay = 1000 * 60 * 5; /* 5 minutes */
-
-const _rebench_dev = 'https://rebench.dev';
 
 export function isReBenchDotDev(): boolean {
   return siteConfig.publicUrl === _rebench_dev;
@@ -83,9 +101,16 @@ export const statsConfig = {
 
 export const siteConfig = {
   port: process.env.PORT || 33333,
-  reportsUrl: process.env.REPORTS_URL || '/static/reports',
-  staticUrl: process.env.STATIC_URL || '/static',
-  publicUrl: process.env.PUBLIC_URL || _rebench_dev,
+  reportsUrl,
+  staticUrl,
+  publicUrl,
+  dataExportUrlBase,
+
+  /**
+   * The path where Node.js writes data files to,
+   * and Postgres generated files are accessible.
+   */
+  dataExportPath: nodeDataExportPath,
   appId: parseInt(process.env.GITHUB_APP_ID || '') || 76497,
   githubPrivateKey:
     process.env.GITHUB_PK || 'rebenchdb.2020-08-11.private-key.pem',

--- a/src/frontend/render.ts
+++ b/src/frontend/render.ts
@@ -50,6 +50,7 @@ export function renderProjectDataOverview(
   projectSlug: string
 ): void {
   const tBody = $('#data-overview');
+  const pSlug = projectSlug;
 
   let hasDesc = false;
 
@@ -73,8 +74,10 @@ export function renderProjectDataOverview(
         )}</p></td>
         <td>${row.hostnames}</td>
         <td class="num-col">${row.runs}</td>
-        <td class="num-col"><a rel="nofollow"
-          href="/${projectSlug}/data/${row.expid}">${row.measurements}</a></td>
+        <td class="num-col">${row.measurements}
+          <a rel="nofollow" href="/${pSlug}/data/${row.expid}.json.gz">JSON</a>,
+          <a rel="nofollow" href="/${pSlug}/data/${row.expid}.csv.gz">CSV</a>
+        </td>
       </tr>`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ router.get('/:projectSlug/source/:sourceId', async (ctx) =>
 );
 router.get('/:projectSlug/timeline', async (ctx) => renderTimeline(ctx, db));
 router.get('/:projectSlug/data', async (ctx) => renderProjectDataPage(ctx, db));
-router.get('/:projectSlug/data/:expId', async (ctx) => {
+router.get('/:projectSlug/data/:expIdAndExtension', async (ctx) => {
   if (
     ctx.header['X-Purpose'] === 'preview' ||
     ctx.header['Purpose'] === 'prefetch' ||

--- a/tests/backend/main/main.test.ts
+++ b/tests/backend/main/main.test.ts
@@ -139,7 +139,7 @@ describe('getLast100Measurements', () => {
 
   let db: TestDatabase;
   beforeAll(async () => {
-    db = await createAndInitializeDB('main_basic', 25, true, false);
+    db = await createAndInitializeDB('main_main', 25, true, false);
   });
 
   afterAll(async () => {

--- a/tests/backend/main/with-data.test.ts
+++ b/tests/backend/main/with-data.test.ts
@@ -37,7 +37,7 @@ describe('Test with basic test data loaded', () => {
   // switch suites to use a template database
 
   beforeAll(async () => {
-    db = await createAndInitializeDB('main_basic', 25, true, false);
+    db = await createAndInitializeDB('main_with_data', 25, true, false);
 
     const data = readFileSync(
       robustPath('../tests/data/small-payload.json')

--- a/tests/rebench-integration/check-data.js
+++ b/tests/rebench-integration/check-data.js
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+
+const data = JSON.parse(readFileSync('actual.json', 'utf-8'));
+
+let allCorrect = true;
+
+function assert(values, criterion, step) {
+  for (let i = 1; i < values.length + 1; i += 1) {
+    const val = values[i - 1];
+    if (i % step === 0) {
+      console.assert(
+        val === i,
+        `${criterion} at ${i}: Expected ${i}, got ${val}`
+      );
+      allCorrect = allCorrect && val === i;
+    } else {
+      console.assert(
+        val === null,
+        `${criterion} at ${i}: Expected null, got ${val}`
+      );
+      allCorrect = allCorrect && val === null;
+    }
+  }
+}
+
+for (const e of data) {
+  if (e.criterion === 'mem') {
+    assert(e.values, e.criterion, 3);
+  } else if (e.criterion === 'compile') {
+    assert(e.values, e.criterion, 7);
+  } else if (e.criterion === 'total') {
+    assert(e.values, e.criterion, 1);
+  }
+}
+
+if (allCorrect) {
+  process.exit(0);
+} else {
+  process.exit(1);
+}

--- a/tests/rebench-integration/check-data.js
+++ b/tests/rebench-integration/check-data.js
@@ -5,8 +5,8 @@ const data = JSON.parse(readFileSync('actual.json', 'utf-8'));
 let allCorrect = true;
 
 function assert(values, criterion, step) {
-  for (let i = 1; i < values.length + 1; i += 1) {
-    const val = values[i - 1];
+  for (let i = 1; i < values.length; i += 1) {
+    const val = values[i];
     if (i % step === 0) {
       console.assert(
         val === i,
@@ -15,22 +15,26 @@ function assert(values, criterion, step) {
       allCorrect = allCorrect && val === i;
     } else {
       console.assert(
-        val === null,
+        val == null,
         `${criterion} at ${i}: Expected null, got ${val}`
       );
-      allCorrect = allCorrect && val === null;
+      allCorrect = allCorrect && val == null;
     }
   }
 }
 
+const byCriterion = { mem: [], compile: [], total: [] };
+
 for (const e of data) {
-  if (e.criterion === 'mem') {
-    assert(e.values, e.criterion, 3);
-  } else if (e.criterion === 'compile') {
-    assert(e.values, e.criterion, 7);
-  } else if (e.criterion === 'total') {
-    assert(e.values, e.criterion, 1);
-  }
+  byCriterion[e.criterion][e.iteration] = e.value;
+}
+
+for (const [c, step] of [
+  ['mem', 3],
+  ['compile', 7],
+  ['total', 1]
+]) {
+  assert(byCriterion[c], c, step);
 }
 
 if (allCorrect) {

--- a/tests/rebench-integration/check-data.js
+++ b/tests/rebench-integration/check-data.js
@@ -1,7 +1,5 @@
 import { readFileSync } from 'node:fs';
 
-const data = JSON.parse(readFileSync('actual.json', 'utf-8'));
-
 let allCorrect = true;
 
 function assert(values, criterion, step) {
@@ -23,19 +21,54 @@ function assert(values, criterion, step) {
   }
 }
 
-const byCriterion = { mem: [], compile: [], total: [] };
+function getJsonData() {
+  const data = JSON.parse(readFileSync('actual.json', 'utf-8'));
 
-for (const e of data) {
-  byCriterion[e.criterion][e.iteration] = e.value;
+  const byCriterion = { mem: [], compile: [], total: [] };
+
+  for (const e of data) {
+    byCriterion[e.criterion][e.iteration] = e.value;
+  }
+
+  return byCriterion;
 }
 
-for (const [c, step] of [
-  ['mem', 3],
-  ['compile', 7],
-  ['total', 1]
-]) {
-  assert(byCriterion[c], c, step);
+function getCsvData() {
+  const data = readFileSync('actual.csv', 'utf-8');
+
+  const lines = data.split('\n');
+  const columnArr = lines.shift().split(',');
+  const criterionIdx = columnArr.indexOf('criterion');
+  const iterationIdx = columnArr.indexOf('iteration');
+  const valueIdx = columnArr.indexOf('value');
+
+  const byCriterion = { mem: [], compile: [], total: [] };
+
+  for (const line of lines) {
+    if (line === '') {
+      continue;
+    }
+    const columns = line.split(',');
+    byCriterion[columns[criterionIdx]][columns[iterationIdx]] = parseInt(
+      columns[valueIdx]
+    );
+  }
+
+  return byCriterion;
 }
+
+function check(byCriterion) {
+  for (const [c, step] of [
+    ['mem', 3],
+    ['compile', 7],
+    ['total', 1]
+  ]) {
+    assert(byCriterion[c], c, step);
+  }
+}
+
+check(getJsonData());
+check(getCsvData());
 
 if (allCorrect) {
   process.exit(0);

--- a/tests/rebench-integration/rebench.conf
+++ b/tests/rebench-integration/rebench.conf
@@ -1,0 +1,33 @@
+default_experiment: benchmarks
+default_data_file: 'rebench.data'
+
+reporting:
+    # Benchmark results will be reported to ReBenchDB
+    rebenchdb:
+        # this url needs to point to the API endpoint
+        db_url: http://localhost:33333/rebenchdb
+        repo_url: https://github.com/smarr/rebenchdb
+        record_all: true # make sure everything is recorded
+        project_name: ReBenchDB-integration-test
+
+benchmark_suites:
+  test-suite:
+    gauge_adapter: RebenchLog
+    command: "%(benchmark)s %(iterations)s"
+    iterations: 100
+    invocations: 1
+    benchmarks:
+      - Test
+
+executors:
+  TestVM:
+    path: .
+    executable: ./test-vm.py
+
+experiments:
+  benchmarks:
+    description: Test Benchmark
+    suites:
+      - test-suite
+    executions:
+      - TestVM

--- a/tests/rebench-integration/test-vm.py
+++ b/tests/rebench-integration/test-vm.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import sys
+
+if len(sys.argv) != 3:
+    print("Usage: test-vm.py <benchmark> <number-of-iterations>")
+    sys.exit(1)
+
+criteria = {
+    "mem": {"unit": "MB", "step": 3},
+    "compile": {"unit": "ms", "step": 7},
+    "total": {"unit": "ms", "step": 1},
+}
+
+benchmark_name = sys.argv[1]
+num_iterations = int(sys.argv[2])
+
+for i in range(1, num_iterations + 1):
+    for n, c in criteria.items():
+        if i % c["step"] == 0:
+            print(f"{benchmark_name}: {n}: {i}{c['unit']}")


### PR DESCRIPTION
This PR adds support to directly export data from Postgres, which avoids Node.js memory limitations. The data is exported as standard CSV file, and compressed with gzip.
Since the data is exported from Postgres, it doesn't need to run through Node.js and JSON conversion first, which enables very large data sets.

To make this work in practice, extra configuration may be necessary when for instance Postgres runs in a container. Generally, it's assume that all data files end up in the same folder.

For this purpose, there are two new environment variables:
 - `RDB_DATA_EXPORT_PATH` the path as seen from Postgres
 - `NODE_DATA_EXPORT_PATH` the path as seen from Node.js, all files are assume to be accessible by Node.js or the web server to serve them to the client

This is now tested on github with a basic end-to-end test.

There are a few other minor commits here:
 - improve log output
 - avoid test race conditions by using separate databases
 - always resolve the path to be absolute when getting a "robust" one
