### PR TITLE
Update the redirect on refreshing a report to use the curent URL

### DIFF
--- a/Dockerfile.rebench
+++ b/Dockerfile.rebench
@@ -1,7 +1,7 @@
 # Used for benchmarking
 FROM rebenchdb-app:latest
 
-RUN apt-get install -y git python3-pip
+RUN apt-get update && apt-get install -y git python3-pip
 RUN pip install --break-system-packages git+https://github.com/smarr/ReBench.git
 
 RUN npm run pretest

--- a/src/backend/compare/compare.ts
+++ b/src/backend/compare/compare.ts
@@ -254,7 +254,7 @@ export async function deleteCachedReport(
         Change:   ${change}
         `;
     ctx.status = 303;
-    ctx.redirect(`/compare/${project}/${base}/${change}`);
+    ctx.redirect(`/${project}/compare/${base}..${change}`);
   } else {
     ctx.body = 'Incorrect authentication.';
     ctx.status = 403;


### PR DESCRIPTION
Previously, the refresh still used the old url, which used the project name instead of the slug that is now used consistently.

@F12-Syntex perhaps something that caused issues for you.