### PR TITLE
Remove support for deprecated URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebenchdb",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "A Web-Based Database for ReBench Results",
   "main": "index.js",
   "author": {

--- a/src/backend/common/standard-responses.ts
+++ b/src/backend/common/standard-responses.ts
@@ -1,14 +1,5 @@
 import { ParameterizedContext } from 'koa';
 
-export function respondProjectIdNotFound(
-  ctx: ParameterizedContext,
-  projectId: number
-): void {
-  ctx.body = `Requested project with id ${projectId} not found`;
-  ctx.status = 404;
-  ctx.type = 'text';
-}
-
 export function respondProjectNotFound(
   ctx: ParameterizedContext,
   projectSlug: string
@@ -26,15 +17,6 @@ export function respondProjectAndSourceNotFound(
   ctx.body =
     `Requested combination of project "${projectSlug}"` +
     ` and source ${sourceId} not found`;
-  ctx.status = 404;
-  ctx.type = 'text';
-}
-
-export function respondExpIdNotFound(
-  ctx: ParameterizedContext,
-  expId: string
-): void {
-  ctx.body = `Requested experiment ${expId} not found`;
   ctx.status = 404;
   ctx.type = 'text';
 }

--- a/src/backend/compare/compare.ts
+++ b/src/backend/compare/compare.ts
@@ -10,7 +10,6 @@ import type {
   WarmupDataForTrial,
   WarmupDataPerCriterion
 } from '../../shared/view-types.js';
-import { respondProjectNotFound } from '../common/standard-responses.js';
 import { refreshSecret } from '../util.js';
 import { deleteReport, renderCompare } from './report.js';
 import type { TimelineRequest } from '../../shared/api.js';
@@ -186,23 +185,6 @@ export async function getTimelineDataAsJson(
     ctx.status = 200;
   }
   ctx.type = 'json';
-}
-
-/**
- * @deprecated remove for 1.0
- */
-export async function redirectToNewCompareUrl(
-  ctx: ParameterizedContext,
-  db: Database
-): Promise<void> {
-  const project = await db.getProjectByName(ctx.params.project);
-  if (project) {
-    ctx.redirect(
-      `/${project.slug}/compare/${ctx.params.baseline}..${ctx.params.change}`
-    );
-  } else {
-    respondProjectNotFound(ctx, ctx.params.project);
-  }
 }
 
 export async function renderComparePage(

--- a/src/backend/project/project.ts
+++ b/src/backend/project/project.ts
@@ -1,9 +1,7 @@
 import { ParameterizedContext } from 'koa';
 import { prepareTemplate } from '../templates.js';
 import {
-  respondExpIdNotFound,
   respondProjectAndSourceNotFound,
-  respondProjectIdNotFound,
   respondProjectNotFound
 } from '../common/standard-responses.js';
 import {
@@ -50,22 +48,6 @@ export async function getSourceAsJson(
   }
 }
 
-/**
- * @deprecated remove for 1.0
- */
-export async function redirectToNewProjectDataUrl(
-  ctx: ParameterizedContext,
-  db: Database
-): Promise<void> {
-  const project = await db.getProject(Number(ctx.params.projectId));
-  if (project) {
-    ctx.redirect(`/${project.slug}/data`);
-  } else {
-    respondProjectIdNotFound(ctx, Number(ctx.params.projectId));
-  }
-  ctx.type = 'html';
-}
-
 const projectDataTpl = prepareTemplate(
   robustPath('backend/project/project-data.html'),
   false
@@ -81,21 +63,6 @@ export async function renderProjectDataPage(
     ctx.type = 'html';
   } else {
     respondProjectNotFound(ctx, ctx.params.projectSlug);
-  }
-}
-
-/**
- * @deprecated remove for 1.0
- */
-export async function redirectToNewProjectDataExportUrl(
-  ctx: ParameterizedContext,
-  db: Database
-): Promise<void> {
-  const project = await db.getProjectByExpId(Number(ctx.params.expId));
-  if (project) {
-    ctx.redirect(`/${project.slug}/data/${ctx.params.expId}`);
-  } else {
-    respondExpIdNotFound(ctx, ctx.params.expId);
   }
 }
 

--- a/src/backend/timeline/timeline.ts
+++ b/src/backend/timeline/timeline.ts
@@ -1,8 +1,5 @@
 import { ParameterizedContext } from 'koa';
-import {
-  respondProjectIdNotFound,
-  respondProjectNotFound
-} from '../common/standard-responses.js';
+import { respondProjectNotFound } from '../common/standard-responses.js';
 import { prepareTemplate } from '../templates.js';
 import { TimelineSuite } from '../../shared/api.js';
 import { Database } from '../db/db.js';
@@ -36,21 +33,6 @@ export async function getTimelineAsJson(
   ctx.body = await db.getTimelineForRun(projectId, runId);
   if (ctx.body === null) {
     ctx.status = 500;
-  }
-}
-
-/**
- * @deprecated remove for 1.0
- */
-export async function redirectToNewTimelineUrl(
-  ctx: ParameterizedContext,
-  db: Database
-): Promise<void> {
-  const project = await db.getProject(Number(ctx.params.projectId));
-  if (project) {
-    ctx.redirect(`/${project.slug}/timeline`);
-  } else {
-    respondProjectIdNotFound(ctx, Number(ctx.params.projectId));
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,15 +21,12 @@ import {
 } from './backend/main/main.js';
 import {
   getSourceAsJson,
-  redirectToNewProjectDataExportUrl,
-  redirectToNewProjectDataUrl,
   renderDataExport,
   renderProjectDataPage,
   renderProjectPage
 } from './backend/project/project.js';
 import {
   getTimelineAsJson,
-  redirectToNewTimelineUrl,
   renderTimeline
 } from './backend/timeline/timeline.js';
 import {
@@ -44,7 +41,6 @@ import {
   getMeasurementsAsJson,
   getProfileAsJson,
   getTimelineDataAsJson,
-  redirectToNewCompareUrl,
   renderComparePage
 } from './backend/compare/compare.js';
 import { getAvailableDataAsJson } from './backend/project/data-export.js';
@@ -110,19 +106,6 @@ router.get('/:projectSlug/data/:expIdAndExtension', async (ctx) => {
 });
 router.get('/:projectSlug/compare/:baseline..:change', async (ctx) =>
   renderComparePage(ctx, db)
-);
-// DEPRECATED: remove for 1.0
-router.get('/timeline/:projectId', async (ctx) =>
-  redirectToNewTimelineUrl(ctx, db)
-);
-router.get('/project/:projectId', async (ctx) =>
-  redirectToNewProjectDataUrl(ctx, db)
-);
-router.get('/rebenchdb/get-exp-data/:expId', async (ctx) =>
-  redirectToNewProjectDataExportUrl(ctx, db)
-);
-router.get('/compare/:project/:baseline/:change', async (ctx) =>
-  redirectToNewCompareUrl(ctx, db)
 );
 
 // todo: rename this to say that this endpoint gets the last 100 measurements

--- a/tests/backend/common/standard-responses.test.ts
+++ b/tests/backend/common/standard-responses.test.ts
@@ -1,19 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
 import {
-  respondExpIdNotFound,
   respondProjectAndSourceNotFound,
-  respondProjectIdNotFound,
   respondProjectNotFound
 } from '../../../src/backend/common/standard-responses.js';
-
-describe('respondProjectIdNotFound', () => {
-  it('should set status to 404 and respond with text', () => {
-    const response: any = {};
-    respondProjectIdNotFound(response, 42);
-    expect(response.status).toEqual(404);
-    expect(response.type).toEqual('text');
-  });
-});
 
 describe('respondProjectNotFound', () => {
   it('should set status to 404 and respond with text', () => {
@@ -28,15 +17,6 @@ describe('respondProjectAndSourceNotFound', () => {
   it('should set status to 404 and respond with text', () => {
     const response: any = {};
     respondProjectAndSourceNotFound(response, 'project-slug', 'sha-commit-id');
-    expect(response.status).toEqual(404);
-    expect(response.type).toEqual('text');
-  });
-});
-
-describe('respondExpIdNotFound', () => {
-  it('should set status to 404 and respond with text', () => {
-    const response: any = {};
-    respondExpIdNotFound(response, 'exp-id');
     expect(response.status).toEqual(404);
     expect(response.type).toEqual('text');
   });


### PR DESCRIPTION
At some point, we redesign the user-visible set of URLs.
Seems now a good point to remove those.