### PR TITLE
Implement #206: Add "Show More" for Table with Changes in Benchmark Set in Compare View

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ test.html
 /tests/data/expected-results/stats-data-prep/tsom/inline-[0-9][0-9].svg
 /tests/data/expected-results/stats-data-prep/tsom/inline-1[0-9][0-9].svg
 /tests/data/expected-results/stats-data-prep/tsom/inline-exe-*.svg
+
+# ignore developer-specific helper scripts
+/*.sh
+

--- a/resources/style.css
+++ b/resources/style.css
@@ -542,3 +542,45 @@ td.warmup-plot {
   z-index: 100;
   min-width: 250px;
 }
+
+.hidden {
+  display: none;
+}
+
+.showMore {
+  background-color: #007bff; 
+  color: #fff; 
+  border: none; 
+  padding: 10px 20px; 
+  font-size: 16px;
+  font-weight: bold;
+  border-radius: 5px; 
+  cursor: pointer; 
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.showMore:hover {
+  background-color: #0056b3;
+  color: #e0e0e0;
+}
+
+.showMore:focus {
+  outline: none;
+  box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+}
+
+.hidden {
+  display: none;
+}
+.collapsible {
+  cursor: pointer;
+  user-select: none;
+  color: #007bff;
+  text-decoration: underline;
+}
+.collapsible:after {
+  content: ' ▼';
+}
+.collapsible.active:after {
+  content: ' ▲';
+}

--- a/resources/style.css
+++ b/resources/style.css
@@ -543,44 +543,19 @@ td.warmup-plot {
   min-width: 250px;
 }
 
-.hidden {
-  display: none;
-}
-
-.showMore {
-  background-color: #007bff; 
-  color: #fff; 
-  border: none; 
-  padding: 10px 20px; 
-  font-size: 16px;
-  font-weight: bold;
-  border-radius: 5px; 
-  cursor: pointer; 
-  transition: background-color 0.3s ease, color 0.3s ease;
-}
-
-.showMore:hover {
-  background-color: #0056b3;
-  color: #e0e0e0;
-}
-
-.showMore:focus {
-  outline: none;
-  box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
-}
-
-.hidden {
-  display: none;
-}
-.collapsible {
+/* Make "Changes in Benchmark Set" Table Expandable */
+.table-expander td {
   cursor: pointer;
   user-select: none;
-  color: #007bff;
-  text-decoration: underline;
+  text-align: center;
 }
-.collapsible:after {
+.table-expander a:after {
   content: ' ▼';
 }
-.collapsible.active:after {
+.table-expander.active a:after {
   content: ' ▲';
+}
+
+table#benchmark-set-change tbody.hide-most-rows tr.benchmark-row:nth-child(n+4) {
+  display: none;
 }

--- a/src/backend/compare/html/index.html
+++ b/src/backend/compare/html/index.html
@@ -104,7 +104,7 @@
 
 {% if (it.notInBoth) { %}
 <h3>Changes in Benchmark Set</h3>
-<table class="table table-sm">
+<table class="table table-sm" id="benchmarkTable">
 <thead>
 <tr>
   <th scope="col">Commit</th>
@@ -117,9 +117,9 @@
   <th scope="col">Extra Arguments</th>
 </tr>
 </thead>
-<tbody>
+<tbody id="benchmarkTableBody">
 {% for (const m of it.stats.acrossVersions.missing) { %}
-  <tr>
+  <tr class="benchmark-row">
     <td>{%= m.commitId.substring(0, 6) %}</td>
     <td>{%= m.e %}</td>
     <td>{%= m.s %}</td>
@@ -132,6 +132,7 @@
 {% } %}
 </tbody>
 </table>
+<p class="collapsible">Show More</p>
 {% } %}
 
 {%- include('compare-versions.html', {...it.stats, config: it.config}) %}

--- a/src/backend/compare/html/index.html
+++ b/src/backend/compare/html/index.html
@@ -104,7 +104,7 @@
 
 {% if (it.notInBoth) { %}
 <h3>Changes in Benchmark Set</h3>
-<table class="table table-sm" id="benchmarkTable">
+<table class="table table-sm" id="benchmark-set-change">
 <thead>
 <tr>
   <th scope="col">Commit</th>
@@ -117,7 +117,7 @@
   <th scope="col">Extra Arguments</th>
 </tr>
 </thead>
-<tbody id="benchmarkTableBody">
+<tbody class="hide-most-rows">
 {% for (const m of it.stats.acrossVersions.missing) { %}
   <tr class="benchmark-row">
     <td>{%= m.commitId.substring(0, 6) %}</td>
@@ -130,9 +130,9 @@
     <td>{%= m.ea %}</td>
   </tr>
 {% } %}
+  <tr class="table-expander"><td colspan="8"><a href>show more</a></td></tr>
 </tbody>
 </table>
-<p class="collapsible">Show More</p>
 {% } %}
 
 {%- include('compare-versions.html', {...it.stats, config: it.config}) %}

--- a/src/frontend/compare.ts
+++ b/src/frontend/compare.ts
@@ -237,45 +237,18 @@ $(() => {
   $('.btn-warmup').on('click', insertWarmupPlot);
   $('.btn-profile').on('click', insertProfiles);
   $('.btn-timeline').on('click', insertTimeline);
-  $('.showMore').on('click', showAllResults);
 
-  $('.collapsible').click(function () {
-    $('.benchmark-row.hidden').toggleClass('hidden');
+  $('.table-expander').on('click', function (event) {
+    event.preventDefault();
+
+    $('table#benchmark-set-change tbody').toggleClass('hide-most-rows');
 
     $(this).toggleClass('active');
 
     const isActivated = $(this).hasClass('active');
-    $(this).text(isActivated ? 'Show Less' : 'Show More');
-
-    const table = document.getElementById('benchmarkTable');
-    const rows = table?.querySelectorAll('tr.benchmark-row');
-    const maxRows = 3;
-    let i = 0;
-    rows?.forEach((row) => {
-      const tableRow = row as HTMLTableRowElement;
-      if (isActivated || i < maxRows) {
-        tableRow.style.display = 'table-row';
-      } else {
-        tableRow.style.display = 'none';
-        window.scrollTo(0, 0);
-      }
-      i++;
-    });
-  });
-
-  const table = document.getElementById('benchmarkTable');
-  const rows = table?.querySelectorAll('tr.benchmark-row');
-  const maxRows = 3;
-  let i = 0;
-
-  rows?.forEach((row) => {
-    const tableRow = row as HTMLTableRowElement;
-    if (i < maxRows) {
-      tableRow.style.display = 'table-row';
-    } else {
-      tableRow.style.display = 'none';
-    }
-    i++;
+    $(this)
+      .find('a')
+      .text(isActivated ? 'show less' : 'show more');
   });
 
   const headlinesForTablesWithWarmupPlots = $('table:has(button.btn-warmup)')
@@ -298,19 +271,3 @@ $(() => {
 
   initializeFilters('.benchmark-details tbody th:nth-child(1)');
 });
-
-function showAllResults(event): void {
-  event.preventDefault();
-
-  const rows = document.querySelectorAll<HTMLTableRowElement>(
-    '#benchmarkTableBody .benchmark-row'
-  );
-  rows.forEach((row) => {
-    row.style.display = 'table-row';
-  });
-
-  const showMoreButton = document.getElementById('showMore');
-  if (showMoreButton) {
-    showMoreButton.style.display = 'none';
-  }
-}

--- a/src/frontend/compare.ts
+++ b/src/frontend/compare.ts
@@ -237,6 +237,46 @@ $(() => {
   $('.btn-warmup').on('click', insertWarmupPlot);
   $('.btn-profile').on('click', insertProfiles);
   $('.btn-timeline').on('click', insertTimeline);
+  $('.showMore').on('click', showAllResults);
+
+  $('.collapsible').click(function () {
+    $('.benchmark-row.hidden').toggleClass('hidden');
+
+    $(this).toggleClass('active');
+
+    const isActivated = $(this).hasClass('active');
+    $(this).text(isActivated ? 'Show Less' : 'Show More');
+
+    const table = document.getElementById('benchmarkTable');
+    const rows = table?.querySelectorAll('tr.benchmark-row');
+    const maxRows = 3;
+    let i = 0;
+    rows?.forEach((row) => {
+      const tableRow = row as HTMLTableRowElement;
+      if (isActivated || i < maxRows) {
+        tableRow.style.display = 'table-row';
+      } else {
+        tableRow.style.display = 'none';
+        window.scrollTo(0, 0);
+      }
+      i++;
+    });
+  });
+
+  const table = document.getElementById('benchmarkTable');
+  const rows = table?.querySelectorAll('tr.benchmark-row');
+  const maxRows = 3;
+  let i = 0;
+
+  rows?.forEach((row) => {
+    const tableRow = row as HTMLTableRowElement;
+    if (i < maxRows) {
+      tableRow.style.display = 'table-row';
+    } else {
+      tableRow.style.display = 'none';
+    }
+    i++;
+  });
 
   const headlinesForTablesWithWarmupPlots = $('table:has(button.btn-warmup)')
     .prev()
@@ -258,3 +298,19 @@ $(() => {
 
   initializeFilters('.benchmark-details tbody th:nth-child(1)');
 });
+
+function showAllResults(event): void {
+  event.preventDefault();
+
+  const rows = document.querySelectorAll<HTMLTableRowElement>(
+    '#benchmarkTableBody .benchmark-row'
+  );
+  rows.forEach((row) => {
+    row.style.display = 'table-row';
+  });
+
+  const showMoreButton = document.getElementById('showMore');
+  if (showMoreButton) {
+    showMoreButton.style.display = 'none';
+  }
+}


### PR DESCRIPTION
Improved the usability of the compare view by introducing a "Show More" link for the "Changes in Benchmark Set" table. Key enhancements include:

- **Initial Display**: The table now initially displays only 3 entries to prevent overwhelming the user with large datasets.
- **Show More Link**: Added a "Show More" link below the table, allowing users to expand and view all entries on demand.
- **CSS Class**: Introduced a `.hidden` class in `style.css` to manage the visibility of additional table rows.
- **JavaScript Function**: Implemented a `showAllResults` function to handle the display of all entries when the "Show More" link is clicked.