### PR TITLE
Move GitLab CI to JKU

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
 
 build-and-benchmark:
   stage: build-and-benchmark
-  tags: [yuria2]
+  tags: [kent-yuria2]
   script:
     - podman build . -f Dockerfile -t rebenchdb-app
     - podman build . -f Dockerfile.rebench -t bench-rdb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ReBenchDB
 
-[![Build Status](https://travis-ci.com/smarr/ReBenchDB.svg?branch=master)](https://travis-ci.com/smarr/ReBenchDB)
+[![Build Status](https://github.com/smarr/ReBenchDB/actions/workflows/ci.yml/badge.svg)](https://github.com/smarr/ReBenchDB/actions)
 [![Documentation](https://readthedocs.org/projects/rebench/badge/?version=latest)](https://rebench.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1311762.svg)](https://doi.org/10.5281/zenodo.1311762)
 


### PR DESCRIPTION
Move the GitLab CI setup to run from the JKU's GitLab instance.