### PR TITLE
Fix report rendering when executor comparison inline plot only has one data series

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "compile": "tsc",
     "postcompile": "npm run prep-static && npm run download-font",
     "prep-static": "cp dist/src/frontend/*.js dist/src/shared/*.js ./resources/",
-    "download-font": "node dist/src/download.js https://github.com/googlefonts/roboto/releases/download/v2.136/roboto-hinted.zip tmp/roboto-hinted.zip && unzip -o -d dist tmp/roboto-hinted.zip",
+    "download-font": "if ! [ -f dist/roboto-hinted/Roboto-Black.ttf ]; then node dist/src/download.js https://github.com/googlefonts/roboto/releases/download/v2.136/roboto-hinted.zip tmp/roboto-hinted.zip && unzip -o -d dist tmp/roboto-hinted.zip; fi",
     "start": "node --enable-source-maps --experimental-json-modules ./dist/src/index.js",
     "nodemon": "DEV=true nodemon --enable-source-maps --experimental-json-modules ./dist/src/index.js --watch ./dist/src --watch ./package.json --watch ./src --ext js,json,html",
     "format": "prettier --config .prettierrc '{src,tests}/**/*.ts' --write",

--- a/src/backend/compare/charts.ts
+++ b/src/backend/compare/charts.ts
@@ -117,9 +117,9 @@ function toDataSetWithBaseChangeBackground(data: ChangeData): any[] {
 }
 
 function toDataSetWithExeColors(data: ChangeData, exeColors: string[]): any[] {
-  if (data.labels.length < 2) {
+  if (data.labels.length < 1) {
     throw new Error(
-      'Expect at least two data series, but only got ' + data.labels.length
+      'Expect at least one data series, but only got ' + data.labels.length
     );
   }
 

--- a/src/backend/compare/html/gen-index.html
+++ b/src/backend/compare/html/gen-index.html
@@ -6,7 +6,7 @@
   {%- include('header.html') %}
 
   {% if (it.generatingReport) { %}
-  <meta http-equiv="refresh" content="30" />
+  <meta http-equiv="refresh" content="5" />
   {% } %}
 </head>
 <body class="compare timeline-multi">

--- a/src/backend/compare/prep-data.ts
+++ b/src/backend/compare/prep-data.ts
@@ -887,7 +887,7 @@ export async function calculateAcrossExesStatsForBenchmark(
       row.exeStats[j].criteria[criterion] = stats[j];
     }
 
-    if (criterion === siteConfig.inlinePlotCriterion) {
+    if (criterion === siteConfig.inlinePlotCriterion && exesArr.length >= 1) {
       lastPlotId += 1;
       row.inlinePlot = await createExeInlinePlot(
         exesArr,


### PR DESCRIPTION
This allows the report to render when there's not actually a comparison, but only a single data series.

The PR also reduces the refresh rate of the report-rending placeholder to 5 seconds, since they render so fast now 🥳 

And, we make download of the font conditional on whether it's not already there. Useful for development setup.

This resolves #189.