### PR TITLE
Improve error on timeline view to indicate missing configuration

### DIFF
--- a/src/backend/timeline/timeline.html
+++ b/src/backend/timeline/timeline.html
@@ -15,6 +15,9 @@
     <h1 class="display-4">ReBench: Timeline {%= it.project.name %}</h1>
     {% if (it.project.description) { %}
     <h2 class="display-5">{%= it.project.description %}</h2>
+    {% }
+       if (it.project.basebranch) { %}
+    <p>Timeline is based on data for the <code>{%= it.project.basebranch %}</code> branch.</p>
     {% } %}
   </div>
   <div class="refresh">
@@ -80,7 +83,11 @@
   <main role="main">
   <div class="jumbotron">
     <h1 class="display-4">No Data Available</h1>
-    <p class="lead">There are no benchmarks available for this project.</p>
+    {% if (it.project.basebranch) { %}
+      <p class="lead">There are no benchmarks available for this project.</p>
+    {% } else { %}
+      <p class="lead">The branch to show on the timeline has not been configured. Please ask the ReBenchDB administrator to set the branch for the timeline view.</p>
+    {% } %}
   </div>
   </div>
   </main>

--- a/tests/data/expected-results/timeline/index.html
+++ b/tests/data/expected-results/timeline/index.html
@@ -21,6 +21,8 @@
 <div class="jumbotron">
 <h1 class="display-4">ReBench: Timeline Small Example Project</h1>
 
+<p>Timeline is based on data for the <code>HEAD -&gt; rebenchdb, smarr/rebenchdb</code> branch.</p>
+
 </div>
 <div class="refresh">
 <div class="flex-nowrap navbar-light">


### PR DESCRIPTION
The timeline view is based on the timeline data, which is only computed for the `baseBranch` configured for the project.
This change shows the configuration on the timeline view, or reports that it's missing.

This fixes #196.