### PR TITLE
Fix CSV Data File export (Resolves #198)

### DIFF
--- a/src/backend/db/db.ts
+++ b/src/backend/db/db.ts
@@ -717,6 +717,7 @@ export abstract class Database {
     projectSlug: string
   ): Promise<{
     project: string;
+    projectSlug: string;
     expName: string;
     expDesc: string;
     projectId: number;
@@ -729,7 +730,8 @@ export abstract class Database {
                   exp.description as expDesc,
                   p.id as pId,
                   p.name as pName,
-                  p.description as pDesc
+                  p.description as pDesc,
+                  p.slug as pSlug
                 FROM
                   Experiment exp
                 JOIN Project p ON exp.projectId = p.id
@@ -744,6 +746,7 @@ export abstract class Database {
 
     return {
       project: result.rows[0].pname,
+      projectSlug: result.rows[0].pslug,
       expName: result.rows[0].expname,
       expDesc: result.rows[0].expDesc,
       projectId: result.rows[0].pid,

--- a/src/backend/project/data-export.ts
+++ b/src/backend/project/data-export.ts
@@ -22,6 +22,7 @@ export async function getExpData(
   if (!result) {
     data = {
       project: '',
+      projectSlug,
       generationFailed: true,
       stdout: 'Experiment was not found'
     };
@@ -29,7 +30,7 @@ export async function getExpData(
     data = result;
   }
 
-  const expFilePrefix = `${data.project}-${expId}`;
+  const expFilePrefix = `${data.projectSlug}-${expId}`;
   const expFileName = `${expFilePrefix}.${format}.gz`;
 
   if (existsSync(`${siteConfig.dataExportPath}/${expFileName}`)) {


### PR DESCRIPTION
Before this PR, we used the project name, which can contain arbitrary unsafe characters.
Though, the project slug is already safe.

So, we just use that one.

It's safe, because projects are created in `recordProject()` with

```sql
INSERT INTO Project (name, slug)
  VALUES ($1, regexp_replace($2, '[^0-9a-zA-Z-]', '-', 'g'))
  RETURNING *
```

This means, all none number and a-z characters are replaced with `-` and made safe.

See https://github.com/smarr/ReBenchDB/blob/f84de3f1f6cf4f77a4639cc170999d5e129c1e5b/src/backend/db/db.ts#L496-L509