### PR TITLE
getColorsForExecutors failed to select color

### DIFF
--- a/src/shared/aesthetics.ts
+++ b/src/shared/aesthetics.ts
@@ -23,6 +23,8 @@ const allTangoShadesPerColor = allTangoColorsAsString
 
 // colors are from the Extended Tango Palette
 // https://emilis.info/other/extended_tango/
+// https://web.archive.org/
+//      web/20250210055446/https://emilis.info/other/extended_tango/
 export const siteAesthetics = {
   changeColor: '#e9b96e',
   baseColor: '#729fcf',
@@ -84,7 +86,29 @@ export const siteAesthetics = {
 
     '#97c4f0',
     '#f57900',
-    '#e0c0e4'
+    '#e0c0e4',
+
+    // column 3
+    '#a40000',
+    '#204a87',
+    '#c4a000',
+
+    '#5c3566',
+    '#4e9a06',
+    '#ce5c00',
+
+    '#8f5902',
+    // column 2
+    '#600000',
+    '#0a3050',
+
+    '#725000',
+    '#371740',
+    '#2a5703',
+
+    '#8c3700',
+    '#555753',
+    '#503000'
   ],
   lighten(color: string): string {
     const colorWithoutHash = color[0] === '#' ? color.slice(1) : color;
@@ -102,7 +126,7 @@ export const siteAesthetics = {
     const colors = new Map<string, string>();
     let i = 0;
     for (const exe of executors) {
-      colors.set(exe, this.exeColors[i]);
+      colors.set(exe, this.exeColors[i % this.exeColors.length]);
       i++;
     }
     return colors;

--- a/tests/shared/aesthetics.test.ts
+++ b/tests/shared/aesthetics.test.ts
@@ -19,3 +19,27 @@ describe('lighten()', () => {
     expect(siteAesthetics.lighten('#ffcccc')).toEqual('#ffcccc');
   });
 });
+
+describe('getColorsForExecutors()', () => {
+  it('should assign colors to executors', () => {
+    const executors = new Set(['exe1', 'exe2', 'exe3', 'exe4']);
+    const colors = siteAesthetics.getColorsForExecutors(executors);
+    expect(colors.get('exe1')).toEqual(siteAesthetics.exeColors[0]);
+    expect(colors.get('exe2')).toEqual(siteAesthetics.exeColors[1]);
+    expect(colors.get('exe3')).toEqual(siteAesthetics.exeColors[2]);
+    expect(colors.get('exe4')).toEqual(siteAesthetics.exeColors[3]);
+  });
+
+  it('should get color even if there are more executors than colors', () => {
+    const executors: Set<string> = new Set();
+    for (let i = 0; i < siteAesthetics.exeColors.length + 2; i++) {
+      executors.add(`exe${i}`);
+    }
+    const colors = siteAesthetics.getColorsForExecutors(executors);
+    for (let i = 0; i < siteAesthetics.exeColors.length + 2; i++) {
+      expect(colors.get(`exe${i}`)).toEqual(
+        siteAesthetics.exeColors[i % siteAesthetics.exeColors.length]
+      );
+    }
+  });
+});


### PR DESCRIPTION
The color selector did not warp around when we had more executors than colors.
So, here we extend the color set a bit and also add wrapping semantics to always have a color result.

This fixes #242.