### PR TITLE
Tie frontend and backend together by typing the REST routes

### DIFF
--- a/src/backend/compare/compare.ts
+++ b/src/backend/compare/compare.ts
@@ -12,30 +12,29 @@ import type {
 } from '../../shared/view-types.js';
 import { refreshSecret } from '../util.js';
 import { deleteReport, renderCompare } from './report.js';
-import type { TimelineRequest } from '../../shared/api.js';
+import type { TimelineRequest, TimelineResponse } from '../../shared/api.js';
 import { getNumberOrError } from '../request-check.js';
 import { log } from '../logging.js';
 
 export async function getProfileAsJson(
   ctx: ParameterizedContext,
   db: Database
-): Promise<void> {
-  ctx.type = 'application/json';
-
+): Promise<ProfileRow[]> {
   const runId = getNumberOrError(ctx, 'runId');
   if (runId === null) {
     log.error((ctx.body as any).error);
-    return;
+    ctx.status = 404;
+    return null as any;
   }
 
   const start = startRequest();
 
-  ctx.body = await getProfile(runId, ctx.params.commitId, db);
-  if (ctx.body === undefined) {
+  const result = await getProfile(runId, ctx.params.commitId, db);
+  if (result === undefined || result.length === 0) {
     ctx.status = 404;
-    ctx.body = {};
   }
   completeRequestAndHandlePromise(start, db, 'get-profiles');
+  return result;
 }
 
 async function getProfile(
@@ -73,18 +72,17 @@ async function getProfile(
 export async function getMeasurementsAsJson(
   ctx: ParameterizedContext,
   db: Database
-): Promise<void> {
-  ctx.type = 'application/json';
-
+): Promise<WarmupDataForTrial[] | null> {
   const runId = getNumberOrError(ctx, 'runId');
   if (runId === null) {
     log.error((ctx.body as any).error);
-    return;
+    ctx.status = 404;
+    return null;
   }
 
   const start = startRequest();
 
-  ctx.body = await getMeasurements(
+  const result = await getMeasurements(
     ctx.params.projectSlug,
     runId,
     ctx.params.baseId,
@@ -93,6 +91,7 @@ export async function getMeasurementsAsJson(
   );
 
   completeRequestAndHandlePromise(start, db, 'get-measurements');
+  return result;
 }
 
 /**
@@ -171,20 +170,17 @@ export async function getMeasurements(
 export async function getTimelineDataAsJson(
   ctx: ParameterizedContext,
   db: Database
-): Promise<void> {
+): Promise<TimelineResponse> {
   const timelineRequest = <TimelineRequest>(<unknown>ctx.request.body);
   const result = await db.getTimelineData(
     ctx.params.projectName,
     timelineRequest
   );
   if (result === null) {
-    ctx.body = { error: 'Requested data was not found' };
     ctx.status = 404;
-  } else {
-    ctx.body = result;
-    ctx.status = 200;
+    return { error: 'Requested data was not found' } as any;
   }
-  ctx.type = 'json';
+  return result;
 }
 
 export async function renderComparePage(

--- a/src/backend/main/main.ts
+++ b/src/backend/main/main.ts
@@ -13,7 +13,10 @@ import {
   startRequest
 } from '../perf-tracker.js';
 import type { AllResults } from '../../shared/api.js';
-import type { ChangesResponse } from '../../shared/view-types.js';
+import type {
+  ChangesResponse,
+  SiteStatsResponse
+} from '../../shared/view-types.js';
 import { Database } from '../db/db.js';
 import { TimedCacheValidity } from '../db/timed-cache-validity.js';
 import { getNumberOrError } from '../request-check.js';
@@ -37,18 +40,18 @@ export async function renderMainPage(
 export async function getLast100MeasurementsAsJson(
   ctx: ParameterizedContext,
   db: Database
-): Promise<void> {
-  ctx.type = 'application/json';
-
+): Promise<AllResults[]> {
   const projectId = getNumberOrError(ctx, 'projectId');
   if (projectId === null) {
     log.error((ctx.body as any).error);
-    return;
+    ctx.status = 404;
+    return null as any;
   }
 
   const start = startRequest();
-  ctx.body = await getLast100Measurements(projectId, db);
+  const result = await getLast100Measurements(projectId, db);
   completeRequestAndHandlePromise(start, db, 'get-results');
+  return result;
 }
 
 const resultsCache: AllResults[][] = [];
@@ -121,14 +124,6 @@ export async function getLast100Measurements(
   return resultsCache[projectId];
 }
 
-export async function getSiteStatsAsJson(
-  ctx: ParameterizedContext,
-  db: Database
-): Promise<void> {
-  ctx.body = await getStatistics(db);
-  ctx.type = 'application/json';
-}
-
 let statisticsCache: { stats: any[]; version: number } | null = null;
 let statsCacheValid: TimedCacheValidity | null = null;
 
@@ -136,9 +131,10 @@ export function statsCache(): TimedCacheValidity | null {
   return statsCacheValid;
 }
 
-export async function getStatistics(
+export async function getSiteStatsAsJson(
+  _: ParameterizedContext,
   db: Database
-): Promise<{ stats: any[]; version: number }> {
+): Promise<SiteStatsResponse> {
   if (
     statisticsCache !== null &&
     statsCacheValid !== null &&
@@ -178,6 +174,7 @@ export async function getChangesAsJson(
   const projectId = getNumberOrError(ctx, 'projectId');
   if (projectId === null) {
     log.error((ctx.body as any).error);
+    ctx.status = 404;
     return null as any;
   }
 

--- a/src/backend/main/main.ts
+++ b/src/backend/main/main.ts
@@ -174,16 +174,14 @@ export async function getStatistics(
 export async function getChangesAsJson(
   ctx: ParameterizedContext,
   db: Database
-): Promise<void> {
-  ctx.type = 'application/json';
-
+): Promise<ChangesResponse> {
   const projectId = getNumberOrError(ctx, 'projectId');
   if (projectId === null) {
     log.error((ctx.body as any).error);
-    return;
+    return null as any;
   }
 
-  ctx.body = await getChanges(projectId, db);
+  return await getChanges(projectId, db);
 }
 
 export async function getChanges(

--- a/src/backend/project/data-export.ts
+++ b/src/backend/project/data-export.ts
@@ -98,16 +98,15 @@ export async function getExpData(
 export async function getAvailableDataAsJson(
   ctx: ParameterizedContext,
   db: Database
-): Promise<void> {
-  ctx.type = 'application/json';
-
+): Promise<{ data: any[] }> {
   const projectId = getNumberOrError(ctx, 'projectId');
   if (projectId === null) {
     log.error((ctx.body as any).error);
-    return;
+    ctx.status = 404;
+    return null as any;
   }
 
-  ctx.body = await getDataOverview(projectId, db);
+  return await getDataOverview(projectId, db);
 }
 
 export async function getDataOverview(

--- a/src/backend/project/project.ts
+++ b/src/backend/project/project.ts
@@ -11,6 +11,7 @@ import {
 import { getExpData } from './data-export.js';
 import { Database } from '../db/db.js';
 import { rebenchVersion, robustPath } from '../../backend/util.js';
+import { Source } from '../db/types.js';
 
 const projectHtml = prepareTemplate(robustPath('backend/project/project.html'));
 
@@ -30,22 +31,21 @@ export async function renderProjectPage(
 export async function getSourceAsJson(
   ctx: ParameterizedContext,
   db: Database
-): Promise<void> {
+): Promise<Source | string> {
   const result = await db.getSourceById(
     ctx.params.projectSlug,
     ctx.params.sourceId
   );
 
   if (result !== null) {
-    ctx.body = result;
-    ctx.type = 'application/json';
-  } else {
-    respondProjectAndSourceNotFound(
-      ctx,
-      ctx.params.projectSlug,
-      ctx.params.sourceId
-    );
+    return result;
   }
+
+  return respondProjectAndSourceNotFound(
+    ctx,
+    ctx.params.projectSlug,
+    ctx.params.sourceId
+  );
 }
 
 const projectDataTpl = prepareTemplate(

--- a/src/backend/server-routes.ts
+++ b/src/backend/server-routes.ts
@@ -1,5 +1,5 @@
 import { Middleware, ParameterizedContext } from 'koa';
-import { apiRoutes, ApiRoutes } from '../shared/view-types.js';
+import { apiRoutes, ApiRoutes } from '../shared/routes.js';
 import Router from '@koa/router';
 import { Database } from './db/db.js';
 

--- a/src/backend/server-routes.ts
+++ b/src/backend/server-routes.ts
@@ -1,0 +1,26 @@
+import { ParameterizedContext } from 'koa';
+import { apiRoutes, ApiRoutes } from '../shared/view-types.js';
+import Router from '@koa/router';
+import { Database } from './db/db.js';
+
+export function defineRoute<Path extends keyof ApiRoutes>(
+  path: Path,
+  router: Router,
+  db: Database,
+  handler: (
+    ctx: ParameterizedContext,
+    db: Database
+  ) => Promise<ApiRoutes[Path]['response']>
+): void {
+  switch (apiRoutes[path].method) {
+    case 'GET':
+      router.get(path, async (ctx) => {
+        const result = await handler(ctx, db);
+        ctx.type = 'application/json';
+        ctx.body = result;
+      });
+      break;
+    default:
+      throw new Error(`Unsupported method: ${apiRoutes[path].method}`);
+  }
+}

--- a/src/backend/server-routes.ts
+++ b/src/backend/server-routes.ts
@@ -1,4 +1,4 @@
-import { ParameterizedContext } from 'koa';
+import { Middleware, ParameterizedContext } from 'koa';
 import { apiRoutes, ApiRoutes } from '../shared/view-types.js';
 import Router from '@koa/router';
 import { Database } from './db/db.js';
@@ -10,7 +10,8 @@ export function defineRoute<Path extends keyof ApiRoutes>(
   handler: (
     ctx: ParameterizedContext,
     db: Database
-  ) => Promise<ApiRoutes[Path]['response']>
+  ) => Promise<ApiRoutes[Path]['response']>,
+  koaBody: Middleware | null = null
 ): void {
   switch (apiRoutes[path].method) {
     case 'GET':
@@ -20,7 +21,12 @@ export function defineRoute<Path extends keyof ApiRoutes>(
         ctx.body = result;
       });
       break;
-    default:
-      throw new Error(`Unsupported method: ${apiRoutes[path].method}`);
+    case 'POST':
+      router.post(path, koaBody!, async (ctx) => {
+        const result = await handler(ctx, db);
+        ctx.type = 'application/json';
+        ctx.body = result;
+      });
+      break;
   }
 }

--- a/src/backend/standard-responses.ts
+++ b/src/backend/standard-responses.ts
@@ -13,10 +13,11 @@ export function respondProjectAndSourceNotFound(
   ctx: ParameterizedContext,
   projectSlug: string,
   sourceId: string
-): void {
-  ctx.body =
-    `Requested combination of project "${projectSlug}"` +
-    ` and source ${sourceId} not found`;
+): string {
   ctx.status = 404;
   ctx.type = 'text';
+  return (
+    `Requested combination of project "${projectSlug}"` +
+    ` and source ${sourceId} not found`
+  );
 }

--- a/src/backend/timeline/timeline.ts
+++ b/src/backend/timeline/timeline.ts
@@ -1,7 +1,7 @@
 import { ParameterizedContext } from 'koa';
 import { respondProjectNotFound } from '../standard-responses.js';
 import { prepareTemplate } from '../templates.js';
-import { TimelineSuite } from '../../shared/api.js';
+import { TimelineResponse, TimelineSuite } from '../../shared/api.js';
 import { Database } from '../db/db.js';
 import { rebenchVersion, robustPath } from '../util.js';
 import { getNumberOrError } from '../request-check.js';
@@ -15,25 +15,26 @@ const timelineTpl = prepareTemplate(
 export async function getTimelineAsJson(
   ctx: ParameterizedContext,
   db: Database
-): Promise<void> {
-  ctx.type = 'application/json';
-
+): Promise<TimelineResponse | null> {
   const projectId = getNumberOrError(ctx, 'projectId');
   if (projectId === null) {
     log.error((ctx.body as any).error);
-    return;
+    ctx.status = 404;
+    return null;
   }
 
   const runId = getNumberOrError(ctx, 'runId');
   if (runId === null) {
     log.error((ctx.body as any).error);
-    return;
+    ctx.status = 404;
+    return null;
   }
 
-  ctx.body = await db.getTimelineForRun(projectId, runId);
-  if (ctx.body === null) {
+  const result = await db.getTimelineForRun(projectId, runId);
+  if (result === null) {
     ctx.status = 500;
   }
+  return result;
 }
 
 export async function renderTimeline(

--- a/src/frontend/api-client.ts
+++ b/src/frontend/api-client.ts
@@ -1,0 +1,24 @@
+import { ApiRoutes } from '../shared/view-types.js';
+
+type ExtractParams<Path extends string> =
+  Path extends `${string}:${infer Param}/${infer Rest}`
+    ? { [K in Param | keyof ExtractParams<Rest>]: string | number }
+    : Path extends `${string}:${infer Param}`
+      ? { [K in Param]: string | number }
+      : Record<string, never>;
+
+export async function apiFetch<Path extends keyof ApiRoutes>(
+  path: Path,
+  params: ExtractParams<Path>
+): Promise<ApiRoutes[Path]['response']> {
+  let url: string = path;
+  for (const [key, value] of Object.entries(params)) {
+    url = url.replace(`:${key}`, String(value));
+  }
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`API request failed with status ${res.status}`);
+  }
+  return res.json();
+}

--- a/src/frontend/api-client.ts
+++ b/src/frontend/api-client.ts
@@ -1,4 +1,4 @@
-import { ApiRoutes } from '../shared/view-types.js';
+import { ApiRoutes, apiRoutes } from '../shared/view-types.js';
 
 type ExtractParams<Path extends string> =
   Path extends `${string}:${infer Param}/${infer Rest}`
@@ -9,14 +9,29 @@ type ExtractParams<Path extends string> =
 
 export async function apiFetch<Path extends keyof ApiRoutes>(
   path: Path,
-  params: ExtractParams<Path>
+  params: ExtractParams<Path>,
+  jsonData?: any
 ): Promise<ApiRoutes[Path]['response']> {
   let url: string = path;
   for (const [key, value] of Object.entries(params)) {
     url = url.replace(`:${key}`, String(value));
   }
 
-  const res = await fetch(url);
+  let options: RequestInit | undefined = undefined;
+  if (apiRoutes[path].method === 'POST') {
+    options = {
+      method: 'POST',
+      mode: 'same-origin',
+      cache: 'no-cache',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      redirect: 'follow',
+      referrerPolicy: 'no-referrer',
+      body: JSON.stringify(jsonData)
+    };
+  }
+
+  const res = await fetch(url, options);
   if (!res.ok) {
     throw new Error(`API request failed with status ${res.status}`);
   }

--- a/src/frontend/api-client.ts
+++ b/src/frontend/api-client.ts
@@ -1,4 +1,4 @@
-import { ApiRoutes, apiRoutes } from '../shared/view-types.js';
+import { ApiRoutes, apiRoutes } from '../shared/routes.js';
 
 type ExtractParams<Path extends string> =
   Path extends `${string}:${infer Param}/${infer Rest}`

--- a/src/frontend/compare.ts
+++ b/src/frontend/compare.ts
@@ -1,7 +1,7 @@
 import { initializeFilters } from './filter.js';
 import { renderComparisonTimelinePlot, renderWarmupPlot } from './plots.js';
-import type { ProfileRow, WarmupDataForTrial } from '../shared/view-types.js';
-import type { ProfileElement } from '../shared/api.js';
+import type { ProfileElement, TimelineRequest } from '../shared/api.js';
+import { apiFetch } from './api-client.js';
 
 function determineAndDisplaySignificance() {
   const val = parseFloat($('#significance').val() as string);
@@ -33,13 +33,15 @@ async function fetchWarmupData(
   changeCommitId: string,
   targetElement: JQuery<HTMLElement>
 ) {
-  const warmupR = await fetch(
-    `/rebenchdb/dash/${projectSlug}/measurements/` +
-      `${runId}/${baseCommitId}/${changeCommitId}`
+  const warmup = await apiFetch(
+    '/rebenchdb/dash/:projectSlug/measurements/:runId/:baseId/:changeId',
+    { projectSlug, runId, baseId: baseCommitId, changeId: changeCommitId }
   );
 
-  const warmupData: WarmupDataForTrial[] = await warmupR.json();
-  renderWarmupPlot(warmupData, baseCommitId, changeCommitId, targetElement);
+  if (warmup === null) {
+    return;
+  }
+  renderWarmupPlot(warmup, baseCommitId, changeCommitId, targetElement);
 }
 
 async function insertWarmupPlot(e) {
@@ -124,11 +126,11 @@ function fetchProfile(
   runId: number,
   jqInsert: JQuery<HTMLElement>
 ) {
-  const profileP = fetch(
-    `/rebenchdb/dash/${projectSlug}/profiles/${runId}/${commitId}`
+  const profileP = apiFetch(
+    '/rebenchdb/dash/:projectSlug/profiles/:runId/:commitId',
+    { projectSlug, runId, commitId }
   );
-  profileP.then(async (profileResponse) => {
-    const profileData: ProfileRow[] = await profileResponse.json();
+  profileP.then(async (profileData) => {
     const profId = `prof-${commitId}-${runId}`;
 
     const container = jqInsert.children();
@@ -178,20 +180,6 @@ function insertProfiles(e): void {
   }
 }
 
-async function fetchPost(url: string, data: any): Promise<any> {
-  const response = await fetch(url, {
-    method: 'POST',
-    mode: 'same-origin',
-    cache: 'no-cache',
-    credentials: 'same-origin',
-    headers: { 'Content-Type': 'application/json' },
-    redirect: 'follow',
-    referrerPolicy: 'no-referrer',
-    body: JSON.stringify(data)
-  });
-  return response.json();
-}
-
 async function insertTimeline(e): Promise<void> {
   const jqButton = $(e.target);
 
@@ -218,11 +206,12 @@ async function insertTimeline(e): Promise<void> {
 
 async function fetchTimelineData(
   projectName: string,
-  dataId,
-  jqInsert
+  dataId: TimelineRequest,
+  jqInsert: JQuery<HTMLElement>
 ): Promise<void> {
-  const response = await fetchPost(
-    `/rebenchdb/dash/${projectName}/timelines`,
+  const response = await apiFetch(
+    '/rebenchdb/dash/:projectName/timelines',
+    { projectName },
     dataId
   );
   renderComparisonTimelinePlot(response, jqInsert);

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './api-client.js';
 import {
   populateStatistics,
   renderAllResults,
@@ -5,8 +6,8 @@ import {
 } from './render.js';
 
 async function showStatistics(): Promise<void> {
-  const statsP = fetch(`/rebenchdb/stats`);
-  await populateStatistics(statsP);
+  const stats = await apiFetch('/rebenchdb/stats', {});
+  await populateStatistics(stats);
   $('#stats-table-button').hide();
 }
 

--- a/src/frontend/plots.ts
+++ b/src/frontend/plots.ts
@@ -13,6 +13,7 @@ import type {
   WarmupDataPerCriterion
 } from '../shared/view-types.js';
 import { siteAesthetics } from '../shared/aesthetics.js';
+import { apiFetch } from './api-client.js';
 
 function simpleSlug(str) {
   return str.replace(/[\W_]+/g, '');
@@ -196,7 +197,7 @@ const sourceCache = new Map();
 async function getSource(
   projectSlug: string,
   sourceId: number
-): Promise<Source> {
+): Promise<Source | null> {
   let project = sourceCache.get(projectSlug);
   if (!project) {
     project = new Map();
@@ -205,8 +206,14 @@ async function getSource(
 
   let source: Source | undefined = project.get(sourceId);
   if (!source) {
-    const p = await fetch(`/${projectSlug}/source/${sourceId}`);
-    source = <Source>await p.json();
+    const sourceOrString = await apiFetch('/:projectSlug/source/:sourceId', {
+      projectSlug,
+      sourceId
+    });
+    if (typeof sourceOrString === 'string') {
+      return null;
+    }
+    source = sourceOrString;
     source.commitmessage = filterCommitMessage(source.commitmessage);
     project.set(sourceId, source);
   }
@@ -215,6 +222,9 @@ async function getSource(
 
 async function tooltipOnClick(projectSlug: string, sourceId: number) {
   const source = await getSource(projectSlug, sourceId);
+  if (source === null) {
+    return;
+  }
   window.open(`${source.repourl}/commit/${source.commitid}`);
 }
 
@@ -253,6 +263,9 @@ function tooltipPlugin({
 
   async function setTooltip(u, seriesIdx: number, dataIdx: number) {
     const source = await getSource(projectSlug, sourceIds[dataIdx]);
+    if (source === null) {
+      return;
+    }
     showTooltip();
 
     const top = u.valToPos(u.data[seriesIdx][dataIdx], 'y');
@@ -330,7 +343,7 @@ function tooltipPlugin({
 
 export function renderTimelinePlot(
   response: TimelineResponse,
-  jqInsert: any,
+  jqInsert: JQuery<HTMLElement>,
   projectSlug: string
 ): any {
   ensureThemeColors();
@@ -386,7 +399,7 @@ export function renderTimelinePlot(
 
 export function renderComparisonTimelinePlot(
   response: TimelineResponse,
-  jqInsert: any
+  jqInsert: JQuery<HTMLElement>
 ): uPlot {
   const series = [
     {},

--- a/src/frontend/project-data.ts
+++ b/src/frontend/project-data.ts
@@ -1,11 +1,14 @@
+import { apiFetch } from './api-client.js';
 import { renderProjectDataOverview } from './render.js';
 
-const projectId = $('#project-id').attr('value');
+const projectId = <string>$('#project-id').attr('value');
 const projectSlug = <string>$('#project-slug').attr('value');
-const dataOverviewP = fetch(`/rebenchdb/dash/${projectId}/data-overview`);
+const dataOverviewP = apiFetch('/rebenchdb/dash/:projectId/data-overview', {
+  projectId
+});
 
 $(async () => {
   const dataOverviewResponse = await dataOverviewP;
-  const data = (await dataOverviewResponse.json()).data;
+  const data = dataOverviewResponse.data;
   renderProjectDataOverview(data, projectSlug);
 });

--- a/src/frontend/render.ts
+++ b/src/frontend/render.ts
@@ -1,10 +1,11 @@
 import type { AllResults } from '../shared/api.js';
 import type { ChangesResponse, ChangesRow } from '../shared/view-types.js';
+import { apiFetch } from './api-client.js';
 import { renderResultsPlots } from './plots.js';
 
 export function filterCommitMessage(msg: string): string {
   const result = msg
-    .normalize() // normalise Unicode first
+    .normalize() // normalize Unicode first
     .replace(/Signed-off-by:.*?\n/g, '')
     .replace(/&/g, '&amp;') // & must be first
     .replace(/</g, '&lt;')
@@ -98,10 +99,8 @@ export function renderProjectDataOverview(
 }
 
 export function renderChanges(projectId: string): void {
-  const changesP = fetch(`/rebenchdb/dash/${projectId}/changes`);
-  changesP.then(
-    async (changesDetailsResponse: Response) =>
-      await renderChangeDetails(changesDetailsResponse, projectId)
+  apiFetch(`/rebenchdb/dash/:projectId/changes`, { projectId }).then(
+    async (details) => await renderChangeDetails(details, projectId)
   );
 }
 
@@ -159,11 +158,7 @@ function setHref(event, projectId: string, isBaseline: boolean) {
   );
 }
 
-async function renderChangeDetails(
-  changesDetailsResponse: Response,
-  projId: string
-) {
-  const details: ChangesResponse = await changesDetailsResponse.json();
+async function renderChangeDetails(details: ChangesResponse, projId: string) {
   const changes = details.changes;
 
   const p1baseline = $(`#p${projId}-baseline`);

--- a/src/frontend/render.ts
+++ b/src/frontend/render.ts
@@ -1,5 +1,8 @@
-import type { AllResults } from '../shared/api.js';
-import type { ChangesResponse, ChangesRow } from '../shared/view-types.js';
+import type {
+  ChangesResponse,
+  ChangesRow,
+  SiteStatsResponse
+} from '../shared/view-types.js';
 import { apiFetch } from './api-client.js';
 import { renderResultsPlots } from './plots.js';
 
@@ -300,17 +303,17 @@ function updateChangesList(
 }
 
 export function renderAllResults(projectId: string): void {
-  const resultsP = fetch(`/rebenchdb/dash/${projectId}/results`);
-  resultsP.then(async (resultsResponse) => {
-    const results = <AllResults[]>await resultsResponse.json();
+  const resultsP = apiFetch('/rebenchdb/dash/:projectId/results', {
+    projectId
+  });
+  resultsP.then(async (results) => {
     renderResultsPlots(results, projectId);
   });
 }
 
-export async function populateStatistics(statsP: any): Promise<void> {
-  const statsResponse = await statsP;
-  const stats = await statsResponse.json();
-
+export async function populateStatistics(
+  stats: SiteStatsResponse
+): Promise<void> {
   const table = $('#stats-table');
   for (const t of stats.stats) {
     table.append(`<tr><td>${t.table}</td><td>${t.cnt}</td></tr>`);

--- a/src/frontend/timeline.ts
+++ b/src/frontend/timeline.ts
@@ -1,8 +1,8 @@
-import type { TimelineResponse } from '../shared/api.js';
+import { apiFetch } from './api-client.js';
 import { initializeFilters } from './filter.js';
 import { renderTimelinePlot } from './plots.js';
 
-const projectId = $('#project-id').attr('value');
+const projectId = <string>$('#project-id').attr('value');
 const projectSlug = <string>$('#project-slug').attr('value');
 
 async function loadPlotOnce(this: any) {
@@ -14,11 +14,16 @@ async function loadPlotOnce(this: any) {
   thisJq.data('requested', true);
 
   const runId = thisJq.data('runid');
-  const timelineP = await fetch(
-    `/rebenchdb/dash/${projectId}/timeline/${runId}`
+  const timeline = await apiFetch(
+    '/rebenchdb/dash/:projectId/timeline/:runId',
+    { projectId, runId }
   );
-  const response = <TimelineResponse>await timelineP.json();
-  renderTimelinePlot(response, thisJq, projectSlug);
+
+  if (!timeline) {
+    return;
+  }
+
+  renderTimelinePlot(timeline, thisJq, projectSlug);
   thisJq.off('appear', onPlotAppearing);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,7 @@ Disallow: /rebenchdb*
 });
 
 router.get('/:projectSlug', async (ctx) => renderProjectPage(ctx, db));
-router.get('/:projectSlug/source/:sourceId', async (ctx) =>
-  getSourceAsJson(ctx, db)
-);
+defineRoute('/:projectSlug/source/:sourceId', router, db, getSourceAsJson);
 router.get('/:projectSlug/timeline', async (ctx) => renderTimeline(ctx, db));
 router.get('/:projectSlug/data', async (ctx) => renderProjectDataPage(ctx, db));
 router.get('/:projectSlug/data/:expIdAndExtension', async (ctx) => {
@@ -109,31 +107,47 @@ router.get('/:projectSlug/compare/:baseline..:change', async (ctx) =>
   renderComparePage(ctx, db)
 );
 
-// todo: rename this to say that this endpoint gets the last 100 measurements
+// TODO: rename this to say that this endpoint gets the last 100 measurements
 //       for the project
-router.get('/rebenchdb/dash/:projectId/results', async (ctx) =>
-  getLast100MeasurementsAsJson(ctx, db)
+defineRoute(
+  '/rebenchdb/dash/:projectId/results',
+  router,
+  db,
+  getLast100MeasurementsAsJson
 );
-router.get('/rebenchdb/dash/:projectId/timeline/:runId', async (ctx) =>
-  getTimelineAsJson(ctx, db)
+defineRoute(
+  '/rebenchdb/dash/:projectId/timeline/:runId',
+  router,
+  db,
+  getTimelineAsJson
 );
-router.get(
+defineRoute(
   '/rebenchdb/dash/:projectSlug/profiles/:runId/:commitId',
-  async (ctx) => getProfileAsJson(ctx, db)
+  router,
+  db,
+  getProfileAsJson
 );
-router.get(
+defineRoute(
   '/rebenchdb/dash/:projectSlug/measurements/:runId/:baseId/:changeId',
-  async (ctx) => getMeasurementsAsJson(ctx, db)
+  router,
+  db,
+  getMeasurementsAsJson
 );
-router.get('/rebenchdb/stats', async (ctx) => getSiteStatsAsJson(ctx, db));
-
+defineRoute('/rebenchdb/stats', router, db, getSiteStatsAsJson);
 defineRoute('/rebenchdb/dash/:projectId/changes', router, db, getChangesAsJson);
 
-router.get('/rebenchdb/dash/:projectId/data-overview', async (ctx) =>
-  getAvailableDataAsJson(ctx, db)
+defineRoute(
+  '/rebenchdb/dash/:projectId/data-overview',
+  router,
+  db,
+  getAvailableDataAsJson
 );
-router.post('/rebenchdb/dash/:projectName/timelines', koaBody(), async (ctx) =>
-  getTimelineDataAsJson(ctx, db)
+defineRoute(
+  '/rebenchdb/dash/:projectName/timelines',
+  router,
+  db,
+  getTimelineDataAsJson,
+  koaBody()
 );
 
 router.get('/admin/perform-timeline-update', async (ctx) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import {
 } from './backend/rebench/results.js';
 import { setTimeout } from 'node:timers/promises';
 import { reportConnectionRefused } from './shared/errors.js';
+import { defineRoute } from './backend/server-routes.js';
 
 log.info('Starting ReBenchDB Version ' + rebenchVersion);
 
@@ -125,9 +126,9 @@ router.get(
   async (ctx) => getMeasurementsAsJson(ctx, db)
 );
 router.get('/rebenchdb/stats', async (ctx) => getSiteStatsAsJson(ctx, db));
-router.get('/rebenchdb/dash/:projectId/changes', async (ctx) =>
-  getChangesAsJson(ctx, db)
-);
+
+defineRoute('/rebenchdb/dash/:projectId/changes', router, db, getChangesAsJson);
+
 router.get('/rebenchdb/dash/:projectId/data-overview', async (ctx) =>
   getAvailableDataAsJson(ctx, db)
 );

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -1,0 +1,60 @@
+import type {
+  ChangesResponse,
+  ProfileRow,
+  SiteStatsResponse,
+  WarmupDataForTrial
+} from './view-types.js';
+
+import type { Source as DbSource } from '../backend/db/types.js';
+import type { AllResults, TimelineResponse } from './api.js';
+
+export const apiRoutes = {
+  '/:projectSlug/source/:sourceId': {
+    method: 'GET',
+    response: undefined as unknown as DbSource | string
+  },
+  '/rebenchdb/dash/:projectId/results': {
+    method: 'GET',
+    response: undefined as unknown as AllResults[]
+  },
+  '/rebenchdb/dash/:projectId/timeline/:runId': {
+    method: 'GET',
+    response: undefined as unknown as TimelineResponse | null
+  },
+  '/rebenchdb/dash/:projectSlug/profiles/:runId/:commitId': {
+    method: 'GET',
+    response: undefined as unknown as ProfileRow[]
+  },
+  '/rebenchdb/dash/:projectSlug/measurements/:runId/:baseId/:changeId': {
+    method: 'GET',
+    response: undefined as unknown as WarmupDataForTrial[] | null
+  },
+
+  '/rebenchdb/stats': {
+    method: 'GET',
+    response: undefined as unknown as SiteStatsResponse
+  },
+  '/rebenchdb/dash/:projectId/changes': {
+    method: 'GET',
+    response: undefined as unknown as ChangesResponse
+  },
+  '/rebenchdb/dash/:projectId/data-overview': {
+    method: 'GET',
+    response: undefined as unknown as { data: any[] }
+  },
+  '/rebenchdb/dash/:projectName/timelines': {
+    method: 'POST',
+    response: undefined as unknown as TimelineResponse
+  }
+} as const;
+
+interface ApiRoute {
+  method: 'GET' | 'POST';
+  response: unknown;
+}
+
+type Routes = Record<string, ApiRoute>;
+
+const _typeCheckApiRoutes: Routes = apiRoutes;
+
+export type ApiRoutes = typeof apiRoutes;

--- a/src/shared/view-types.ts
+++ b/src/shared/view-types.ts
@@ -293,3 +293,12 @@ export interface ChangesRow {
 export interface ChangesResponse {
   changes: ChangesRow[];
 }
+
+export const apiRoutes = {
+  '/rebenchdb/dash/:projectId/changes': {
+    method: 'GET',
+    response: undefined as unknown as ChangesResponse
+  }
+} as const;
+
+export type ApiRoutes = typeof apiRoutes;

--- a/src/shared/view-types.ts
+++ b/src/shared/view-types.ts
@@ -1,16 +1,13 @@
 import type {
-  AllResults,
   BenchmarkId,
   CriterionWithoutData,
   ProfileElement,
-  TimelineResponse,
   ValuesPossiblyMissing
 } from './api.js';
 import type {
   CriterionData,
   Environment,
-  RevisionData,
-  Source
+  RevisionData
 } from '../backend/db/types.js';
 import type { ComparisonStatistics, SummaryStatsWithUnit } from './stats.js';
 
@@ -301,54 +298,3 @@ export interface SiteStatsResponse {
   stats: any[];
   version: number;
 }
-
-export const apiRoutes = {
-  '/:projectSlug/source/:sourceId': {
-    method: 'GET',
-    response: undefined as unknown as Source | string
-  },
-  '/rebenchdb/dash/:projectId/results': {
-    method: 'GET',
-    response: undefined as unknown as AllResults[]
-  },
-  '/rebenchdb/dash/:projectId/timeline/:runId': {
-    method: 'GET',
-    response: undefined as unknown as TimelineResponse | null
-  },
-  '/rebenchdb/dash/:projectSlug/profiles/:runId/:commitId': {
-    method: 'GET',
-    response: undefined as unknown as ProfileRow[]
-  },
-  '/rebenchdb/dash/:projectSlug/measurements/:runId/:baseId/:changeId': {
-    method: 'GET',
-    response: undefined as unknown as WarmupDataForTrial[] | null
-  },
-
-  '/rebenchdb/stats': {
-    method: 'GET',
-    response: undefined as unknown as SiteStatsResponse
-  },
-  '/rebenchdb/dash/:projectId/changes': {
-    method: 'GET',
-    response: undefined as unknown as ChangesResponse
-  },
-  '/rebenchdb/dash/:projectId/data-overview': {
-    method: 'GET',
-    response: undefined as unknown as { data: any[] }
-  },
-  '/rebenchdb/dash/:projectName/timelines': {
-    method: 'POST',
-    response: undefined as unknown as TimelineResponse
-  }
-} as const;
-
-interface ApiRoute {
-  method: 'GET' | 'POST';
-  response: unknown;
-}
-
-type Routes = Record<string, ApiRoute>;
-
-const _typeCheckApiRoutes: Routes = apiRoutes;
-
-export type ApiRoutes = typeof apiRoutes;

--- a/src/shared/view-types.ts
+++ b/src/shared/view-types.ts
@@ -1,13 +1,16 @@
 import type {
+  AllResults,
   BenchmarkId,
   CriterionWithoutData,
   ProfileElement,
+  TimelineResponse,
   ValuesPossiblyMissing
 } from './api.js';
 import type {
   CriterionData,
   Environment,
-  RevisionData
+  RevisionData,
+  Source
 } from '../backend/db/types.js';
 import type { ComparisonStatistics, SummaryStatsWithUnit } from './stats.js';
 
@@ -294,11 +297,58 @@ export interface ChangesResponse {
   changes: ChangesRow[];
 }
 
+export interface SiteStatsResponse {
+  stats: any[];
+  version: number;
+}
+
 export const apiRoutes = {
+  '/:projectSlug/source/:sourceId': {
+    method: 'GET',
+    response: undefined as unknown as Source | string
+  },
+  '/rebenchdb/dash/:projectId/results': {
+    method: 'GET',
+    response: undefined as unknown as AllResults[]
+  },
+  '/rebenchdb/dash/:projectId/timeline/:runId': {
+    method: 'GET',
+    response: undefined as unknown as TimelineResponse | null
+  },
+  '/rebenchdb/dash/:projectSlug/profiles/:runId/:commitId': {
+    method: 'GET',
+    response: undefined as unknown as ProfileRow[]
+  },
+  '/rebenchdb/dash/:projectSlug/measurements/:runId/:baseId/:changeId': {
+    method: 'GET',
+    response: undefined as unknown as WarmupDataForTrial[] | null
+  },
+
+  '/rebenchdb/stats': {
+    method: 'GET',
+    response: undefined as unknown as SiteStatsResponse
+  },
   '/rebenchdb/dash/:projectId/changes': {
     method: 'GET',
     response: undefined as unknown as ChangesResponse
+  },
+  '/rebenchdb/dash/:projectId/data-overview': {
+    method: 'GET',
+    response: undefined as unknown as { data: any[] }
+  },
+  '/rebenchdb/dash/:projectName/timelines': {
+    method: 'POST',
+    response: undefined as unknown as TimelineResponse
   }
 } as const;
+
+interface ApiRoute {
+  method: 'GET' | 'POST';
+  response: unknown;
+}
+
+type Routes = Record<string, ApiRoute>;
+
+const _typeCheckApiRoutes: Routes = apiRoutes;
 
 export type ApiRoutes = typeof apiRoutes;

--- a/tests/backend/main/main.test.ts
+++ b/tests/backend/main/main.test.ts
@@ -18,7 +18,7 @@ import {
 import {
   getChanges,
   getLast100Measurements,
-  getStatistics
+  getSiteStatsAsJson
 } from '../../../src/backend/main/main.js';
 
 describe('Test on empty DB', () => {
@@ -40,7 +40,7 @@ describe('Test on empty DB', () => {
   });
 
   it('Should get empty statistics', async () => {
-    const result = await getStatistics(db);
+    const result = await getSiteStatsAsJson(null as any, db);
     expect(result.stats.length).toBeGreaterThan(1);
     for (const table of result.stats) {
       expect(table.cnt).toEqual('0');

--- a/tests/backend/main/with-data.test.ts
+++ b/tests/backend/main/with-data.test.ts
@@ -10,7 +10,7 @@ import { robustPath } from '../../../src/backend/util.js';
 import {
   getChanges,
   getLast100Measurements,
-  getStatistics
+  getSiteStatsAsJson
 } from '../../../src/backend/main/main.js';
 import { getDataOverview } from '../../../src/backend/project/data-export.js';
 import { prepareTemplate } from '../../../src/backend/templates.js';
@@ -91,7 +91,7 @@ describe('Test with basic test data loaded', () => {
   });
 
   it('Should get statistics', async () => {
-    const result = (await getStatistics(db)).stats;
+    const result = (await getSiteStatsAsJson(null as any, db)).stats;
     expect(result.length).toBeGreaterThan(2);
 
     for (const table of result) {


### PR DESCRIPTION
This PR introduces static type checking for REST routes.

At the server side, routes are now registered with the `defineRoute()` function.
The client, i.e., frontend can access them with the `apiFetch()` function.

Both rely on the `ApiRoutes` type, which allows us to connect the route to a specific response type, which we define in `shared/routes.ts`.
`ApiRoutes` is the precise type, while `apiRoutes` is the object available at run time, for instance to act based on the specific HTTP `method`.