### PR TITLE
Handle invalid requests and make asHumanHz a bit more robust

### DIFF
--- a/src/backend/compare/compare.ts
+++ b/src/backend/compare/compare.ts
@@ -14,23 +14,28 @@ import { respondProjectNotFound } from '../common/standard-responses.js';
 import { refreshSecret } from '../util.js';
 import { deleteReport, renderCompare } from './report.js';
 import type { TimelineRequest } from '../../shared/api.js';
+import { getNumberOrError } from '../request-check.js';
+import { log } from '../logging.js';
 
 export async function getProfileAsJson(
   ctx: ParameterizedContext,
   db: Database
 ): Promise<void> {
+  ctx.type = 'application/json';
+
+  const runId = getNumberOrError(ctx, 'runId');
+  if (runId === null) {
+    log.error((ctx.body as any).error);
+    return;
+  }
+
   const start = startRequest();
 
-  ctx.body = await getProfile(
-    Number(ctx.params.runId),
-    ctx.params.commitId,
-    db
-  );
+  ctx.body = await getProfile(runId, ctx.params.commitId, db);
   if (ctx.body === undefined) {
     ctx.status = 404;
     ctx.body = {};
   }
-  ctx.type = 'application/json';
   completeRequestAndHandlePromise(start, db, 'get-profiles');
 }
 
@@ -70,17 +75,24 @@ export async function getMeasurementsAsJson(
   ctx: ParameterizedContext,
   db: Database
 ): Promise<void> {
+  ctx.type = 'application/json';
+
+  const runId = getNumberOrError(ctx, 'runId');
+  if (runId === null) {
+    log.error((ctx.body as any).error);
+    return;
+  }
+
   const start = startRequest();
 
   ctx.body = await getMeasurements(
     ctx.params.projectSlug,
-    Number(ctx.params.runId),
+    runId,
     ctx.params.baseId,
     ctx.params.changeId,
     db
   );
 
-  ctx.type = 'application/json';
   completeRequestAndHandlePromise(start, db, 'get-measurements');
 }
 

--- a/src/backend/project/data-export.ts
+++ b/src/backend/project/data-export.ts
@@ -7,6 +7,7 @@ import { dbConfig, siteConfig, storeJsonGzip } from '../util.js';
 import { log } from '../logging.js';
 import { Database } from '../db/db.js';
 import { ParameterizedContext } from 'koa';
+import { getNumberOrError } from '../request-check.js';
 
 const expDataPreparation = new Map();
 
@@ -98,8 +99,15 @@ export async function getAvailableDataAsJson(
   ctx: ParameterizedContext,
   db: Database
 ): Promise<void> {
-  ctx.body = await getDataOverview(Number(ctx.params.projectId), db);
   ctx.type = 'application/json';
+
+  const projectId = getNumberOrError(ctx, 'projectId');
+  if (projectId === null) {
+    log.error((ctx.body as any).error);
+    return;
+  }
+
+  ctx.body = await getDataOverview(projectId, db);
 }
 
 export async function getDataOverview(

--- a/src/backend/request-check.ts
+++ b/src/backend/request-check.ts
@@ -1,0 +1,19 @@
+import { ParameterizedContext } from 'koa';
+
+export function getNumberOrError(
+  ctx: ParameterizedContext,
+  paramName: string
+): number | null {
+  const value = Number(ctx.params[paramName]);
+
+  if (isNaN(value)) {
+    ctx.status = 400;
+    ctx.body = {
+      error: `Invalid ${paramName} provided. Received "${ctx.params.runId}".`
+    };
+
+    return null;
+  }
+
+  return value;
+}

--- a/src/shared/data-format.ts
+++ b/src/shared/data-format.ts
@@ -53,7 +53,7 @@ export function asHumanMem(val: number, digits = 0): string {
  * As frequency value rounded to an appropriate unit.
  */
 export function asHumanHz(val: number, digits = 0): string {
-  if (isNaN(val)) {
+  if (isNaN(val) || typeof val !== 'number') {
     return '';
   }
 


### PR DESCRIPTION
The rebench.dev errors logs show some invalid requests, which are now hopefully rejected earlier.
It also shows some issue in rendering a template because of an issue in asHumanHz where `h.toFixed` is not a function. I assume that's because `h` is of a wrong type somehow.