### PR TITLE
Issue #222: Expressions inside angle brackets in commit names get removed

### DIFF
--- a/src/frontend/render.ts
+++ b/src/frontend/render.ts
@@ -4,8 +4,9 @@ import { renderResultsPlots } from './plots.js';
 
 export function filterCommitMessage(msg: string): string {
   const result = msg
+    .normalize() // normalise Unicode first
     .replace(/Signed-off-by:.*?\n/g, '')
-    .replace(/&/g, '&amp;')
+    .replace(/&/g, '&amp;') // & must be first
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')

--- a/src/frontend/render.ts
+++ b/src/frontend/render.ts
@@ -3,7 +3,13 @@ import type { ChangesResponse, ChangesRow } from '../shared/view-types.js';
 import { renderResultsPlots } from './plots.js';
 
 export function filterCommitMessage(msg: string): string {
-  const result = msg.replace(/Signed-off-by:.*?\n/g, '');
+  const result = msg
+    .replace(/Signed-off-by:.*?\n/g, '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
   return result.trim();
 }
 

--- a/tests/frontend/render.test.ts
+++ b/tests/frontend/render.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from '@jest/globals';
+import { filterCommitMessage } from '../../src/frontend/render.js';
+
+describe('filterCommitMessage(msg: string)', () => {
+  describe('removal of sign off lines', () => {
+    it('should remove a sign off line', () => {
+      const msg = `This is a message\n\nSigned-off-by: J.D. <jd@ex.com>\n`;
+      const expected = `This is a message`;
+      expect(filterCommitMessage(msg)).toBe(expected);
+    });
+
+    it('should remove multiple sign off lines', () => {
+      const msg = `This is a message
+
+      Signed-off-by: J.D. <jd@ex.com>\n
+      Signed-off-by: A.B. <ab@ex.com>\n`;
+      const expected = `This is a message`;
+      expect(filterCommitMessage(msg)).toBe(expected);
+    });
+  });
+});

--- a/tests/frontend/render.test.ts
+++ b/tests/frontend/render.test.ts
@@ -18,4 +18,26 @@ describe('filterCommitMessage(msg: string)', () => {
       expect(filterCommitMessage(msg)).toBe(expected);
     });
   });
+
+  describe('escaping of html characters', () => {
+    it('should escape html characters <, >', () => {
+      const msg = `This is a message with <html> characters`;
+      const expected = `This is a message with &lt;html&gt; characters`;
+      expect(filterCommitMessage(msg)).toBe(expected);
+    });
+
+    it('should escape html characters ", \' and &', () => {
+      const msg = `Message with ", ' and &`;
+      const expected = `Message with &quot;, &#39; and &amp;`;
+      expect(filterCommitMessage(msg)).toBe(expected);
+    });
+  });
+
+  describe('normal messages', () => {
+    it('should leave a normal message unchanged', () => {
+      const msg = `Normal message with no special handling needed.`;
+      const expected = `Normal message with no special handling needed.`;
+      expect(filterCommitMessage(msg)).toBe(expected);
+    });
+  });
 });


### PR DESCRIPTION
Special HTML-Characters (&, <, >, ", ') are now replaced/escaped.