### PR TITLE
Fix order of most used sorting of branches

### DIFF
--- a/src/frontend/render.ts
+++ b/src/frontend/render.ts
@@ -220,7 +220,7 @@ function renderSidebar(
     switch (selectedOrder) {
       case 'Most Used': {
         branches.sort(
-          (a, b) => branchDetails.get(a)!.count - branchDetails.get(b)!.count
+          (a, b) => branchDetails.get(b)!.count - branchDetails.get(a)!.count
         );
         break;
       }


### PR DESCRIPTION
The ordering was switched, and showed least-used first.