### PR TITLE
Fix chartjs init for benchmark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,15 @@ RUN apt-get update && apt-get install -y \
     libfontconfig1-dev \
     libpq-dev
 
-# Copy only package.json to enable caching
-COPY ./package.json ./package-lock.json /project/
+# Copy only package*.json, which are likely unchanged, allowing caching
+COPY package.json package-lock.json /project/
 
 # Set the working dir to the project & install and compile all dependency
 WORKDIR /project/
 
 RUN SKIP_COMPILE=true npm ci --ignore-scripts=false --foreground-scripts
 
-# all of the project files will be copyed to a new dir called project
-COPY . /project
+# copy all files, which likely have changed, and prevent caching
+COPY . /project/
 
 RUN npm run compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
 
 # Copy only package*.json, which are likely unchanged, allowing caching
 COPY package.json package-lock.json /project/
+COPY patches /project/patches
 
 # Set the working dir to the project & install and compile all dependency
 WORKDIR /project/

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "eslint-plugin-prettier": "5.1.3",
         "jest": "29.7.0",
         "nodemon": "3.1.0",
-        "patch-package": "^8.0.0",
+        "patch-package": "8.0.0",
         "pixelmatch": "5.3.0",
         "prettier": "3.2.5",
         "source-map-support": "0.5.21",

--- a/src/backend/compare/charts.ts
+++ b/src/backend/compare/charts.ts
@@ -25,9 +25,11 @@ const marginTopWithTitle = 34;
 const marginBottom = 28;
 const perEntryHeight = 34;
 
-export function initChartJS(): void {
+/** Register all standard plugins. This is for convenience. */
+function initChartJS(): void {
   Chart.register(...registerables);
 }
+initChartJS();
 
 function calculatePlotHeight(title: string | null, data: ChangeData): number {
   const result = marginBottom + data.labels.length * perEntryHeight;

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,6 @@ import {
 } from './backend/rebench/results.js';
 import { setTimeout } from 'node:timers/promises';
 import { reportConnectionRefused } from './shared/errors.js';
-import { initChartJS } from './backend/compare/charts.js';
 
 log.info('Starting ReBenchDB Version ' + rebenchVersion);
 
@@ -218,7 +217,6 @@ async function tryToConnect(n: number): Promise<boolean> {
   }
 
   await initPerfTracker(db);
-  initChartJS();
 
   log.info(`Starting server on http://localhost:${siteConfig.port}`);
   app.listen(siteConfig.port);

--- a/tests/backend/compare/charts.test.ts
+++ b/tests/backend/compare/charts.test.ts
@@ -9,7 +9,6 @@ import {
 import { robustPath } from '../../../src/backend/util.js';
 import {
   createCanvas,
-  initChartJS,
   renderInlinePlot,
   renderOverviewPlots
 } from '../../../src/backend/compare/charts.js';
@@ -26,7 +25,6 @@ import {
 } from '../../payload.js';
 
 initJestMatchers();
-initChartJS();
 
 const outputFolder = isRequestedToUpdateExpectedData()
   ? robustPath('../tests/data/expected-results/charts')

--- a/tests/backend/compare/compare-view.test.ts
+++ b/tests/backend/compare/compare-view.test.ts
@@ -30,10 +30,8 @@ import {
   loadCompareViewJsSomPayload,
   loadCompareViewTSomPayload
 } from '../../payload.js';
-import { initChartJS } from '../../../src/backend/compare/charts.js';
 
 initJestMatchers();
-initChartJS();
 
 const dataJsSOM = loadCompareViewJsSomPayload();
 const dataTruffleSOM = loadCompareViewTSomPayload();

--- a/tests/backend/compare/prep-data.test.ts
+++ b/tests/backend/compare/prep-data.test.ts
@@ -46,10 +46,8 @@ import {
   loadCompareViewJsSomPayload,
   loadCompareViewTSomPayload
 } from '../../payload.js';
-import { initChartJS } from '../../../src/backend/compare/charts.js';
 
 initJestMatchers();
-initChartJS();
 
 describe('compareStringOrNull()', () => {
   it('should compare null and null', () => {


### PR DESCRIPTION
I was a bit too eager and didn't notice that benchmarking was broken for #190, which fixed memory leaks as noticed in #188.

This PR fixes the initialization of ChartJS, doing it now unconditionally when even the relevant code is loaded.

This PR also fixes the Dockerfile so that the patching from #190 also works.

And with that, we see that results are generated now in 22%-40% less time:

https://rebench.dev/ReBenchDB/compare/b0b149a77371ca2e685cf0aab786a32ec26ca958..55c5c5d7ba7d1f6cd4ebbef5febae9bd3bd40539