### PR TITLE
Use int for FKs for runId and trialId

### DIFF
--- a/src/backend/db/db.sql
+++ b/src/backend/db/db.sql
@@ -150,8 +150,8 @@ CREATE TABLE Run (
 
 -- One value for one specific criterion.
 CREATE TABLE Measurement (
-  runId smallint,
-  trialId smallint,
+  runId int,
+  trialId int,
   criterion smallint,
   invocation smallint,
 
@@ -164,8 +164,8 @@ CREATE TABLE Measurement (
 );
 
 CREATE TABLE ProfileData (
-  runId smallint,
-  trialId smallint,
+  runId int,
+  trialId int,
   invocation smallint,
   numIterations smallint,
 
@@ -178,8 +178,8 @@ CREATE TABLE ProfileData (
 
 -- Summary Statistics for comparing over time
 CREATE TABLE Timeline (
-  runId smallint,
-  trialId smallint,
+  runId int,
+  trialId int,
   criterion smallint,
 
   numSamples int,
@@ -202,8 +202,8 @@ CREATE TABLE Timeline (
 
 -- Used by ReBenchDB's perf-tracker, for self-performance tracking
 CREATE PROCEDURE recordAdditionalMeasurement(
-  aRunId smallint,
-  aTrialId smallint,
+  aRunId int,
+  aTrialId int,
   aCriterionId smallint,
   aValue float4)
 LANGUAGE plpgsql

--- a/src/backend/db/schema-updates/migration.014.sql
+++ b/src/backend/db/schema-updates/migration.014.sql
@@ -1,0 +1,37 @@
+-- Change the smallint runId and trialId to int, to allow for more runs and trials.
+ALTER TABLE Measurement
+  ALTER COLUMN runId   TYPE int,
+  ALTER COLUMN trialId TYPE int;
+
+ALTER TABLE ProfileData
+  ALTER COLUMN runId   TYPE int,
+  ALTER COLUMN trialId TYPE int;
+
+ALTER TABLE Timeline
+  ALTER COLUMN runId   TYPE int,
+  ALTER COLUMN trialId TYPE int;
+
+DROP PROCEDURE recordAdditionalMeasurement(smallint, smallint, smallint, float4);
+
+CREATE PROCEDURE recordAdditionalMeasurement(
+  aRunId int,
+  aTrialId int,
+  aCriterionId smallint,
+  aValue float4)
+LANGUAGE plpgsql
+AS $$
+  BEGIN
+    UPDATE Measurement m
+      SET values = array_append(values, aValue)
+      WHERE
+        m.runId = aRunId AND
+        m.trialId = aTrialId AND
+        m.criterion = aCriterionId AND
+        m.invocation = 1;
+
+    IF NOT FOUND THEN
+      INSERT INTO Measurement (runId, trialId, criterion, invocation, values)
+      VALUES (aRunId, aTrialId, aCriterionId, 1, ARRAY[aValue]);
+    END IF;
+  END;
+$$; 


### PR DESCRIPTION
This PR changes the database schema to use `int` for `runId` and `trialId`.
It also adds the migration script used on rebench.dev.

This should give us another few years for now.
There may be a performance cost: https://rebench.dev/ReBenchDB/compare/4b82a61eb47fd8818a1915c7c9c3aacf69ea13cb..d9dad8c469836d7907bf42f4e0e5c90b28114940