### PR TITLE
Update Bootstrap to 5.3.3

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -175,7 +175,7 @@ main {
     display: none;
   }
   main {
-    max-width: 67%;
+    max-width: 67% !important;
   }
 }
 

--- a/src/backend/compare/html/gen-index.html
+++ b/src/backend/compare/html/gen-index.html
@@ -12,14 +12,14 @@
 <body class="compare timeline-multi">
 
 <header>
-<div class="jumbotron compare">
+<div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5 compare">
   <h2>ReBenchDB for {%= it.project %}</h2>
-  {% if (it.revisionFound) { %}
+{% if (it.revisionFound) { %}
   <h3>Comparing <a href="{%= it.base.repourl%}/compare/{%= it.baselineHash%}...{%= it.changeHash%}">{%= it.baselineHash6%} with {%= it.changeHash6%}</a></h3>
-  {% } else { %}
+{% } else { %}
   <h3>Comparing {%= it.baselineHash6%} with {%= it.changeHash6%}</h3>
-  {% } %}
-</div>
+{% } %}
+</div></div>
 </header>
 
 {% if (it.revisionFound) { %}

--- a/src/backend/compare/html/index.html
+++ b/src/backend/compare/html/index.html
@@ -18,14 +18,14 @@
 </svg>
 
 <header>
-<div class="jumbotron compare">
+<div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5 compare">
   <h2>ReBenchDB for {%= it.project %}</h2>
-  {% if (it.revisionFound) { %}
+{% if (it.revisionFound) { %}
   <h3>Comparing <a href="{%= it.base.repourl%}/compare/{%= it.baselineHash%}...{%= it.changeHash%}">{%= it.baselineHash6%} with {%= it.changeHash6%}</a></h3>
-  {% } else { %}
+{% } else { %}
   <h3>Comparing {%= it.baselineHash6%} with {%= it.changeHash6%}</h3>
-  {% } %}
-</div>
+{% } %}
+</div></div>
 
 {%- include('refresh-menu.html', it) %}
 </header>

--- a/src/backend/compare/html/refresh-menu.html
+++ b/src/backend/compare/html/refresh-menu.html
@@ -1,7 +1,7 @@
 <div class="refresh">
   <div class="flex-nowrap navbar-light">
     <button type="button" class="btn btn-outline-secondary btn-sm"
-        data-toggle="collapse" data-target="#filters" aria-controls="#filters"
+        data-bs-toggle="collapse" data-bs-target="#filters" aria-controls="#filters"
         aria-expanded="false" aria-label="Toggle Filters">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-funnel" viewBox="0 0 16 16">
         <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5v-2zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2h-11z"/>
@@ -13,8 +13,8 @@
         <path fill-rule="evenodd" d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5.002 5.002 0 0 0 8 3zM3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9H3.1z"/>
       </svg>
     </button>
-    <button class="navbar-toggler" type="button" data-toggle="collapse"
-        data-target="nav.compare" aria-controls="nav.compare"
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+        data-bs-target="nav.compare" aria-controls="nav.compare"
         aria-expanded="false" aria-label="Toggle Outline"
         id="report-nav-toggler">
       <span class="navbar-toggler-icon"></span>

--- a/src/backend/compare/html/stats-row-buttons-info.html
+++ b/src/backend/compare/html/stats-row-buttons-info.html
@@ -3,17 +3,17 @@ const d = it.details;
 const b = it.benchId;
 const f = it.dataFormatters;
 %}<button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>{%= d.cmdline %}</code>"></button>
+  data-bs-content="<code>{%= d.cmdline %}</code>"></button>
 {%
    if (it.environments) {
 %}<button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content="{%= f.formatEnvironment(d.envId, it.environments) %}"></button>
+    data-bs-content="{%= f.formatEnvironment(d.envId, it.environments) %}"></button>
 {% }
 
    if (d.hasWarmup) {
 %}<button type="button" class="btn btn-sm btn-light btn-warmup" data-content="{%= d.runId %}"></button>
 {%
-   } 
+   }
 
    if (d.profiles) {
 %}<button type="button" class="btn btn-sm btn-profile" data-content="{%= d.runId %}"></button>

--- a/src/backend/main/index.html
+++ b/src/backend/main/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 
-  <div class="jumbotron">
+  <div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5">
     <h1 class="display-4">ReBench</h1>
     <h2 class="display-5">Execute and document benchmarks reproducibly.</h2>
 
@@ -21,7 +21,7 @@
     <a href="https://github.com/smarr/ReBench"><img src="https://img.shields.io/badge/GitHub-ReBench-success"></a>
     <a href="https://github.com/smarr/ReBenchDB"><img src="https://img.shields.io/badge/GitHub-ReBenchDB-success"></a>
     <a href="https://rebench.readthedocs.io/"><img src="https://img.shields.io/badge/Documentation-Go-informational"></a>
-  </div>
+  </div></div>
 
   <div id="projects">
     {% for (const p of it.projects) { %}

--- a/src/backend/project/get-exp-data.html
+++ b/src/backend/project/get-exp-data.html
@@ -9,10 +9,10 @@
 </head>
 <body class="compare">
 
-<div class="jumbotron">
+<div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5">
   <h2>ReBenchDB for {%= it.project %}</h2>
   <h3>Preparing Data for download of {%= it.expName %}</h3>
-</div>
+</div></div>
 
 {% if (it.preparingData) { %}
 <div class="alert alert-secondary" role="alert">

--- a/src/backend/project/project-data.html
+++ b/src/backend/project/project-data.html
@@ -9,12 +9,12 @@
 </head>
 <body>
 
-  <div class="jumbotron">
+  <div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5">
     <h1 class="display-4">{%= it.project.name %}</h1>
     {% if (it.project.description) { %}
     <h2 class="display-5">{%= it.project.description %}</h2>
     {% } %}
-  </div>
+  </div></div>
 
   <div>
     <table class="table table-sm">

--- a/src/backend/project/project.html
+++ b/src/backend/project/project.html
@@ -10,12 +10,12 @@
 </head>
 <body class="project-body">
 
-  <div class="jumbotron">
+  <div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5">
     <h1 class="display-4">{%= it.name %}</h1>
     {% if (it.description) { %}
     <h2 class="display-5">{%= it.description%}</h2>
     {% } %}
-  </div>
+  </div></div>
 
   <div id="project">
     <div class="branch-sidebar left">

--- a/src/backend/timeline/timeline.html
+++ b/src/backend/timeline/timeline.html
@@ -11,7 +11,7 @@
 <body class="timeline-multi timeline">
 
 <header>
-  <div class="jumbotron">
+  <div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5">
     <h1 class="display-4">ReBench: Timeline {%= it.project.name %}</h1>
     {% if (it.project.description) { %}
     <h2 class="display-5">{%= it.project.description %}</h2>
@@ -19,7 +19,7 @@
        if (it.project.basebranch) { %}
     <p>Timeline is based on data for the <code>{%= it.project.basebranch %}</code> branch.</p>
     {% } %}
-  </div>
+  </div></div>
   <div class="refresh">
     <div class="flex-nowrap navbar-light">
       <button type="button" class="btn btn-outline-secondary btn-sm"
@@ -81,15 +81,14 @@
   </div></div> <!-- closing class="row flex-nowrap" and class="container-fluid" -->
   {% } else { %}
   <main role="main">
-  <div class="jumbotron">
+  <div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5">
     <h1 class="display-4">No Data Available</h1>
     {% if (it.project.basebranch) { %}
       <p class="lead">There are no benchmarks available for this project.</p>
     {% } else { %}
       <p class="lead">The branch to show on the timeline has not been configured. Please ask the ReBenchDB administrator to set the branch for the timeline view.</p>
     {% } %}
-  </div>
-  </div>
+  </div></div>
   </main>
   {% } %}
 </body>

--- a/src/backend/timeline/timeline.html
+++ b/src/backend/timeline/timeline.html
@@ -23,14 +23,14 @@
   <div class="refresh">
     <div class="flex-nowrap navbar-light">
       <button type="button" class="btn btn-outline-secondary btn-sm"
-          data-toggle="collapse" data-target="#filters" aria-controls="#filters"
+          data-bs-toggle="collapse" data-bs-target="#filters" aria-controls="#filters"
           aria-expanded="false" aria-label="Toggle Filters">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-funnel" viewBox="0 0 16 16">
           <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5v-2zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2h-11z"/>
         </svg>
       </button>
-      <button class="navbar-toggler" type="button" data-toggle="collapse"
-          data-target="nav.compare" aria-controls="nav.compare"
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+          data-bs-target="nav.compare" aria-controls="nav.compare"
           aria-expanded="false" aria-label="Toggle Outline"
           id="report-nav-toggler">
         <span class="navbar-toggler-icon"></span>

--- a/src/frontend/compare.ts
+++ b/src/frontend/compare.ts
@@ -79,7 +79,7 @@ function createEntry(e: string | ProfileElement, profId, counter) {
 
   if (hasTrace) {
     // eslint-disable-next-line max-len
-    entryHtml += `<a href="#${profId}-item-${counter.cnt}" data-toggle="collapse">`;
+    entryHtml += `<a href="#${profId}-item-${counter.cnt}" data-bs-toggle="collapse">`;
   } else {
     entryHtml += `<span>`;
   }

--- a/src/frontend/render.ts
+++ b/src/frontend/render.ts
@@ -4,7 +4,7 @@ import { renderResultsPlots } from './plots.js';
 
 export function filterCommitMessage(msg: string): string {
   const result = msg.replace(/Signed-off-by:.*?\n/g, '');
-  return result;
+  return result.trim();
 }
 
 function shortCommitId(commitId) {
@@ -33,16 +33,16 @@ export function expandMessage(event: any): void {
 }
 
 function formatCommitMessages(messages) {
-  messages = filterCommitMessage(messages);
-  const newLineIdx = messages.indexOf('\n');
+  const filteredMsg = filterCommitMessage(messages);
+  const newLineIdx = filteredMsg.indexOf('\n');
   if (newLineIdx > -1) {
-    const firstLine = messages.substring(0, newLineIdx);
+    const firstLine = filteredMsg.substring(0, newLineIdx);
     return (
-      `${firstLine} <a href="#" onclick="expandMessage(event)"` +
-      ` data-fulltext="${messages.replace('"', '\x22')}">&hellip;</a>`
+      `${firstLine} <a href="#"` +
+      ` data-fulltext="${filteredMsg.replace('"', '\x22')}">&hellip;</a>`
     );
   } else {
-    return messages;
+    return filteredMsg;
   }
 }
 
@@ -80,6 +80,7 @@ export function renderProjectDataOverview(
           <a rel="nofollow" href="/${pSlug}/data/${row.expid}.csv.gz">CSV</a>
         </td>
       </tr>`);
+    tBody.find('a').on('click', expandMessage);
   }
 
   if (!hasDesc) {

--- a/src/frontend/render.ts
+++ b/src/frontend/render.ts
@@ -108,7 +108,7 @@ function addChangesToList(
 
     const option = `<a class="list-group-item list-group-item-action
       list-min-padding"
-      data-toggle="list" data-hash="${change.commitid}" href="">
+      data-bs-toggle="list" data-hash="${change.commitid}" href="">
         <div class="exp-date" title="Experiment Start Date">${date}</div>
         ${change.commitid.substring(0, 6)} ${change.branchortag}<br>
         <div class="change-msg">${msg}</div>
@@ -266,7 +266,7 @@ function renderBranchList(
   for (const b of branches) {
     const $link = $(`<a
           class="list-group-item list-group-item-action list-min-padding"
-          data-toggle="list" data-branch="${b}" href>${b}</a>`);
+          data-bs-toggle="list" data-branch="${b}" href>${b}</a>`);
     $branchList.append($link);
   }
 

--- a/src/views/header.html
+++ b/src/views/header.html
@@ -2,10 +2,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 <!-- Bootstrap from CDN -->
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" referrerpolicy="no-referrer">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-<!-- <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script> -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js" integrity="sha512-2rNj2KJ+D8s1ceNasTIex6z4HWyOnEYLVC3FigGOmyQCZc2eBXKgOxQmo3oKLHyfcj53uz4QMsRCWNbLd32Q1g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
 <link rel="stylesheet" href="/static/style.css?v={%= it.rebenchVersion %}">

--- a/tests/data/expected-results/compare-view/compare-versions.html
+++ b/tests/data/expected-results/compare-view/compare-versions.html
@@ -31,9 +31,9 @@
 <td><span class="stats-median" title="median">222b</span></td>
 <td><span class="stats-change" title="diff %">64600</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-data-content="<code>som/some-command with args</code>"></button>
+data-bs-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
+data-bs-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button></td>

--- a/tests/data/expected-results/compare-view/stats-row-button-info.html
+++ b/tests/data/expected-results/compare-view/stats-row-button-info.html
@@ -1,7 +1,7 @@
 <button type="button" class="btn btn-sm btn-cmdline btn-popover"
-data-content="<code>som/some-command with args</code>"></button>
+data-bs-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
+data-bs-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button>

--- a/tests/data/expected-results/compare-view/stats-row-exe.html
+++ b/tests/data/expected-results/compare-view/stats-row-exe.html
@@ -35,9 +35,9 @@ ast
 <br><span class="stats-change" title="diff %">604600</span>
 </td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-data-content="<code>som/some-command with args</code>"></button>
+data-bs-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
+data-bs-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button></td>

--- a/tests/data/expected-results/compare-view/stats-row-version-one-criteria-missing.html
+++ b/tests/data/expected-results/compare-view/stats-row-version-one-criteria-missing.html
@@ -11,9 +11,9 @@
 <td><span class="stats-median" title="median">0.33</span></td>
 <td><span class="stats-change stats-total" title="diff %">54600</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-data-content="<code>som/some-command with args</code>"></button>
+data-bs-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
+data-bs-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button></td>

--- a/tests/data/expected-results/compare-view/stats-row-version.html
+++ b/tests/data/expected-results/compare-view/stats-row-version.html
@@ -10,9 +10,9 @@
 <td><span class="stats-median" title="median">222b</span></td>
 <td><span class="stats-change" title="diff %">64600</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-data-content="<code>som/some-command with args</code>"></button>
+data-bs-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
+data-bs-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button></td>

--- a/tests/data/expected-results/compare-view/stats-tbl.html
+++ b/tests/data/expected-results/compare-view/stats-tbl.html
@@ -26,9 +26,9 @@
 <td><span class="stats-median" title="median">222b</span></td>
 <td><span class="stats-change" title="diff %">64600</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-data-content="<code>som/some-command with args</code>"></button>
+data-bs-content="<code>som/some-command with args</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-data-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
+data-bs-content="MyHost | Linux | 121kb | Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz | 3GHz"></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-profile" data-content="1"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"my-benchmark","e":"exe1","s":"suite2"}'></button></td>

--- a/tests/data/expected-results/main/index.html
+++ b/tests/data/expected-results/main/index.html
@@ -5,16 +5,15 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <!-- Bootstrap from CDN -->
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" referrerpolicy="no-referrer">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-<!-- <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script> -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js" integrity="sha512-2rNj2KJ+D8s1ceNasTIex6z4HWyOnEYLVC3FigGOmyQCZc2eBXKgOxQmo3oKLHyfcj53uz4QMsRCWNbLd32Q1g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="/static/style.css?v=testVersion">
 <script src="/static/index.js" type="module"></script>
 </head>
 <body>
-<div class="jumbotron">
+<div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5">
 <h1 class="display-4">ReBench</h1>
 <h2 class="display-5">Execute and document benchmarks reproducibly.</h2>
 <p class="lead">ReBench is a tool to run and document benchmark experiments. Currently, it is mostly used for benchmarking language implementations, but it can be used to monitor the performance of all kinds of other applications and programs, too.</p>
@@ -26,7 +25,7 @@ Our focus is to facilitate the software engineering process with useful performa
 <a href="https://github.com/smarr/ReBench"><img src="https://img.shields.io/badge/GitHub-ReBench-success"></a>
 <a href="https://github.com/smarr/ReBenchDB"><img src="https://img.shields.io/badge/GitHub-ReBenchDB-success"></a>
 <a href="https://rebench.readthedocs.io/"><img src="https://img.shields.io/badge/Documentation-Go-informational"></a>
-</div>
+</div></div>
 <div id="projects">
 
 <div class="card project-data" data-id="1" data-showchanges="true" data-allresults="false">

--- a/tests/data/expected-results/project/get-exp-data.html
+++ b/tests/data/expected-results/project/get-exp-data.html
@@ -5,19 +5,18 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <!-- Bootstrap from CDN -->
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" referrerpolicy="no-referrer">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-<!-- <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script> -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js" integrity="sha512-2rNj2KJ+D8s1ceNasTIex6z4HWyOnEYLVC3FigGOmyQCZc2eBXKgOxQmo3oKLHyfcj53uz4QMsRCWNbLd32Q1g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="/static/style.css?v=testVersion">
 <meta http-equiv="refresh" content="10" />
 </head>
 <body class="compare">
-<div class="jumbotron">
+<div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5">
 <h2>ReBenchDB for Test Project</h2>
 <h3>Preparing Data for download of Test Experiment</h3>
-</div>
+</div></div>
 
 <div class="alert alert-secondary" role="alert">
 <h4 class="alert-heading">Data is currently being prepared for download</h4>

--- a/tests/data/expected-results/project/project-data.html
+++ b/tests/data/expected-results/project/project-data.html
@@ -7,21 +7,20 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <!-- Bootstrap from CDN -->
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" referrerpolicy="no-referrer">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-<!-- <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script> -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js" integrity="sha512-2rNj2KJ+D8s1ceNasTIex6z4HWyOnEYLVC3FigGOmyQCZc2eBXKgOxQmo3oKLHyfcj53uz4QMsRCWNbLd32Q1g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="/static/style.css?v=testVersion">
 <script src="/static/project-data.js" type="module"></script>
 </head>
 <body>
-<div class="jumbotron">
+<div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5">
 <h1 class="display-4">Test Project</h1>
 
 <h2 class="display-5">desc</h2>
 
-</div>
+</div></div>
 <div>
 <table class="table table-sm">
 <thead>

--- a/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
@@ -10,11 +10,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 <!-- Bootstrap from CDN -->
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" referrerpolicy="no-referrer">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-<!-- <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script> -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js" integrity="sha512-2rNj2KJ+D8s1ceNasTIex6z4HWyOnEYLVC3FigGOmyQCZc2eBXKgOxQmo3oKLHyfcj53uz4QMsRCWNbLd32Q1g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
 <link rel="stylesheet" href="/static/style.css?v=testVersion">
 
@@ -29,12 +28,12 @@
 </svg>
 
 <header>
-<div class="jumbotron compare">
+<div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5 compare">
   <h2>ReBenchDB for jssom</h2>
-  
+
   <h3>Comparing <a href="repo-url/compare/4dff7e...bc1105">4dff7e with bc1105</a></h3>
-  
-</div>
+
+</div></div>
 
 <div class="refresh">
   <div class="flex-nowrap navbar-light">

--- a/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-jssom.html
@@ -38,7 +38,7 @@
 <div class="refresh">
   <div class="flex-nowrap navbar-light">
     <button type="button" class="btn btn-outline-secondary btn-sm"
-        data-toggle="collapse" data-target="#filters" aria-controls="#filters"
+        data-bs-toggle="collapse" data-bs-target="#filters" aria-controls="#filters"
         aria-expanded="false" aria-label="Toggle Filters">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-funnel" viewBox="0 0 16 16">
         <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5v-2zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2h-11z"/>
@@ -50,8 +50,8 @@
         <path fill-rule="evenodd" d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5.002 5.002 0 0 0 8 3zM3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9H3.1z"/>
       </svg>
     </button>
-    <button class="navbar-toggler" type="button" data-toggle="collapse"
-        data-target="nav.compare" aria-controls="nav.compare"
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+        data-bs-target="nav.compare" aria-controls="nav.compare"
         aria-expanded="false" aria-label="Toggle Outline"
         id="report-nav-toggler">
       <span class="navbar-toggler-icon"></span>
@@ -159,9 +159,9 @@
 <td><span class="stats-median" title="median">90.54</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 10 0  50</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 10 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1979"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"som","s":"macro"}'></button>
 </td>
@@ -174,9 +174,9 @@
 <td><span class="stats-median" title="median">51.72</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 10 0  4</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 10 0  4</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1993"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"som","s":"macro"}'></button>
 </td>
@@ -189,9 +189,9 @@
 <td><span class="stats-median" title="median">126.04</span></td>
 <td><span class="stats-change stats-total" title="diff %">-7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som JsonSmall 10 0  1</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som JsonSmall 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1986"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"JsonSmall","e":"som","s":"macro"}'></button>
 </td>
@@ -204,9 +204,9 @@
 <td><span class="stats-median" title="median">81.38</span></td>
 <td><span class="stats-change stats-total" title="diff %">-10</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 10 0  500</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 10 0  500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1969"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"som","s":"macro"}'></button>
 </td>
@@ -219,9 +219,9 @@
 <td><span class="stats-median" title="median">208.31</span></td>
 <td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 10 0  40</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 10 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1992"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"som","s":"macro"}'></button>
 </td>
@@ -234,9 +234,9 @@
 <td><span class="stats-median" title="median">2589.35</span></td>
 <td><span class="stats-change stats-total" title="diff %">7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 10 0  1</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1994"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"som","s":"macro"}'></button>
 </td>
@@ -272,9 +272,9 @@
 <td><span class="stats-median" title="median">80.36</span></td>
 <td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 10 0  2</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1976"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"som","s":"micro"}'></button>
 </td>
@@ -287,9 +287,9 @@
 <td><span class="stats-median" title="median">127.88</span></td>
 <td><span class="stats-change stats-total" title="diff %">-4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 10 0  3</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1980"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"som","s":"micro"}'></button>
 </td>
@@ -302,9 +302,9 @@
 <td><span class="stats-median" title="median">70.81</span></td>
 <td><span class="stats-change stats-total" title="diff %">-13</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 10 0  2</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1981"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"som","s":"micro"}'></button>
 </td>
@@ -317,9 +317,9 @@
 <td><span class="stats-median" title="median">59.91</span></td>
 <td><span class="stats-change stats-total" title="diff %">5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 10 0  6</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 10 0  6</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1970"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"som","s":"micro"}'></button>
 </td>
@@ -332,9 +332,9 @@
 <td><span class="stats-median" title="median">263.34</span></td>
 <td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 10 0  3</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1971"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"som","s":"micro"}'></button>
 </td>
@@ -347,9 +347,9 @@
 <td><span class="stats-median" title="median">190.50</span></td>
 <td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 10 0  1</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1991"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"som","s":"micro"}'></button>
 </td>
@@ -362,9 +362,9 @@
 <td><span class="stats-median" title="median">149.09</span></td>
 <td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 10 0  2</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1983"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"som","s":"micro"}'></button>
 </td>
@@ -377,9 +377,9 @@
 <td><span class="stats-median" title="median">124.80</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 10 0  2</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1973"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"som","s":"micro"}'></button>
 </td>
@@ -392,9 +392,9 @@
 <td><span class="stats-median" title="median">164.68</span></td>
 <td><span class="stats-change stats-total" title="diff %">5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 10 0  5</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 10 0  5</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1985"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"som","s":"micro"}'></button>
 </td>
@@ -407,9 +407,9 @@
 <td><span class="stats-median" title="median">138.32</span></td>
 <td><span class="stats-change stats-total" title="diff %">-7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 10 0  30</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 10 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1988"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"som","s":"micro"}'></button>
 </td>
@@ -422,9 +422,9 @@
 <td><span class="stats-median" title="median">130.80</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 10 0  3</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1978"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"som","s":"micro"}'></button>
 </td>
@@ -437,9 +437,9 @@
 <td><span class="stats-median" title="median">100.68</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 10 0  2</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1982"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"som","s":"micro"}'></button>
 </td>
@@ -452,9 +452,9 @@
 <td><span class="stats-median" title="median">27.68</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 10 0  1</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1974"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"som","s":"micro"}'></button>
 </td>
@@ -467,9 +467,9 @@
 <td><span class="stats-median" title="median">147.77</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 10 0  3</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 10 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1989"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"som","s":"micro"}'></button>
 </td>
@@ -482,9 +482,9 @@
 <td><span class="stats-median" title="median">124.33</span></td>
 <td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 10 0  4</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 10 0  4</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1975"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"som","s":"micro"}'></button>
 </td>
@@ -497,9 +497,9 @@
 <td><span class="stats-median" title="median">34.65</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 10 0  1</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1990"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"som","s":"micro"}'></button>
 </td>
@@ -512,9 +512,9 @@
 <td><span class="stats-median" title="median">64.02</span></td>
 <td><span class="stats-change stats-total" title="diff %">5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 10 0  2</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1987"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"som","s":"micro"}'></button>
 </td>
@@ -527,9 +527,9 @@
 <td><span class="stats-median" title="median">176.06</span></td>
 <td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 10 0  2</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 10 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1984"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"som","s":"micro"}'></button>
 </td>
@@ -542,9 +542,9 @@
 <td><span class="stats-median" title="median">80.91</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 10 0  1</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 10 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1972"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"som","s":"micro"}'></button>
 </td>
@@ -557,9 +557,9 @@
 <td><span class="stats-median" title="median">92.95</span></td>
 <td><span class="stats-change stats-total" title="diff %">9</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 10 0  10</code>"></button>
+  data-bs-content="<code>som.sh -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 10 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1977"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"som","s":"micro"}'></button>
 </td>

--- a/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
@@ -38,7 +38,7 @@
 <div class="refresh">
   <div class="flex-nowrap navbar-light">
     <button type="button" class="btn btn-outline-secondary btn-sm"
-        data-toggle="collapse" data-target="#filters" aria-controls="#filters"
+        data-bs-toggle="collapse" data-bs-target="#filters" aria-controls="#filters"
         aria-expanded="false" aria-label="Toggle Filters">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-funnel" viewBox="0 0 16 16">
         <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5v-2zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2h-11z"/>
@@ -50,8 +50,8 @@
         <path fill-rule="evenodd" d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5.002 5.002 0 0 0 8 3zM3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9H3.1z"/>
       </svg>
     </button>
-    <button class="navbar-toggler" type="button" data-toggle="collapse"
-        data-target="nav.compare" aria-controls="nav.compare"
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+        data-bs-target="nav.compare" aria-controls="nav.compare"
         aria-expanded="false" aria-label="Toggle Outline"
         id="report-nav-toggler">
       <span class="navbar-toggler-icon"></span>
@@ -199,9 +199,9 @@
 <td><span class="stats-median" title="median">21624.67</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"SomSom-native-interp-ast","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -213,9 +213,9 @@
 <td><span class="stats-median" title="median">15196.07</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"SomSom-native-interp-ast","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -227,9 +227,9 @@
 <td><span class="stats-median" title="median">351.52</span></td>
 <td><span class="stats-change stats-total" title="diff %">-6</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  3</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"SomSom-native-interp-ast","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -241,9 +241,9 @@
 <td><span class="stats-median" title="median">14760.86</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"SomSom-native-interp-ast","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -255,9 +255,9 @@
 <td><span class="stats-median" title="median">13668.42</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"SomSom-native-interp-ast","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -292,9 +292,9 @@
 <td><span class="stats-median" title="median">28426.29</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"SomSom-native-interp-bc","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -306,9 +306,9 @@
 <td><span class="stats-median" title="median">19723.08</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"SomSom-native-interp-bc","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -320,9 +320,9 @@
 <td><span class="stats-median" title="median">456.26</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  3</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"SomSom-native-interp-bc","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -334,9 +334,9 @@
 <td><span class="stats-median" title="median">18868.32</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"SomSom-native-interp-bc","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -348,9 +348,9 @@
 <td><span class="stats-median" title="median">18004.65</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"SomSom-native-interp-bc","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -385,9 +385,9 @@
 <td><span class="stats-median" title="median">275.04</span></td>
 <td><span class="stats-change stats-total" title="diff %">9</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"TruffleSOM-graal","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -399,9 +399,9 @@
 <td><span class="stats-median" title="median">182.46</span></td>
 <td><span class="stats-change stats-total" title="diff %">-8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"TruffleSOM-graal","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -413,9 +413,9 @@
 <td><span class="stats-median" title="median">253.06</span></td>
 <td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Json","e":"TruffleSOM-graal","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -427,9 +427,9 @@
 <td><span class="stats-median" title="median">132.49</span></td>
 <td><span class="stats-change stats-total" title="diff %">-14</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"TruffleSOM-graal","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -441,9 +441,9 @@
 <td><span class="stats-median" title="median">159.80</span></td>
 <td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"TruffleSOM-graal","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -478,9 +478,9 @@
 <td><span class="stats-median" title="median">49.53</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1076"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
@@ -493,9 +493,9 @@
 <td><span class="stats-median" title="median">71.07</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1087"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
@@ -508,9 +508,9 @@
 <td><span class="stats-median" title="median">105.25</span></td>
 <td><span class="stats-change stats-total" title="diff %">-5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="553"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Json","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
@@ -523,9 +523,9 @@
 <td><span class="stats-median" title="median">70.04</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1070"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
@@ -538,9 +538,9 @@
 <td><span class="stats-median" title="median">114.29</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1089"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
@@ -553,9 +553,9 @@
 <td><span class="stats-median" title="median">99.78</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="1068"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
@@ -591,9 +591,9 @@
 <td><span class="stats-median" title="median">151.69</span></td>
 <td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -605,9 +605,9 @@
 <td><span class="stats-median" title="median">129.31</span></td>
 <td><span class="stats-change stats-total" title="diff %">-8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -619,9 +619,9 @@
 <td><span class="stats-median" title="median">100.84</span></td>
 <td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -633,9 +633,9 @@
 <td><span class="stats-median" title="median">134.85</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -647,9 +647,9 @@
 <td><span class="stats-median" title="median">47.32</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -661,9 +661,9 @@
 <td><span class="stats-median" title="median">89.40</span></td>
 <td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -675,9 +675,9 @@
 <td><span class="stats-median" title="median">80.21</span></td>
 <td><span class="stats-change stats-total" title="diff %">7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -689,9 +689,9 @@
 <td><span class="stats-median" title="median">88.65</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -703,9 +703,9 @@
 <td><span class="stats-median" title="median">123.19</span></td>
 <td><span class="stats-change stats-total" title="diff %">9</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -717,9 +717,9 @@
 <td><span class="stats-median" title="median">145.52</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -731,9 +731,9 @@
 <td><span class="stats-median" title="median">119.00</span></td>
 <td><span class="stats-change stats-total" title="diff %">-9</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -745,9 +745,9 @@
 <td><span class="stats-median" title="median">185.47</span></td>
 <td><span class="stats-change stats-total" title="diff %">8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -759,9 +759,9 @@
 <td><span class="stats-median" title="median">128.25</span></td>
 <td><span class="stats-change stats-total" title="diff %">11</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -773,9 +773,9 @@
 <td><span class="stats-median" title="median">132.23</span></td>
 <td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -787,9 +787,9 @@
 <td><span class="stats-median" title="median">158.52</span></td>
 <td><span class="stats-change stats-total" title="diff %">14</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -801,9 +801,9 @@
 <td><span class="stats-median" title="median">80.63</span></td>
 <td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -815,9 +815,9 @@
 <td><span class="stats-median" title="median">140.07</span></td>
 <td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -829,9 +829,9 @@
 <td><span class="stats-median" title="median">156.97</span></td>
 <td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -843,9 +843,9 @@
 <td><span class="stats-median" title="median">67.42</span></td>
 <td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -880,9 +880,9 @@
 <td><span class="stats-median" title="median">139.58</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="606"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -895,9 +895,9 @@
 <td><span class="stats-median" title="median">83.49</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="615"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -910,9 +910,9 @@
 <td><span class="stats-median" title="median">223.33</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="579"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -925,9 +925,9 @@
 <td><span class="stats-median" title="median">46.52</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="582"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -940,9 +940,9 @@
 <td><span class="stats-median" title="median">85.58</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="604"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -955,9 +955,9 @@
 <td><span class="stats-median" title="median">240.07</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="595"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -970,9 +970,9 @@
 <td><span class="stats-median" title="median">155.00</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="577"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -985,9 +985,9 @@
 <td><span class="stats-median" title="median">105.67</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="576"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1000,9 +1000,9 @@
 <td><span class="stats-median" title="median">2.41</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="589"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1015,9 +1015,9 @@
 <td><span class="stats-median" title="median">358.87</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="596"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1030,9 +1030,9 @@
 <td><span class="stats-median" title="median">135.55</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="586"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1045,9 +1045,9 @@
 <td><span class="stats-median" title="median">119.42</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="597"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1060,9 +1060,9 @@
 <td><span class="stats-median" title="median">121.89</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="599"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1075,9 +1075,9 @@
 <td><span class="stats-median" title="median">122.70</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="610"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1090,9 +1090,9 @@
 <td><span class="stats-median" title="median">100.75</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="614"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1105,9 +1105,9 @@
 <td><span class="stats-median" title="median">97.29</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="612"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1120,9 +1120,9 @@
 <td><span class="stats-median" title="median">250.33</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="594"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1135,9 +1135,9 @@
 <td><span class="stats-median" title="median">343.36</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="605"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1150,9 +1150,9 @@
 <td><span class="stats-median" title="median">154.65</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="611"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1165,9 +1165,9 @@
 <td><span class="stats-median" title="median">181.69</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="584"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
@@ -1203,9 +1203,9 @@
 <td><span class="stats-median" title="median">292.45</span></td>
 <td><span class="stats-change stats-total" title="diff %">15</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"TruffleSOM-graal-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -1217,9 +1217,9 @@
 <td><span class="stats-median" title="median">212.70</span></td>
 <td><span class="stats-change stats-total" title="diff %">6</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"TruffleSOM-graal-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -1231,9 +1231,9 @@
 <td><span class="stats-median" title="median">254.33</span></td>
 <td><span class="stats-change stats-total" title="diff %">-10</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Json","e":"TruffleSOM-graal-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -1245,9 +1245,9 @@
 <td><span class="stats-median" title="median">172.67</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"TruffleSOM-graal-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -1259,9 +1259,9 @@
 <td><span class="stats-median" title="median">287.66</span></td>
 <td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"TruffleSOM-graal-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -1273,9 +1273,9 @@
 <td><span class="stats-median" title="median">689.30</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"TruffleSOM-graal-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -1310,9 +1310,9 @@
 <td><span class="stats-median" title="median">160.50</span></td>
 <td><span class="stats-change stats-total" title="diff %">5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2214"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
@@ -1325,9 +1325,9 @@
 <td><span class="stats-median" title="median">72.17</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2208"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
@@ -1340,9 +1340,9 @@
 <td><span class="stats-median" title="median">111.11</span></td>
 <td><span class="stats-change stats-total" title="diff %">-6</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2205"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Json","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
@@ -1355,9 +1355,9 @@
 <td><span class="stats-median" title="median">61.05</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2212"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
@@ -1370,9 +1370,9 @@
 <td><span class="stats-median" title="median">107.50</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2202"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
@@ -1385,9 +1385,9 @@
 <td><span class="stats-median" title="median">97.56</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2207"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"TruffleSOM-graal-bc","s":"macro-steady"}'></button>
 </td>
@@ -1423,9 +1423,9 @@
 <td><span class="stats-median" title="median">163.67</span></td>
 <td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1437,9 +1437,9 @@
 <td><span class="stats-median" title="median">141.15</span></td>
 <td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1451,9 +1451,9 @@
 <td><span class="stats-median" title="median">115.17</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1465,9 +1465,9 @@
 <td><span class="stats-median" title="median">194.92</span></td>
 <td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1479,9 +1479,9 @@
 <td><span class="stats-median" title="median">231.00</span></td>
 <td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1493,9 +1493,9 @@
 <td><span class="stats-median" title="median">65.15</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1507,9 +1507,9 @@
 <td><span class="stats-median" title="median">228.15</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1521,9 +1521,9 @@
 <td><span class="stats-median" title="median">76.16</span></td>
 <td><span class="stats-change stats-total" title="diff %">17</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1535,9 +1535,9 @@
 <td><span class="stats-median" title="median">118.13</span></td>
 <td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1549,9 +1549,9 @@
 <td><span class="stats-median" title="median">244.78</span></td>
 <td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1563,9 +1563,9 @@
 <td><span class="stats-median" title="median">189.32</span></td>
 <td><span class="stats-change stats-total" title="diff %">-29</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1577,9 +1577,9 @@
 <td><span class="stats-median" title="median">186.72</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1591,9 +1591,9 @@
 <td><span class="stats-median" title="median">239.84</span></td>
 <td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1605,9 +1605,9 @@
 <td><span class="stats-median" title="median">144.41</span></td>
 <td><span class="stats-change stats-total" title="diff %">9</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1619,9 +1619,9 @@
 <td><span class="stats-median" title="median">172.03</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1633,9 +1633,9 @@
 <td><span class="stats-median" title="median">179.38</span></td>
 <td><span class="stats-change stats-total" title="diff %">4</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1647,9 +1647,9 @@
 <td><span class="stats-median" title="median">110.34</span></td>
 <td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1661,9 +1661,9 @@
 <td><span class="stats-median" title="median">178.94</span></td>
 <td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1675,9 +1675,9 @@
 <td><span class="stats-median" title="median">217.42</span></td>
 <td><span class="stats-change stats-total" title="diff %">14</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1689,9 +1689,9 @@
 <td><span class="stats-median" title="median">225.86</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -1726,9 +1726,9 @@
 <td><span class="stats-median" title="median">216.01</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2204"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1741,9 +1741,9 @@
 <td><span class="stats-median" title="median">78.22</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2211"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1756,9 +1756,9 @@
 <td><span class="stats-median" title="median">196.97</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2219"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1771,9 +1771,9 @@
 <td><span class="stats-median" title="median">195.80</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2209"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1786,9 +1786,9 @@
 <td><span class="stats-median" title="median">116.58</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2222"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1801,9 +1801,9 @@
 <td><span class="stats-median" title="median">239.91</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2206"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1816,9 +1816,9 @@
 <td><span class="stats-median" title="median">268.56</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2217"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1831,9 +1831,9 @@
 <td><span class="stats-median" title="median">101.37</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2201"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1846,9 +1846,9 @@
 <td><span class="stats-median" title="median">175.47</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2210"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1861,9 +1861,9 @@
 <td><span class="stats-median" title="median">394.93</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2220"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1876,9 +1876,9 @@
 <td><span class="stats-median" title="median">424.57</span></td>
 <td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2225"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1891,9 +1891,9 @@
 <td><span class="stats-median" title="median">106.88</span></td>
 <td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2221"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1906,9 +1906,9 @@
 <td><span class="stats-median" title="median">246.59</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2213"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1921,9 +1921,9 @@
 <td><span class="stats-median" title="median">138.64</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2203"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1936,9 +1936,9 @@
 <td><span class="stats-median" title="median">102.64</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2224"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1951,9 +1951,9 @@
 <td><span class="stats-median" title="median">197.72</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2218"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1966,9 +1966,9 @@
 <td><span class="stats-median" title="median">190.78</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2215"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1981,9 +1981,9 @@
 <td><span class="stats-median" title="median">335.06</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2226"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -1996,9 +1996,9 @@
 <td><span class="stats-median" title="median">159.52</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2223"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -2011,9 +2011,9 @@
 <td><span class="stats-median" title="median">787.93</span></td>
 <td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-light btn-warmup" data-content="2216"></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-graal-bc","s":"micro-steady"}'></button>
 </td>
@@ -2049,9 +2049,9 @@
 <td><span class="stats-median" title="median">357.33</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"TruffleSOM-interp","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2086,9 +2086,9 @@
 <td><span class="stats-median" title="median">123.53</span></td>
 <td><span class="stats-change stats-total" title="diff %">-7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-interp","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2123,9 +2123,9 @@
 <td><span class="stats-median" title="median">71.54</span></td>
 <td><span class="stats-change stats-total" title="diff %">8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"TruffleSOM-native-interp-ast","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2137,9 +2137,9 @@
 <td><span class="stats-median" title="median">59.00</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"TruffleSOM-native-interp-ast","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2151,9 +2151,9 @@
 <td><span class="stats-median" title="median">158.93</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Json","e":"TruffleSOM-native-interp-ast","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2165,9 +2165,9 @@
 <td><span class="stats-median" title="median">69.55</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"TruffleSOM-native-interp-ast","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2179,9 +2179,9 @@
 <td><span class="stats-median" title="median">64.81</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"TruffleSOM-native-interp-ast","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2193,9 +2193,9 @@
 <td><span class="stats-median" title="median">412.86</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"TruffleSOM-native-interp-ast","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2230,9 +2230,9 @@
 <td><span class="stats-median" title="median">87.33</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2244,9 +2244,9 @@
 <td><span class="stats-median" title="median">70.28</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2258,9 +2258,9 @@
 <td><span class="stats-median" title="median">64.68</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2272,9 +2272,9 @@
 <td><span class="stats-median" title="median">44.35</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2286,9 +2286,9 @@
 <td><span class="stats-median" title="median">60.74</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2300,9 +2300,9 @@
 <td><span class="stats-median" title="median">34.76</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2314,9 +2314,9 @@
 <td><span class="stats-median" title="median">55.56</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2328,9 +2328,9 @@
 <td><span class="stats-median" title="median">19.29</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2342,9 +2342,9 @@
 <td><span class="stats-median" title="median">122.04</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2356,9 +2356,9 @@
 <td><span class="stats-median" title="median">105.75</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2370,9 +2370,9 @@
 <td><span class="stats-median" title="median">107.63</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2384,9 +2384,9 @@
 <td><span class="stats-median" title="median">67.01</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2398,9 +2398,9 @@
 <td><span class="stats-median" title="median">92.15</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2412,9 +2412,9 @@
 <td><span class="stats-median" title="median">61.08</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2426,9 +2426,9 @@
 <td><span class="stats-median" title="median">91.75</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2440,9 +2440,9 @@
 <td><span class="stats-median" title="median">68.34</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2454,9 +2454,9 @@
 <td><span class="stats-median" title="median">142.33</span></td>
 <td><span class="stats-change stats-total" title="diff %">8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2468,9 +2468,9 @@
 <td><span class="stats-median" title="median">45.54</span></td>
 <td><span class="stats-change stats-total" title="diff %">-8</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2482,9 +2482,9 @@
 <td><span class="stats-median" title="median">57.86</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2496,9 +2496,9 @@
 <td><span class="stats-median" title="median">84.46</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-native-interp-ast","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2533,9 +2533,9 @@
 <td><span class="stats-median" title="median">76.58</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"TruffleSOM-native-interp-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2547,9 +2547,9 @@
 <td><span class="stats-median" title="median">69.81</span></td>
 <td><span class="stats-change stats-total" title="diff %">3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"TruffleSOM-native-interp-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2561,9 +2561,9 @@
 <td><span class="stats-median" title="median">153.97</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Json","e":"TruffleSOM-native-interp-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2575,9 +2575,9 @@
 <td><span class="stats-median" title="median">81.59</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"TruffleSOM-native-interp-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2589,9 +2589,9 @@
 <td><span class="stats-median" title="median">105.03</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"TruffleSOM-native-interp-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2603,9 +2603,9 @@
 <td><span class="stats-median" title="median">624.07</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"TruffleSOM-native-interp-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -2640,9 +2640,9 @@
 <td><span class="stats-median" title="median">89.81</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2654,9 +2654,9 @@
 <td><span class="stats-median" title="median">95.55</span></td>
 <td><span class="stats-change stats-total" title="diff %">-7</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2668,9 +2668,9 @@
 <td><span class="stats-median" title="median">123.38</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2682,9 +2682,9 @@
 <td><span class="stats-median" title="median">71.65</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2696,9 +2696,9 @@
 <td><span class="stats-median" title="median">139.68</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2710,9 +2710,9 @@
 <td><span class="stats-median" title="median">22.88</span></td>
 <td><span class="stats-change stats-total" title="diff %">12</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2724,9 +2724,9 @@
 <td><span class="stats-median" title="median">150.75</span></td>
 <td><span class="stats-change stats-total" title="diff %">6</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2738,9 +2738,9 @@
 <td><span class="stats-median" title="median">22.22</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2752,9 +2752,9 @@
 <td><span class="stats-median" title="median">528.11</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2766,9 +2766,9 @@
 <td><span class="stats-median" title="median">124.67</span></td>
 <td><span class="stats-change stats-total" title="diff %">-2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2780,9 +2780,9 @@
 <td><span class="stats-median" title="median">129.47</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2794,9 +2794,9 @@
 <td><span class="stats-median" title="median">118.02</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2808,9 +2808,9 @@
 <td><span class="stats-median" title="median">89.83</span></td>
 <td><span class="stats-change stats-total" title="diff %">-3</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2822,9 +2822,9 @@
 <td><span class="stats-median" title="median">76.64</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2836,9 +2836,9 @@
 <td><span class="stats-median" title="median">115.01</span></td>
 <td><span class="stats-change stats-total" title="diff %">-1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2850,9 +2850,9 @@
 <td><span class="stats-median" title="median">77.53</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2864,9 +2864,9 @@
 <td><span class="stats-median" title="median">254.49</span></td>
 <td><span class="stats-change stats-total" title="diff %">1</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2878,9 +2878,9 @@
 <td><span class="stats-median" title="median">69.94</span></td>
 <td><span class="stats-change stats-total" title="diff %">2</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2892,9 +2892,9 @@
 <td><span class="stats-median" title="median">79.03</span></td>
 <td><span class="stats-change stats-total" title="diff %">0</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2906,9 +2906,9 @@
 <td><span class="stats-median" title="median">92.71</span></td>
 <td><span class="stats-change stats-total" title="diff %">-5</span></td>
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
+  data-bs-content="<code>som-native-interp-bc -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-native-interp-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -2960,9 +2960,9 @@ ast
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"SomSom-native-interp-ast","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -2988,9 +2988,9 @@ ast
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"SomSom-native-interp-ast","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -3016,9 +3016,9 @@ ast
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  3</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  3</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"SomSom-native-interp-ast","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -3044,9 +3044,9 @@ ast
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"SomSom-native-interp-ast","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -3072,9 +3072,9 @@ ast
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  1</code>"></button>
+  data-bs-content="<code>som-native-interp-ast -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"SomSom-native-interp-ast","s":"micro-somsom"}'></button>
 </td>
 </tr>
@@ -3129,9 +3129,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"TruffleSOM-graal","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -3165,9 +3165,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"TruffleSOM-graal","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -3201,9 +3201,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Json","e":"TruffleSOM-graal","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -3237,9 +3237,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 1 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"TruffleSOM-graal","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -3273,9 +3273,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 1 0  75</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"TruffleSOM-graal","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -3309,9 +3309,9 @@ graal-bc
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"TruffleSOM-graal-bc","s":"macro-startup"}'></button>
 </td>
 </tr>
@@ -3358,9 +3358,9 @@ graal-bc
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som DeltaBlue 120 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"DeltaBlue","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -3386,9 +3386,9 @@ graal-bc
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som GraphSearch 250 0  25</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"GraphSearch","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -3414,9 +3414,9 @@ graal-bc
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Json 120 0  80</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Json","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -3442,9 +3442,9 @@ graal-bc
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som NBody 120 0  200000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"NBody","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -3470,9 +3470,9 @@ graal-bc
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som PageRank 120 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"PageRank","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -3498,9 +3498,9 @@ graal-bc
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som Richards 130 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Richards","e":"TruffleSOM-graal","s":"macro-steady"}'></button>
 </td>
 </tr>
@@ -3555,9 +3555,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3591,9 +3591,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3627,9 +3627,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3663,9 +3663,9 @@ graal-bc
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
+  data-bs-content="<code>som  -Dsom.interp=BC  -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-graal-bc","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3699,9 +3699,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3735,9 +3735,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 1 0  1</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3771,9 +3771,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3807,9 +3807,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3843,9 +3843,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 1 0  100</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3879,9 +3879,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 1 0  50</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3915,9 +3915,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3951,9 +3951,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 1 0  10</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -3987,9 +3987,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 1 0  15</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -4023,9 +4023,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 1 0  12</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -4059,9 +4059,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 1 0  20</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -4095,9 +4095,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 1 0  8</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -4131,9 +4131,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 1 0  40</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -4167,9 +4167,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 1 0  2</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -4203,9 +4203,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 1 0  7</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -4239,9 +4239,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 1 0  30</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-graal","s":"micro-startup"}'></button>
 </td>
 </tr>
@@ -4288,9 +4288,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Bounce 60 0  4000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Bounce","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4316,9 +4316,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som BubbleSort 55 0  3000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"BubbleSort","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4344,9 +4344,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Dispatch 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Dispatch","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4372,9 +4372,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fannkuch 55 0  9</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fannkuch","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4400,9 +4400,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Fibonacci 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Fibonacci","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4428,9 +4428,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som FieldLoop 55 0  900</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"FieldLoop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4456,9 +4456,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som IntegerLoop 55 0  8000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"IntegerLoop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4484,9 +4484,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som List 65 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"List","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4512,9 +4512,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Loop 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Loop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4540,9 +4540,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Mandelbrot 110 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Mandelbrot","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4568,9 +4568,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Permute 55 0  1500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Permute","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4596,9 +4596,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Queens 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Queens","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4624,9 +4624,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som QuickSort 55 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"QuickSort","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4652,9 +4652,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Recurse 65 0  2000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Recurse","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4680,9 +4680,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sieve 60 0  2500</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sieve","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4708,9 +4708,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Storage 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Storage","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4736,9 +4736,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Sum 55 0  10000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Sum","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4764,9 +4764,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som Towers 55 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"Towers","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4792,9 +4792,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som TreeSort 60 0  1000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"TreeSort","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>
@@ -4820,9 +4820,9 @@ graal
 </td>
 
 <td><button type="button" class="btn btn-sm btn-cmdline btn-popover"
-  data-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>
+  data-bs-content="<code>som -cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som WhileLoop 55 0  9000</code>"></button>
 <button type="button" class="btn btn-sm btn-environment btn-popover"
-    data-content=""></button>
+    data-bs-content=""></button>
 <button type="button" class="btn btn-sm btn-timeline" data-content='{"b":"WhileLoop","e":"TruffleSOM-graal","s":"micro-steady"}'></button>
 </td>
 </tr>

--- a/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
+++ b/tests/data/expected-results/stats-data-prep/compare-view-tsom.html
@@ -10,11 +10,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 <!-- Bootstrap from CDN -->
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" referrerpolicy="no-referrer">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-<!-- <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script> -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js" integrity="sha512-2rNj2KJ+D8s1ceNasTIex6z4HWyOnEYLVC3FigGOmyQCZc2eBXKgOxQmo3oKLHyfcj53uz4QMsRCWNbLd32Q1g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
 <link rel="stylesheet" href="/static/style.css?v=testVersion">
 
@@ -29,12 +28,12 @@
 </svg>
 
 <header>
-<div class="jumbotron compare">
+<div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5 compare">
   <h2>ReBenchDB for tsom</h2>
-  
+
   <h3>Comparing <a href="repo-url/compare/5820ec...5fa4bd">5820ec with 5fa4bd</a></h3>
-  
-</div>
+
+</div></div>
 
 <div class="refresh">
   <div class="flex-nowrap navbar-light">

--- a/tests/data/expected-results/timeline/index.html
+++ b/tests/data/expected-results/timeline/index.html
@@ -7,23 +7,22 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <!-- Bootstrap from CDN -->
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" referrerpolicy="no-referrer">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-<!-- <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script> -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js" integrity="sha512-2rNj2KJ+D8s1ceNasTIex6z4HWyOnEYLVC3FigGOmyQCZc2eBXKgOxQmo3oKLHyfcj53uz4QMsRCWNbLd32Q1g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="/static/style.css?v=testVersion">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.appear/0.4.1/jquery.appear.min.js" integrity="sha256-19/eyBKQKb8IPrt7321hbLkI1+xyM8d/DpzjyiEKnCE=" crossorigin="anonymous"></script>
 <script src="/static/timeline.js" type="module"></script>
 </head>
 <body class="timeline-multi timeline">
 <header>
-<div class="jumbotron">
+<div class="p-4 mb-4 bg-light rounded-2"><div class="container-fluid py-5">
 <h1 class="display-4">ReBench: Timeline Small Example Project</h1>
 
 <p>Timeline is based on data for the <code>HEAD -&gt; rebenchdb, smarr/rebenchdb</code> branch.</p>
 
-</div>
+</div></div>
 <div class="refresh">
 <div class="flex-nowrap navbar-light">
 <button type="button" class="btn btn-outline-secondary btn-sm"

--- a/tests/data/expected-results/timeline/index.html
+++ b/tests/data/expected-results/timeline/index.html
@@ -26,14 +26,14 @@
 <div class="refresh">
 <div class="flex-nowrap navbar-light">
 <button type="button" class="btn btn-outline-secondary btn-sm"
-data-toggle="collapse" data-target="#filters" aria-controls="#filters"
+data-bs-toggle="collapse" data-bs-target="#filters" aria-controls="#filters"
 aria-expanded="false" aria-label="Toggle Filters">
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-funnel" viewBox="0 0 16 16">
 <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5v-2zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2h-11z"/>
 </svg>
 </button>
-<button class="navbar-toggler" type="button" data-toggle="collapse"
-data-target="nav.compare" aria-controls="nav.compare"
+<button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+data-bs-target="nav.compare" aria-controls="nav.compare"
 aria-expanded="false" aria-label="Toggle Outline"
 id="report-nav-toggler">
 <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
This PR updates the Bootstrap version to the latest available version.
To make this work, I need to:
 - replace the removed jumbotron with a custom verion
 - use namespaced data attributes (data-bs-toggle, data-bs-target, data-bs-content) where I use features such as collapse, list, and popover.
 - adapt CSS for 2/3 width to work with new version
 
Additionally, I fixed an issue with the commit message expansion on the data papge.